### PR TITLE
Initialise m_transforms in ShellRenderInterfaceOpenGL constructor

### DIFF
--- a/Samples/shell/src/ShellRenderInterfaceOpenGL.cpp
+++ b/Samples/shell/src/ShellRenderInterfaceOpenGL.cpp
@@ -32,11 +32,9 @@
 
 #define GL_CLAMP_TO_EDGE 0x812F
 
-ShellRenderInterfaceOpenGL::ShellRenderInterfaceOpenGL()
+ShellRenderInterfaceOpenGL::ShellRenderInterfaceOpenGL() : m_width(0), m_height(0), m_transforms(0), m_rmlui_context(NULL)
 {
-	m_rmlui_context = NULL;
-	m_width = 0;
-	m_height = 0;
+
 }
 
 // Called by RmlUi when it wants to render geometry that it does not wish to optimise.


### PR DESCRIPTION
Fix 'conditional jump or move depends on uninitialised value(s)' warning spewed by valgrind when running opengl samples.