### PR TITLE
Add missing include headers

### DIFF
--- a/Include/RmlUi/Core/Types.h
+++ b/Include/RmlUi/Core/Types.h
@@ -31,7 +31,9 @@
 
 #include <float.h>
 #include <limits.h>
+#include <cstring>
 #include <string>
+#include <algorithm>
 #include <map>
 #include <memory>
 #include <set>


### PR DESCRIPTION
We need to include cstring and algorithm for memmove and find_if respectively