### PR TITLE
Add support for a set of rotations for the tiled decorator

### DIFF
--- a/Source/Core/DecoratorTiled.cpp
+++ b/Source/Core/DecoratorTiled.cpp
@@ -53,7 +53,7 @@ DecoratorTiled::Tile::Tile() : position(0, 0), size(1, 1)
 {
 	texture_index = -1;
 	repeat_mode = STRETCH;
-	orientation = ROTATE_0_CW;
+	orientation = ROTATE_0;
 
 	position_absolute[0] = false;
 	position_absolute[1] = false;

--- a/Source/Core/DecoratorTiled.h
+++ b/Source/Core/DecoratorTiled.h
@@ -67,10 +67,10 @@ public:
 	 */
 	enum TileOrientation
 	{
-		ROTATE_0_CW = 0,		// Rotated zero degrees clockwise.
-		ROTATE_90_CW = 1,		// Rotated 90 degrees clockwise.
-		ROTATE_180_CW = 2,		// Rotated 180 degrees clockwise.
-		ROTATE_270_CW = 3,		// Rotated 270 degrees clockwise.
+		ROTATE_0 = 0,			// Rotated zero degrees clockwise.
+		ROTATE_90 = 1,			// Rotated 90 degrees clockwise.
+		ROTATE_18 = 2,			// Rotated 180 degrees clockwise.
+		ROTATE_270 = 3,			// Rotated 270 degrees clockwise.
 		FLIP_HORIZONTAL = 4,	// Flipped horizontally.
 		FLIP_VERTICAL = 5		// Flipped vertically.
 	};

--- a/Source/Core/DecoratorTiledInstancer.cpp
+++ b/Source/Core/DecoratorTiledInstancer.cpp
@@ -51,17 +51,21 @@ void DecoratorTiledInstancer::RegisterTileProperty(const String& name, bool regi
 	RegisterShorthand(CreateString(32, "%s-pos", name.c_str()), CreateString(64, "%s-x, %s-y", name.c_str(), name.c_str()), ShorthandType::FallThrough);
 	RegisterShorthand(CreateString(32, "%s-size", name.c_str()), CreateString(64, "%s-width, %s-height", name.c_str(), name.c_str()), ShorthandType::FallThrough);
 
+	ids.orientation = RegisterProperty(CreateString(32, "%s-orientation", name.c_str()), "none")
+		.AddParser("keyword", "none, rotate-90, rotate-180, rotate-270, flip-horizontal, flip-vertical")
+		.GetId();
+
 	if (register_repeat_modes)
 	{
 		ids.repeat = RegisterProperty(CreateString(32, "%s-repeat", name.c_str()), "stretch")
 			.AddParser("keyword", "stretch, clamp-stretch, clamp-truncate, repeat-stretch, repeat-truncate")
 			.GetId();
-		RegisterShorthand(name, CreateString(256, "%s-src, %s-repeat, %s-x, %s-y, %s-width, %s-height", name.c_str(), name.c_str(), name.c_str(), name.c_str(), name.c_str(), name.c_str()), ShorthandType::FallThrough);
+		RegisterShorthand(name, CreateString(256, "%s-src, %s-repeat, %s-x, %s-y, %s-width, %s-height, %s-orientation", name.c_str(), name.c_str(), name.c_str(), name.c_str(), name.c_str(), name.c_str(), name.c_str()), ShorthandType::FallThrough);
 	}
 	else
 	{
 		ids.repeat = PropertyId::Invalid;
-		RegisterShorthand(name, CreateString(256, "%s-src, %s-x, %s-y, %s-width, %s-height", name.c_str(), name.c_str(), name.c_str(), name.c_str(), name.c_str()), ShorthandType::FallThrough);
+		RegisterShorthand(name, CreateString(256, "%s-src, %s-x, %s-y, %s-width, %s-height, %s-orientation", name.c_str(), name.c_str(), name.c_str(), name.c_str(), name.c_str(), name.c_str()), ShorthandType::FallThrough);
 	}
 
 	tile_property_ids.push_back(ids);
@@ -156,6 +160,12 @@ bool DecoratorTiledInstancer::GetTileProperties(DecoratorTiled::Tile* tiles, Tex
 		{
 			const Property& repeat_property = *properties.GetProperty(ids.repeat);
 			tile.repeat_mode = (DecoratorTiled::TileRepeatMode)repeat_property.value.Get< int >();
+		}
+
+		if (ids.orientation != PropertyId::Invalid)
+		{
+			const Property& repeat_property = *properties.GetProperty(ids.orientation);
+			tile.orientation = (DecoratorTiled::TileOrientation)repeat_property.value.Get< int >();
 		}
 	}
 

--- a/Source/Core/DecoratorTiledInstancer.h
+++ b/Source/Core/DecoratorTiledInstancer.h
@@ -62,7 +62,7 @@ protected:
 
 private:
 	struct TilePropertyIds {
-		PropertyId src, repeat, x, y, width, height;
+		PropertyId src, repeat, x, y, width, height, orientation;
 	};
 
 	std::vector<TilePropertyIds> tile_property_ids;


### PR DESCRIPTION
The keywords are: none, rotate-90, rotate-180, rotate-270, flip-horizontal, flip-vertical