### PR TITLE
Add RmlUi libraries and examples to Appveyor artifacts

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -16,9 +16,11 @@ install:
 
     appveyor DownloadFile https://github.com/ubawurinna/freetype-windows-binaries/releases/download/v%FREETYPE_VER%/freetype-%FREETYPE_VER%.zip
 
-    unzip -o freetype-%FREETYPE_VER%.zip
+    unzip -o freetype-%FREETYPE_VER%.zip -d freetype-%FREETYPE_VER%
 
-    mv win64 lib
+    mv freetype-%FREETYPE_VER%/include include
+
+    mv freetype-%FREETYPE_VER%/win64 lib
 
     cd ..
 
@@ -27,3 +29,13 @@ build:
   project: RmlUi.sln
   parallel: true
   verbosity: minimal
+after_build:
+- cmd: >-
+    IF "%BUILD_SHARED_LIBS%"=="ON" 7z a RmlUi-Debug-win64.zip ./Debug/* -r -x!*.exp -x!*.lib -x!*.ilk -x!*.pdb -x!src/*
+
+    IF "%BUILD_SHARED_LIBS%"=="ON" IF "%BUILD_SAMPLES%"=="ON" 7z a RmlUi-Debug-win64.zip Dependencies/freetype-%FREETYPE_VER%/*.txt ./Dependencies/lib/freetype.dll ./Samples/* -r -x!*.exp -x!*.lib -x!*.ilk -x!*.pdb -x!src/*
+
+    IF "%BUILD_SHARED_LIBS%"=="OFF" mkdir Lib && cp ./Debug/*.lib Lib && 7z a RmlUi-static-Debug-win64.zip Lib Include
+artifacts:
+- path: RmlUi-Debug-win64.zip
+- path: RmlUi-static-Debug-win64.zip


### PR DESCRIPTION
Add RmlUi libraries and examples (along with freetype) to Appveyor artifacts. Makes it easier for interested parties to check the library out.

This also lays the groundwork for github releases if you opt use this feature someday.