### PR TITLE
Creating files for releases

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -64,7 +64,7 @@ after_build:
     
     7z a RmlUi-%PLATFORM_NAME%.zip Bin/ Include/ Readme.txt LICENSE Dependencies/freetype-%FREETYPE_VER%/ Samples/
     
-    mkdir Samples/Dependencies/freetype-%FREETYPE_VER%
+    mkdir Samples\Dependencies\freetype-%FREETYPE_VER%
     cp Dependencies/freetype-%FREETYPE_VER%/*.TXT Samples/Dependencies/freetype-%FREETYPE_VER%
     IF "%PLATFORM_NAME%"=="win64" 7z a RmlUi-%PLATFORM_NAME%-samples-only.zip LICENSE .\Samples\* -r -xr!src\ -x!luainvaders\
     

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -66,7 +66,7 @@ after_build:
     
     mkdir Samples\Dependencies\freetype-%FREETYPE_VER%
     cp Dependencies/freetype-%FREETYPE_VER%/*.TXT Samples/Dependencies/freetype-%FREETYPE_VER%
-    IF "%PLATFORM_NAME%"=="win64" 7z a RmlUi-%PLATFORM_NAME%-samples-only.zip LICENSE .\Samples\* -r -xr!src\ -x!luainvaders\
+    IF "%PLATFORM_NAME%"=="win64" 7z a RmlUi-%PLATFORM_NAME%-samples-only.zip LICENSE .\Samples\* -r -xr!src\ -x!shell\ -x!luainvaders\
     
 artifacts:
 - path: RmlUi-win64.zip

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -64,8 +64,13 @@ after_build:
     
     7z a RmlUi-%PLATFORM_NAME%.zip Bin/ Include/ Readme.txt LICENSE Dependencies/freetype-%FREETYPE_VER%/ Samples/
     
+    mkdir Samples/Dependencies/freetype-%FREETYPE_VER%
+    cp Dependencies/freetype-%FREETYPE_VER%/*.TXT Samples/Dependencies/freetype-%FREETYPE_VER%
+    IF "%PLATFORM_NAME%"=="win64" 7z a RmlUi-%PLATFORM_NAME%-samples-only.zip LICENSE .\Samples\* -r -xr!src\ -x!luainvaders\
+    
 artifacts:
 - path: RmlUi-win64.zip
+- path: RmlUi-win64-samples-only.zip
 - path: RmlUi-win32.zip
 deploy:
   release: RmlUi $(APPVEYOR_REPO_TAG_NAME)

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,41 +1,80 @@
-version: 2.0.{build}
+version: build.{build}
 image: Visual Studio 2017
 environment:
+  FREETYPE_VER: 2.10.1
   matrix:
-  - FREETYPE_VER: 2.10.0
-    VS_GENERATOR: Visual Studio 15 2017 Win64
-    BUILD_SHARED_LIBS: ON
-    BUILD_SAMPLES: ON
-  - FREETYPE_VER: 2.10.0
-    VS_GENERATOR: Visual Studio 15 2017 Win64
-    BUILD_SHARED_LIBS: OFF
-    BUILD_SAMPLES: OFF
+    - VS_GENERATOR: Visual Studio 15 2017 Win64
+      PLATFORM_NAME: win64
+    - VS_GENERATOR: Visual Studio 15 2017
+      PLATFORM_NAME: win32
 install:
-- cmd: >-
+- cmd: |-
     cd Dependencies
 
-    appveyor DownloadFile https://github.com/ubawurinna/freetype-windows-binaries/releases/download/v%FREETYPE_VER%/freetype-%FREETYPE_VER%.zip
-
-    unzip -o freetype-%FREETYPE_VER%.zip -d freetype-%FREETYPE_VER%
-
-    mv freetype-%FREETYPE_VER%/include include
-
-    mv freetype-%FREETYPE_VER%/win64 lib
-
+    appveyor DownloadFile https://github.com/ubawurinna/freetype-windows-binaries/releases/download/v%FREETYPE_VER%/freetype.zip
+    unzip -o freetype.zip -d freetype_tmp
+    mv freetype_tmp/include include
+    mv freetype_tmp/%PLATFORM_NAME% lib
+    
     cd ..
+    mkdir Build-Dynamic, Build-Static
+    
+    cd Build-Dynamic
+    cmake -G "%VS_GENERATOR%" -DBUILD_SHARED_LIBS=ON -DBUILD_SAMPLES=ON ..
 
-    cmake -G "%VS_GENERATOR%" -DBUILD_SHARED_LIBS=%BUILD_SHARED_LIBS% -DBUILD_SAMPLES=%BUILD_SAMPLES% .
-build:
-  project: RmlUi.sln
-  parallel: true
-  verbosity: minimal
+    cd ../Build-Static
+    cmake -G "%VS_GENERATOR%" -DBUILD_SHARED_LIBS=OFF -DBUILD_SAMPLES=OFF ..
+    
+    cd ..
+    
+build_script:
+- cmd: |-
+    msbuild Build-Dynamic/RmlUi.sln /p:configuration=debug   /verbosity:minimal /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+    
+    msbuild Build-Dynamic/RmlUi.sln /p:configuration=release /verbosity:minimal /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+    
+    msbuild Build-Static/RmlUi.sln  /p:configuration=debug   /verbosity:minimal /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+    
+    msbuild Build-Static/RmlUi.sln  /p:configuration=release /verbosity:minimal /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+    
 after_build:
-- cmd: >-
-    IF "%BUILD_SHARED_LIBS%"=="ON" 7z a RmlUi-Debug-win64.zip ./Debug/* -r -x!*.exp -x!*.lib -x!*.ilk -x!*.pdb -x!src/*
+- cmd: |-
+    mkdir Bin
+    cd Bin
+    mkdir Dynamic-Debug, Dynamic-Release, Static-Debug, Static-Release
+    cp ../Build-Dynamic/Debug/Rml*.{lib,dll,pdb} Dynamic-Debug
+    cp ../Build-Dynamic/Release/Rml*.{lib,dll} Dynamic-Release
+    cp ../Build-Static/Debug/Rml*.{lib,pdb} Static-Debug
+    cp ../Build-Static/Release/Rml*.lib Static-Release
+    cd ..
+    
+    cp Build-Dynamic/Release/*.exe Samples
+    cp Bin/Dynamic-Release/*.dll Samples
+    cp Dependencies/lib/*.dll Samples
 
-    IF "%BUILD_SHARED_LIBS%"=="ON" IF "%BUILD_SAMPLES%"=="ON" 7z a RmlUi-Debug-win64.zip Dependencies/freetype-%FREETYPE_VER%/*.txt ./Dependencies/lib/freetype.dll ./Samples/* -r -x!*.exp -x!*.lib -x!*.ilk -x!*.pdb -x!src/*
-
-    IF "%BUILD_SHARED_LIBS%"=="OFF" mkdir Lib && cp ./Debug/*.lib Lib && 7z a RmlUi-static-Debug-win64.zip Lib Include
+    mv Dependencies/lib/ Dependencies/freetype-%FREETYPE_VER%
+    cp Dependencies/freetype_tmp/*.TXT Dependencies/freetype-%FREETYPE_VER%
+    
+    IF NOT "%APPVEYOR_REPO_TAG_NAME%"=="" SET RMLUI_VERSION= %APPVEYOR_REPO_TAG_NAME%
+    
+    echo RmlUi%RMLUI_VERSION% library and sample binaries for %PLATFORM_NAME%.> Readme.txt& echo.>>Readme.txt
+    echo https://github.com/mikke89/RmlUi>> Readme.txt& echo.>>Readme.txt
+    echo Built using %VS_GENERATOR% on %APPVEYOR_REPO_COMMIT_TIMESTAMP:~0,10% (build %APPVEYOR_BUILD_NUMBER%).>> Readme.txt
+    echo Commit id: %APPVEYOR_REPO_COMMIT%.>> Readme.txt
+    
+    7z a RmlUi-%PLATFORM_NAME%.zip Bin/ Include/ Readme.txt LICENSE Dependencies/freetype-%FREETYPE_VER%/ Samples/
+    
 artifacts:
-- path: RmlUi-Debug-win64.zip
-- path: RmlUi-static-Debug-win64.zip
+- path: RmlUi-win64.zip
+- path: RmlUi-win32.zip
+deploy:
+  release: RmlUi $(APPVEYOR_REPO_TAG_NAME)
+  description: 'Release description'
+  provider: GitHub
+  auth_token:
+    secure: g/WlXrOszpqKYC++IvUvNOPhuEeHbMm+2/TWzcgQko+nIGKmjvfAWUxouNhgsUy9
+  artifact: /.*\.zip/
+  draft: true
+  prerelease: false
+  on:
+    APPVEYOR_REPO_TAG: true

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -62,7 +62,7 @@ after_build:
     echo Built using %VS_GENERATOR% on %APPVEYOR_REPO_COMMIT_TIMESTAMP:~0,10% (build %APPVEYOR_BUILD_NUMBER%).>> Readme.txt
     echo Commit id: %APPVEYOR_REPO_COMMIT%.>> Readme.txt
     
-    7z a RmlUi-%PLATFORM_NAME%.zip Bin/ Include/ Readme.txt LICENSE Dependencies/freetype-%FREETYPE_VER%/ Samples/
+    7z a RmlUi-%PLATFORM_NAME%.zip Bin/ Include/ Readme.txt changelog.md LICENSE Dependencies/freetype-%FREETYPE_VER%/ Samples/
     
     mkdir Samples\Dependencies\freetype-%FREETYPE_VER%
     cp Dependencies/freetype-%FREETYPE_VER%/*.TXT Samples/Dependencies/freetype-%FREETYPE_VER%

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,15 @@
-# Primary cmake build target
+# Primary CMake build target
 /Build/
+
+# Other common build targets
+/build/
+/Bin/
+/bin/
+/Lib/
+/lib/
+
+# Distribution target
+/Distribution/
 
 # Ignore MacOSX directory info
 .DS_Store
@@ -12,5 +22,3 @@
 *.dir/
 Win32/
 x64/
-
-/Distribution/

--- a/CMake/builddist.py
+++ b/CMake/builddist.py
@@ -8,12 +8,14 @@ import shutil
 import re
 
 def Usage(args):
-	print sys.argv[0] + ' [-hp] [-r revision]'
-	print ''
-	print ' -r\t: Specify RmlUi internal revision number'
-	print ' -s\t: Include full source code and build files'
-	print ' -h\t: This help screen'
-	print ''
+	print(sys.argv[0] + ' [-h] [-s] [-b] [-a] [-v version]')
+	print('')
+	print(' -h\t: This help screen')
+	print(' -s\t: Include full source code and build files')
+	print(' -b\t: Include sample binaries')
+	print(' -a\t: Create archive using 7z')
+	print(' -v\t: Specify RmlUi version')
+	print('')
 	sys.exit()
 
 def CheckVSVars():
@@ -21,7 +23,7 @@ def CheckVSVars():
 		return
 		
 	if not 'VS90COMNTOOLS' in os.environ:
-		print "Unable to find VS9 install - check your VS90COMNTOOLS environment variable"
+		print("Unable to find VS9 install - check your VS90COMNTOOLS environment variable")
 		sys.exit()
 		
 	path = os.environ['VS90COMNTOOLS']
@@ -30,22 +32,26 @@ def CheckVSVars():
 	
 def ProcessOptions(args):
 
-	options = {'RMLUI_VERSION': 'custom', 'FULL_SOURCE': False, 'ARCHIVE_NAME': 'RmlUi-sdk'}
+	options = {'RMLUI_VERSION': 'custom', 'FULL_SOURCE': False, 'ARCHIVE_NAME': 'RmlUi-sdk', 'SAMPLE_BINARIES': False, 'ARCHIVE': False}
 	
 	try:
-		optlist, args = getopt.getopt(args, 'r:phs')
-	except getopt.GetoptError, e:
-		print '\nError: ' + str(e) + '\n'
+		optlist, args = getopt.getopt(args, 'v:hsba')
+	except getopt.GetoptError as e:
+		print('\nError: ' + str(e) + '\n')
 		Usage(args)
 	
 	for opt in optlist:
 		if opt[0] == '-h':
 			Usage(args)
-		if opt[0] == '-r':
+		if opt[0] == '-v':
 			options['RMLUI_VERSION'] = opt[1]
 		if opt[0] == '-s':
 			options['FULL_SOURCE'] = True
 			options['ARCHIVE_NAME'] = 'RmlUi-source'
+		if opt[0] == '-b':
+			options['SAMPLE_BINARIES'] = True
+		if opt[0] == '-a':
+			options['ARCHIVE'] = True
 			
 	return options
 		
@@ -57,14 +63,14 @@ def Build(project, configs, defines = {}):
 	else:
 		os.environ['CL'] = ''
 
-	for name, value in defines.iteritems():
+	for name, value in defines.items():
 		os.environ['CL'] = os.environ['CL'] + ' /D' + name + '=' + value
 		
 	for config in configs:
 		cmd = '"' + os.environ['VCINSTALLDIR'] + '\\vcpackages\\vcbuild.exe" /rebuild ' + project + '.vcproj "' + config + '|Win32"'
 		ret = subprocess.call(cmd)
 		if ret != 0:
-			print "Failed to build " + project
+			print("Failed to build " + project)
 			sys.exit()
 			
 	os.environ['CL'] = old_cl
@@ -73,68 +79,69 @@ def DelTree(path):
 	if not os.path.exists(path):
 		return
 		
-	print 'Deleting ' + path + '...'
+	print('Deleting ' + path + '...')
 	for root, dirs, files in os.walk(path, topdown=False):
 		for name in files:
 			os.remove(os.path.join(root, name))
 		for name in dirs:
 			os.rmdir(os.path.join(root, name))
 
-def CopyFiles(source_path, destination_path, file_list = [], exclude_list = [], preserve_paths = True):
+def CopyFiles(source_path, destination_path, file_list = [], exclude_directories = [], exclude_files = [], preserve_paths = True):
 	working_directory = os.getcwd()
 	source_directory = os.path.abspath(os.path.join(working_directory, os.path.normpath(source_path)))
 	destination_directory = os.path.abspath(os.path.join(working_directory, os.path.normpath(destination_path)))
-	print "Copying " + source_directory + " to " + destination_directory + " ..."
+	print("Copying " + source_directory + " to " + destination_directory + " ...")
 	
 	if not os.path.exists(source_directory):
-		print "Warning: Source directory " + source_directory + " doesn't exist."
+		print("Warning: Source directory " + source_directory + " doesn't exist.")
 		return False
 	
-	for root, directories, files in os.walk(source_directory, False):
-			for file in files:
-				
-				# Skip files not in the include list.
-				if len(file_list) > 0:
-					included = False
-					for include in file_list:
-						if re.search(include, file):
-							included = True
-							break;
+	for root, directories, files in os.walk(source_directory, topdown=True):
+		directories[:] = [d for d in directories if d not in exclude_directories]
+		
+		for file in files:
+			# Skip files not in the include list.
+			if len(file_list) > 0:
+				included = False
+				for include in file_list:
+					if re.search(include, file):
+						included = True
+						break;
 
-					if not included:
-						continue
-				
-				# Determine our subdirectory.
-				subdir = root.replace(source_directory, "")
-				if subdir[:1] == os.path.normcase('/'):
-					subdir = subdir[1:]
-				
-				# Skip paths in the exclude list
-				excluded = False
-				for exclude in exclude_list:
-					if re.search(exclude, file):
-						excluded = True
-						break
-						
-				if excluded:
+				if not included:
 					continue
-				
-				# Build up paths
-				source_file = os.path.join(root, file)
-				destination_subdir = destination_directory
-				if preserve_paths:
-					destination_subdir = os.path.join(destination_directory, subdir)
-				
-				if not os.path.exists(destination_subdir):
-					os.makedirs(destination_subdir)
-				destination_file = os.path.join(destination_subdir, file)
-				
-				# Copy files
-				try:
-					shutil.copy(source_file, destination_file)
-				except:
-					print "Failed copying " + source_file + " to " + destination_file
-					traceback.print_exc()
+			
+			# Determine our subdirectory.
+			subdir = root.replace(source_directory, "")
+			if subdir[:1] == os.path.normcase('/'):
+				subdir = subdir[1:]
+			
+			# Skip paths in the exclude list
+			excluded = False
+			for exclude in exclude_files:
+				if re.search(exclude, file):
+					excluded = True
+					break
+					
+			if excluded:
+				continue
+			
+			# Build up paths
+			source_file = os.path.join(root, file)
+			destination_subdir = destination_directory
+			if preserve_paths:
+				destination_subdir = os.path.join(destination_directory, subdir)
+			
+			if not os.path.exists(destination_subdir):
+				os.makedirs(destination_subdir)
+			destination_file = os.path.join(destination_subdir, file)
+			
+			# Copy files
+			try:
+				shutil.copy(source_file, destination_file)
+			except:
+				print("Failed copying " + source_file + " to " + destination_file)
+				traceback.print_exc()
 					
 	return True
 	
@@ -144,26 +151,31 @@ def Archive(archive_name, path):
 	file_name = archive_name + '.zip'
 	if os.path.exists(file_name):
 		os.unlink(file_name)
-	os.system('zip -r ' + file_name + ' ' + path[path.rfind('/')+1:])
+	os.system('7z a ' + file_name + ' ' + path[path.rfind('/')+1:])
 	os.chdir(cwd)
 	
 def main():
-	CheckVSVars()
 	options = ProcessOptions(sys.argv[1:])
 	
-	Build('RmlCore', ['Debug', 'Release'], {'RMLUI_VERSION': '\\"' + options['RMLUI_VERSION'] + '\\"'})
-	Build('RmlControls', ['Debug', 'Release'])
-	Build('RmlDebugger', ['Debug', 'Release'])
+	#CheckVSVars()
+	#Build('RmlCore', ['Debug', 'Release'], {'RMLUI_VERSION': '\\"' + options['RMLUI_VERSION'] + '\\"'})
+	#Build('RmlControls', ['Debug', 'Release'])
+	#Build('RmlDebugger', ['Debug', 'Release'])
 	
 	DelTree('../Distribution/RmlUi')
 	CopyFiles('../Include', '../Distribution/RmlUi/Include')
-	CopyFiles('../Build', '../Distribution/RmlUi/Build', ['\.dll$', '^[^_].*\.lib$', '\.py$', '\.pyd$'])
-	CopyFiles('../Samples', '../Distribution/RmlUi/Samples', ['\.h$', '\.cpp$', '\.vcproj$', '\.sln$', '\.vcproj\.user$', '\.rml$', '\.rcss$', '\.tga$', '\.py$', '\.otf$', '\.txt$'])
+	CopyFiles('../Build', '../Distribution/RmlUi/Build', ['\.dll$', '^Rml.*\.lib$'], ['CMakeFiles'])
+	CopyFiles('../CMake', '../Distribution/RmlUi/CMake', ['\.cmake$', '\.in$', '\.plist$', '\.py$', '\.sh$'])
+	CopyFiles('../Samples', '../Distribution/RmlUi/Samples', ['\.h$', '\.cpp$', '\.rml$', '\.rcss$', '\.tga$', '\.py$', '\.otf$', '\.ttf$', '\.txt$'])
 	if options['FULL_SOURCE']:
-		CopyFiles('../Build', '../Distribution/RmlUi/Build', ['\.vcproj$', '\.sln$', '\.vsprops$', '\.py$'])
+		CopyFiles('../Build', '../Distribution/RmlUi/Build', ['\.vcxproj$', '\.sln$', '\.vsprops$', '\.py$'], ['CMakeFiles'])
 		CopyFiles('../Source', '../Distribution/RmlUi/Source', ['\.cpp$', '\.h$', '\.inl$'])
-	shutil.copyfile('../changelog.txt', '../Distribution/RmlUi/changelog.txt')
-	Archive(options['ARCHIVE_NAME'] + '-' + options['RMLUI_VERSION'], '../Distribution/RmlUi');
+	if options['SAMPLE_BINARIES']:
+		CopyFiles('../Build', '../Distribution/RmlUi/Build', ['\.exe$'], ['CMakeFiles'])
+	shutil.copyfile('../LICENSE', '../Distribution/RmlUi/LICENSE')
+	shutil.copyfile('../readme.md', '../Distribution/RmlUi/readme.md')
+	if options['ARCHIVE']:
+		Archive(options['ARCHIVE_NAME'] + '-' + options['RMLUI_VERSION'], '../Distribution/RmlUi');
 	
 if __name__ == '__main__':
 	main()


### PR DESCRIPTION
I'd like to automate the process of making releases on GitHub whenever we add a new tag. 

First of all, we need to decide what kind of files we would like to include in a release. Some suggestions:

1. Full copy of repository (with source code and assets).
2. Runnable sample binaries for Windows. What about Linux and macOS?
3. Static and dynamic binaries for Windows. What about Linux and macOS?
   - With header files or full source code?
   - Include `Debug` and `Release` builds for RmlCore, RmlControls, RmlDebugger.
4. Full source with Visual Studio projects, no binaries.

What do you think, which of these could be useful? Any other suggestions?

How useful even are binaries for a project like this? I think generally, you'd like to build the files using the compiler used for your project, but perhaps something like `4.` is easier to get going for some new users. But they would still need FreeType which might be confusing. For Linux and macOS building should be simpler already.

Currently, we have an appveyor artifact producing number `2.` for Windows. For `3.` there are separate archives produced for the Debug/Release and Static/Dynamic combinations. Does anyone know if it is possible to combine these into a single archive, or do we have to do this manually for each release?