### PR TITLE
Only define Windows string functions if needed

### DIFF
--- a/Include/RmlUi/Core/StringUtilities.h
+++ b/Include/RmlUi/Core/StringUtilities.h
@@ -45,7 +45,7 @@ namespace Core {
 // Redefine Windows APIs as their STDC counterparts.
 #ifdef _MSC_VER
 	#define strcasecmp stricmp
-	#define strcasecmp strnicmp
+	#define strncasecmp strnicmp
 #endif
 
 class StringView;

--- a/Include/RmlUi/Core/StringUtilities.h
+++ b/Include/RmlUi/Core/StringUtilities.h
@@ -44,8 +44,12 @@ namespace Core {
 
 // Redefine Windows APIs as their STDC counterparts.
 #ifdef RMLUI_PLATFORM_WIN32
-	#define strcasecmp stricmp
-	#define strncasecmp strnicmp
+	#ifndef strcasecmp
+		#define strcasecmp stricmp
+	#endif
+	#ifndef strncasecmp
+		#define strcasecmp strnicmp
+	#endif
 #endif
 
 class StringView;

--- a/Include/RmlUi/Core/StringUtilities.h
+++ b/Include/RmlUi/Core/StringUtilities.h
@@ -43,13 +43,9 @@ namespace Core {
  */
 
 // Redefine Windows APIs as their STDC counterparts.
-#ifdef RMLUI_PLATFORM_WIN32
-	#ifndef strcasecmp
-		#define strcasecmp stricmp
-	#endif
-	#ifndef strncasecmp
-		#define strcasecmp strnicmp
-	#endif
+#ifdef _MSC_VER
+	#define strcasecmp stricmp
+	#define strcasecmp strnicmp
 #endif
 
 class StringView;


### PR DESCRIPTION
Otherwise this results in warnings when compiling with MinGW-w64:

```
In file included from Include/RmlUi/Core/TypeConverter.h:35,
                 from Include/RmlUi/Core/Variant.h:34,
                 from Include/RmlUi/Core/Property.h:32,
                 from Include/RmlUi/Core/PropertyDictionary.h:33,
                 from Include/RmlUi/Core/DecoratorInstancer.h:33,
                 from Include/RmlUi/Core/Core.h:41,
                 from Source/Core/precompiled.h:32,
                 from Source/Core/Texture.cpp:29:
Include/RmlUi/Core/StringUtilities.h:47: warning: "strcasecmp" redefined
   47 |  #define strcasecmp stricmp
      |
```