### PR TITLE
Fix sign comparision in DataQuery.cpp

### DIFF
--- a/Source/Controls/DataQuery.cpp
+++ b/Source/Controls/DataQuery.cpp
@@ -137,7 +137,7 @@ bool DataQuery::NextRow()
 bool DataQuery::IsFieldSet(const Rml::Core::String& field) const
 {
 	FieldIndices::const_iterator itr = field_indices.find(field);
-	if (itr == field_indices.end() || (*itr).second >= (int)rows[current_row].size())
+	if (itr == field_indices.end() || (*itr).second >= rows[current_row].size())
 	{
 		return false;
 	}


### PR DESCRIPTION
```
Source/Controls/DataQuery.cpp:140:50: warning: comparison of integer expressions of different signedness: 'const long long unsigned int' and 'int' [-Wsign-compare]
  140 |  if (itr == field_indices.end() || (*itr).second >= (int)rows[current_row].size())
      |                                    ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```