### PR TITLE
Remove redundant c_str() call found by clang-tidy

### DIFF
--- a/Source/Controls/DataSourceListener.cpp
+++ b/Source/Controls/DataSourceListener.cpp
@@ -95,7 +95,7 @@ bool DataSourceListener::ParseDataSource(DataSource*& data_source, Rml::Core::St
 	Rml::Core::StringList data_source_parts;
 	Rml::Core::StringUtilities::ExpandString(data_source_parts, data_source_name, '.');
 
-	DataSource* new_data_source = DataSource::GetDataSource(data_source_parts[0].c_str());
+	DataSource* new_data_source = DataSource::GetDataSource(data_source_parts[0]);
 
 	if (data_source_parts.size() != 2 || !new_data_source)
 	{


### PR DESCRIPTION
```
Source/Controls/DataSourceListener.cpp:98:58: error: redundant call to 'c_str' [readability-redundant-string-cstr,-warnings-as-errors]
        DataSource* new_data_source = DataSource::GetDataSource(data_source_parts[0].c_str());
                                                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                                                data_source_parts[0]
```