### PR TITLE
Make <html> the parent element of the document instead of <body>

### DIFF
--- a/CMake/FileList.cmake
+++ b/CMake/FileList.cmake
@@ -86,6 +86,7 @@ set(Core_HDR_FILES
     ${PROJECT_SOURCE_DIR}/Source/Core/XMLNodeHandlerBody.h
     ${PROJECT_SOURCE_DIR}/Source/Core/XMLNodeHandlerDefault.h
     ${PROJECT_SOURCE_DIR}/Source/Core/XMLNodeHandlerHead.h
+	${PROJECT_SOURCE_DIR}/Source/Core/XMLNodeHandlerHtml.h
     ${PROJECT_SOURCE_DIR}/Source/Core/XMLNodeHandlerTemplate.h
     ${PROJECT_SOURCE_DIR}/Source/Core/XMLParseTools.h
 )
@@ -314,6 +315,7 @@ set(Core_SRC_FILES
     ${PROJECT_SOURCE_DIR}/Source/Core/XMLNodeHandlerBody.cpp
     ${PROJECT_SOURCE_DIR}/Source/Core/XMLNodeHandlerDefault.cpp
     ${PROJECT_SOURCE_DIR}/Source/Core/XMLNodeHandlerHead.cpp
+	${PROJECT_SOURCE_DIR}/Source/Core/XMLNodeHandlerHtml.cpp
     ${PROJECT_SOURCE_DIR}/Source/Core/XMLNodeHandlerTemplate.cpp
     ${PROJECT_SOURCE_DIR}/Source/Core/XMLParser.cpp
     ${PROJECT_SOURCE_DIR}/Source/Core/XMLParseTools.cpp

--- a/Include/RmlUi/Core/Context.h
+++ b/Include/RmlUi/Core/Context.h
@@ -88,7 +88,7 @@ public:
 	/// Creates a new, empty document and places it into this context.
 	/// @param[in] tag The document type to create.
 	/// @return The new document, or nullptr if no document could be created.
-	ElementDocument* CreateDocument(const String& tag = "body");
+	ElementDocument* CreateDocument(const String& tag = "html");
 	/// Load a document into the context.
 	/// @param[in] document_path The path to the document to load.
 	/// @return The loaded document, or nullptr if no document was loaded.

--- a/Source/Core/Context.cpp
+++ b/Source/Core/Context.cpp
@@ -62,7 +62,7 @@ Context::Context(const String& name) : name(name), dimensions(0, 0), density_ind
 	root->SetOffset(Vector2f(0, 0), nullptr);
 	root->SetProperty(PropertyId::ZIndex, Property(0, Property::NUMBER));
 
-	cursor_proxy = Factory::InstanceElement(nullptr, "body", "body", XMLAttributes());
+	cursor_proxy = Factory::InstanceElement(nullptr, "html", "html", XMLAttributes());
 	ElementDocument* cursor_proxy_document = rmlui_dynamic_cast< ElementDocument* >(cursor_proxy.get());
 	if (cursor_proxy_document)
 		cursor_proxy_document->context = this;
@@ -216,7 +216,7 @@ bool Context::Render()
 // Creates a new, empty document and places it into this context.
 ElementDocument* Context::CreateDocument(const String& tag)
 {
-	ElementPtr element = Factory::InstanceElement(nullptr, tag, "body", XMLAttributes());
+	ElementPtr element = Factory::InstanceElement(nullptr, tag, "html", XMLAttributes());
 	if (!element)
 	{
 		Log::Message(Log::LT_ERROR, "Failed to instance document on tag '%s', instancer returned nullptr.", tag.c_str());

--- a/Source/Core/Factory.cpp
+++ b/Source/Core/Factory.cpp
@@ -101,6 +101,7 @@ struct DefaultInstancers {
 	Ptr<ElementInstancer> element_text_default = std::make_unique<ElementInstancerTextDefault>();
 	Ptr<ElementInstancer> element_img = std::make_unique<ElementInstancerGeneric<ElementImage>>();
 	Ptr<ElementInstancer> element_handle = std::make_unique<ElementInstancerGeneric<ElementHandle>>();
+	Ptr<ElementInstancer> element_body = std::make_unique<ElementInstancerElement>();
 	Ptr<ElementInstancer> element_html = std::make_unique<ElementInstancerGeneric<ElementDocument>>();
 
 	Ptr<DecoratorInstancer> decorator_tiled_horizontal = std::make_unique<DecoratorTiledHorizontalInstancer>();
@@ -155,6 +156,7 @@ bool Factory::Initialise()
 	RegisterElementInstancer("img", default_instancers->element_img.get());
 	RegisterElementInstancer("#text", default_instancers->element_text_default.get());
 	RegisterElementInstancer("handle", default_instancers->element_handle.get());
+	RegisterElementInstancer("body", default_instancers->element_body.get());
 	RegisterElementInstancer("html", default_instancers->element_html.get());
 
 	// Bind the default decorator instancers
@@ -172,6 +174,7 @@ bool Factory::Initialise()
 
 	// Register the core XML node handlers.
 	XMLParser::RegisterNodeHandler("", std::make_shared<XMLNodeHandlerDefault>());
+	XMLParser::RegisterNodeHandler("body", std::make_shared<XMLNodeHandlerBody>());
 	XMLParser::RegisterNodeHandler("html", std::make_shared<XMLNodeHandlerHtml>());
 	XMLParser::RegisterNodeHandler("head", std::make_shared<XMLNodeHandlerHead>());
 	XMLParser::RegisterNodeHandler("template", std::make_shared<XMLNodeHandlerTemplate>());

--- a/Source/Core/Factory.cpp
+++ b/Source/Core/Factory.cpp
@@ -61,6 +61,7 @@
 #include "XMLNodeHandlerBody.h"
 #include "XMLNodeHandlerDefault.h"
 #include "XMLNodeHandlerHead.h"
+#include "XMLNodeHandlerHtml.h"
 #include "XMLNodeHandlerTemplate.h"
 #include "XMLParseTools.h"
 
@@ -100,7 +101,7 @@ struct DefaultInstancers {
 	Ptr<ElementInstancer> element_text_default = std::make_unique<ElementInstancerTextDefault>();
 	Ptr<ElementInstancer> element_img = std::make_unique<ElementInstancerGeneric<ElementImage>>();
 	Ptr<ElementInstancer> element_handle = std::make_unique<ElementInstancerGeneric<ElementHandle>>();
-	Ptr<ElementInstancer> element_body = std::make_unique<ElementInstancerGeneric<ElementDocument>>();
+	Ptr<ElementInstancer> element_html = std::make_unique<ElementInstancerGeneric<ElementDocument>>();
 
 	Ptr<DecoratorInstancer> decorator_tiled_horizontal = std::make_unique<DecoratorTiledHorizontalInstancer>();
 	Ptr<DecoratorInstancer> decorator_tiled_vertical = std::make_unique<DecoratorTiledVerticalInstancer>();
@@ -154,7 +155,7 @@ bool Factory::Initialise()
 	RegisterElementInstancer("img", default_instancers->element_img.get());
 	RegisterElementInstancer("#text", default_instancers->element_text_default.get());
 	RegisterElementInstancer("handle", default_instancers->element_handle.get());
-	RegisterElementInstancer("body", default_instancers->element_body.get());
+	RegisterElementInstancer("html", default_instancers->element_html.get());
 
 	// Bind the default decorator instancers
 	RegisterDecoratorInstancer("tiled-horizontal", default_instancers->decorator_tiled_horizontal.get());
@@ -171,7 +172,7 @@ bool Factory::Initialise()
 
 	// Register the core XML node handlers.
 	XMLParser::RegisterNodeHandler("", std::make_shared<XMLNodeHandlerDefault>());
-	XMLParser::RegisterNodeHandler("body", std::make_shared<XMLNodeHandlerBody>());
+	XMLParser::RegisterNodeHandler("html", std::make_shared<XMLNodeHandlerHtml>());
 	XMLParser::RegisterNodeHandler("head", std::make_shared<XMLNodeHandlerHead>());
 	XMLParser::RegisterNodeHandler("template", std::make_shared<XMLNodeHandlerTemplate>());
 
@@ -270,9 +271,9 @@ bool Factory::InstanceElementText(Element* parent, const String& text)
 	{
 		RMLUI_ZoneScopedNC("InstanceStream", 0xDC143C);
 		auto stream = std::make_unique<StreamMemory>(translated_data.size() + 32);
-		stream->Write("<body>", 6);
+		stream->Write("<html>", 6);
 		stream->Write(translated_data);
-		stream->Write("</body>", 7);
+		stream->Write("</html>", 7);
 		stream->Seek(0, SEEK_SET);
 
 		InstanceElementStream(parent, stream.get());
@@ -333,7 +334,7 @@ ElementPtr Factory::InstanceDocumentStream(Rml::Core::Context* context, Stream* 
 {
 	RMLUI_ZoneScoped;
 
-	ElementPtr element = Factory::InstanceElement(nullptr, "body", "body", XMLAttributes());
+	ElementPtr element = Factory::InstanceElement(nullptr, "html", "html", XMLAttributes());
 	if (!element)
 	{
 		Log::Message(Log::LT_ERROR, "Failed to instance document, instancer returned nullptr.");

--- a/Source/Core/XMLNodeHandlerBody.cpp
+++ b/Source/Core/XMLNodeHandlerBody.cpp
@@ -43,9 +43,8 @@ XMLNodeHandlerBody::~XMLNodeHandlerBody()
 {
 }
 
-Element* XMLNodeHandlerBody::ElementStart(XMLParser* parser, const String& RMLUI_UNUSED_ASSERT_PARAMETER(name), const XMLAttributes& attributes)
+Element* XMLNodeHandlerBody::ElementStart(XMLParser* parser, const String& name, const XMLAttributes& attributes)
 {
-	RMLUI_UNUSED_ASSERT(name);
 	RMLUI_ASSERT(name == "body");
 
     // Determine the parent

--- a/Source/Core/XMLNodeHandlerBody.cpp
+++ b/Source/Core/XMLNodeHandlerBody.cpp
@@ -45,8 +45,6 @@ XMLNodeHandlerBody::~XMLNodeHandlerBody()
 
 Element* XMLNodeHandlerBody::ElementStart(XMLParser* parser, const String& name, const XMLAttributes& attributes)
 {
-	RMLUI_ASSERT(name == "body");
-
     // Determine the parent
     Element* parent = parser->GetParseFrame()->element;
 

--- a/Source/Core/XMLNodeHandlerHead.cpp
+++ b/Source/Core/XMLNodeHandlerHead.cpp
@@ -80,12 +80,12 @@ Element* XMLNodeHandlerHead::ElementStart(XMLParser* parser, const String& name,
 
 			else
 			{
-				//Log::ParseError(parser->GetSourceURL().GetURL(), parser->GetLineNumber(), "Invalid link type '%s'", type.c_str());
+				Log::ParseError(parser->GetSourceURL().GetURL(), parser->GetLineNumber(), "Invalid link type '%s'", type.c_str());
 			}
 		}
 		else
 		{
-			//Log::ParseError(parser->GetSourceURL().GetURL(), parser->GetLineNumber(), "Link tag requires type and href attributes");
+			Log::ParseError(parser->GetSourceURL().GetURL(), parser->GetLineNumber(), "Link tag requires type and href attributes");
 		}
 	}
 
@@ -100,19 +100,21 @@ Element* XMLNodeHandlerHead::ElementStart(XMLParser* parser, const String& name,
 		}
 	}
 
-	//////////////// Added by Digitalknob ////////////////////////////////
+	// Determine the parent
 	Element* parent = parser->GetParseFrame()->element;
+
+	// Attempt to instance the element with the instancer
 	ElementPtr element = Factory::InstanceElement(parent, name, name, attributes);
-	if (!element){
-		Log::Message(Log::LT_ERROR, "Failed to create element for tag %s, instancer returned NULL.", name.c_str());
-		return NULL;
+	if (!element)
+	{
+		Log::Message(Log::LT_ERROR, "Failed to create element for tag %s, instancer returned nullptr.", name.c_str());
+		return nullptr;
 	}
+
+	// Add the element to its parent and remove the reference
 	Element* result = parent->AppendChild(std::move(element));
+
 	return result;
-	//////////////////////////////////////////////////////////////////////
-	
-	// No elements constructed
-	//return nullptr;
 }
 
 bool XMLNodeHandlerHead::ElementEnd(XMLParser* parser, const String& name)
@@ -154,12 +156,7 @@ bool XMLNodeHandlerHead::ElementData(XMLParser* parser, const String& data)
 		parser->GetDocumentHeader()->rcss_inline_line_numbers.push_back(parser->GetLineNumberOpenTag());
 	}
 
-	//////////////// Added by Digitalknob ////////////////////////////////
-	Element* parent = parser->GetParseFrame()->element;
-	return Factory::InstanceElementText(parent, data);
-	//////////////////////////////////////////////////////////////////////
-	
-	//return true;
+	return Factory::InstanceElementText(parser->GetParseFrame()->element, data);
 }
 
 }

--- a/Source/Core/XMLNodeHandlerHead.cpp
+++ b/Source/Core/XMLNodeHandlerHead.cpp
@@ -80,12 +80,12 @@ Element* XMLNodeHandlerHead::ElementStart(XMLParser* parser, const String& name,
 
 			else
 			{
-				Log::ParseError(parser->GetSourceURL().GetURL(), parser->GetLineNumber(), "Invalid link type '%s'", type.c_str());
+				//Log::ParseError(parser->GetSourceURL().GetURL(), parser->GetLineNumber(), "Invalid link type '%s'", type.c_str());
 			}
 		}
 		else
 		{
-			Log::ParseError(parser->GetSourceURL().GetURL(), parser->GetLineNumber(), "Link tag requires type and href attributes");
+			//Log::ParseError(parser->GetSourceURL().GetURL(), parser->GetLineNumber(), "Link tag requires type and href attributes");
 		}
 	}
 
@@ -100,8 +100,19 @@ Element* XMLNodeHandlerHead::ElementStart(XMLParser* parser, const String& name,
 		}
 	}
 
+	//////////////// Added by Digitalknob ////////////////////////////////
+	Element* parent = parser->GetParseFrame()->element;
+	ElementPtr element = Factory::InstanceElement(parent, name, name, attributes);
+	if (!element){
+		Log::Message(Log::LT_ERROR, "Failed to create element for tag %s, instancer returned NULL.", name.c_str());
+		return NULL;
+	}
+	Element* result = parent->AppendChild(std::move(element));
+	return result;
+	//////////////////////////////////////////////////////////////////////
+	
 	// No elements constructed
-	return nullptr;
+	//return nullptr;
 }
 
 bool XMLNodeHandlerHead::ElementEnd(XMLParser* parser, const String& name)
@@ -143,7 +154,12 @@ bool XMLNodeHandlerHead::ElementData(XMLParser* parser, const String& data)
 		parser->GetDocumentHeader()->rcss_inline_line_numbers.push_back(parser->GetLineNumberOpenTag());
 	}
 
-	return true;
+	//////////////// Added by Digitalknob ////////////////////////////////
+	Element* parent = parser->GetParseFrame()->element;
+	return Factory::InstanceElementText(parent, data);
+	//////////////////////////////////////////////////////////////////////
+	
+	//return true;
 }
 
 }

--- a/Source/Core/XMLNodeHandlerHead.cpp
+++ b/Source/Core/XMLNodeHandlerHead.cpp
@@ -32,6 +32,7 @@
 #include "../../Include/RmlUi/Core/Core.h"
 #include "../../Include/RmlUi/Core/Element.h"
 #include "../../Include/RmlUi/Core/ElementDocument.h"
+#include "../../Include/RmlUi/Core/Factory.h"
 #include "../../Include/RmlUi/Core/StringUtilities.h"
 #include "../../Include/RmlUi/Core/SystemInterface.h"
 #include "../../Include/RmlUi/Core/XMLParser.h"

--- a/Source/Core/XMLNodeHandlerHtml.cpp
+++ b/Source/Core/XMLNodeHandlerHtml.cpp
@@ -1,0 +1,85 @@
+/*
+ * This source file is part of RmlUi, the HTML/CSS Interface Middleware
+ *
+ * For the latest information, see http://github.com/mikke89/RmlUi
+ *
+ * Copyright (c) 2008-2010 CodePoint Ltd, Shift Technology Ltd
+ * Copyright (c) 2019 The RmlUi Team, and contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+#include "XMLNodeHandlerHtml.h"
+#include "XMLParseTools.h"
+#include "../../Include/RmlUi/Core/XMLParser.h"
+#include "../../Include/RmlUi/Core/ElementDocument.h"
+#include "../../Include/RmlUi/Core/Factory.h"
+
+namespace Rml {
+namespace Core {
+
+XMLNodeHandlerHtml::XMLNodeHandlerHtml()
+{
+}
+
+XMLNodeHandlerHtml::~XMLNodeHandlerHtml()
+{
+}
+
+Element* XMLNodeHandlerHtml::ElementStart(XMLParser* parser, const String& RMLUI_UNUSED_ASSERT_PARAMETER(name), const XMLAttributes& attributes)
+{
+	RMLUI_UNUSED_ASSERT(name);
+	RMLUI_ASSERT(name == "html");
+
+	Element* element = parser->GetParseFrame()->element;
+
+	// Check for and apply any template
+	String template_name = Get<String>(attributes, "template", "");
+	if (!template_name.empty())
+	{
+		element = XMLParseTools::ParseTemplate(element, template_name);
+	}
+
+	// Apply any attributes to the document
+	ElementDocument* document = parser->GetParseFrame()->element->GetOwnerDocument();
+	if (document)
+		document->SetAttributes(attributes);
+
+	// Tell the parser to use the element handler for all children
+	parser->PushDefaultHandler();
+	
+	return element;
+}
+
+bool XMLNodeHandlerHtml::ElementEnd(XMLParser* RMLUI_UNUSED_PARAMETER(parser), const String& RMLUI_UNUSED_PARAMETER(name))
+{
+	RMLUI_UNUSED(parser);
+	RMLUI_UNUSED(name);
+
+	return true;
+}
+
+bool XMLNodeHandlerHtml::ElementData(XMLParser* parser, const String& data)
+{
+	return Factory::InstanceElementText(parser->GetParseFrame()->element, data);
+}
+
+}
+}

--- a/Source/Core/XMLNodeHandlerHtml.h
+++ b/Source/Core/XMLNodeHandlerHtml.h
@@ -1,0 +1,60 @@
+/*
+ * This source file is part of RmlUi, the HTML/CSS Interface Middleware
+ *
+ * For the latest information, see http://github.com/mikke89/RmlUi
+ *
+ * Copyright (c) 2008-2010 CodePoint Ltd, Shift Technology Ltd
+ * Copyright (c) 2019 The RmlUi Team, and contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+#ifndef RMLUICOREXMLNODEHANDLERHTML_H
+#define RMLUICOREXMLNODEHANDLERHTML_H
+
+#include "../../Include/RmlUi/Core/XMLNodeHandler.h"
+
+namespace Rml {
+namespace Core {
+
+/**
+	Element Node handler that processes the HTML tag
+
+	@author Lloyd Weehuizen
+ */
+
+class XMLNodeHandlerHtml : public XMLNodeHandler
+{
+public:
+	XMLNodeHandlerHtml();
+	~XMLNodeHandlerHtml();
+
+	/// Called when a new element start is opened
+	Element* ElementStart(XMLParser* parser, const String& name, const XMLAttributes& attributes) override;
+	/// Called when an element is closed
+	bool ElementEnd(XMLParser* parser, const String& name) override;
+	/// Called for element data
+	bool ElementData(XMLParser* parser, const String& data) override;
+};
+
+}
+}
+
+#endif

--- a/Source/Debugger/BeaconSource.h
+++ b/Source/Debugger/BeaconSource.h
@@ -27,7 +27,7 @@
  */
 
 static const char* beacon_rcss = R"RCSS(
-body
+html
 {
 	position: absolute;
 	top: 5px;

--- a/Source/Debugger/CommonSource.h
+++ b/Source/Debugger/CommonSource.h
@@ -27,7 +27,7 @@
  */
 
 static const char* common_rcss = R"RCSS(
-body
+html
 {
 	font-family: rmlui-debugger-font;
 	z-index: 1000000;

--- a/Source/Debugger/InfoSource.h
+++ b/Source/Debugger/InfoSource.h
@@ -27,7 +27,7 @@
  */
 
 static const char* info_rcss = R"RCSS(
-body
+html
 {
 	width: 320dp;
 	min-width: 320dp;

--- a/Source/Debugger/LogSource.h
+++ b/Source/Debugger/LogSource.h
@@ -26,7 +26,7 @@
  *
  */
 
-static const char* log_rcss = R"RCSS(body
+static const char* log_rcss = R"RCSS(html
 {
 	width: 400dp;
 	height: 300dp;

--- a/Source/Debugger/MenuSource.h
+++ b/Source/Debugger/MenuSource.h
@@ -27,7 +27,7 @@
  */
 
 static const char* menu_rcss = R"RCSS(
-body
+html
 {
 	width: 100%;
 	height: 32dp;


### PR DESCRIPTION
I've made some improvements on how RmlUi parses html and xml data. Originally, a body element would be created as the parent element of the document. All browsers create an html tag for the parent HTMLElement node. I've added the necessary changes to bring this one step closer to browser standards. This change should not break any existing html, rml, or css code, And the body tag will still implement templates as before. Also, the html, head and body tags are now, all viewable inside the debugger. Please review and test for issues and merge consideration. Thanks.

