### PR TITLE
Fix mingw build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,10 +171,6 @@ if(NO_FONT_INTERFACE_DEFAULT)
 	add_definitions(-DRMLUI_NO_FONT_INTERFACE_DEFAULT)
 endif()
 
-if (WIN32)
-	add_definitions(-DWIN32)
-endif(WIN32)
-
 if(NOT BUILD_SHARED_LIBS)
 	add_definitions(-DRMLUI_STATIC_LIB)
 	message("-- Building static libraries. Make sure to #define RMLUI_STATIC_LIB before including RmlUi in your project.")
@@ -451,10 +447,6 @@ macro(bl_sample NAME)
 	endif()
 
 	target_link_libraries(${NAME} ${ARGN})
-
-	if (WIN32)
-		target_link_libraries(${NAME} shlwapi)
-	endif()
 endmacro()
 
 if(BUILD_SAMPLES)
@@ -520,6 +512,10 @@ endif(NOT BUILD_FRAMEWORK)
 	
 	if (PRECOMPILED_HEADERS_ENABLED)
 		target_precompile_headers(shell PRIVATE ${PROJECT_SOURCE_DIR}/Samples/shell/src/precompiled.h)
+	endif()
+
+	if (WIN32)
+		target_link_libraries(shell PUBLIC shlwapi)
 	endif()
 
 	# Build and install the basic samples

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,6 +171,10 @@ if(NO_FONT_INTERFACE_DEFAULT)
 	add_definitions(-DRMLUI_NO_FONT_INTERFACE_DEFAULT)
 endif()
 
+if (WIN32)
+	add_definitions(-DWIN32)
+endif(WIN32)
+
 if(NOT BUILD_SHARED_LIBS)
 	add_definitions(-DRMLUI_STATIC_LIB)
 	message("-- Building static libraries. Make sure to #define RMLUI_STATIC_LIB before including RmlUi in your project.")
@@ -447,6 +451,10 @@ macro(bl_sample NAME)
 	endif()
 
 	target_link_libraries(${NAME} ${ARGN})
+
+	if (WIN32)
+		target_link_libraries(${NAME} shlwapi)
+	endif()
 endmacro()
 
 if(BUILD_SAMPLES)

--- a/Samples/basic/treeview/src/FileSystem.cpp
+++ b/Samples/basic/treeview/src/FileSystem.cpp
@@ -32,7 +32,7 @@
 #include <cstdio>
 #include <string.h>
 
-#ifdef WIN32
+#ifdef RMLUI_PLATFORM_WIN32
 #include <io.h>
 #else
 #include <dirent.h>
@@ -72,7 +72,7 @@ struct FileSystemNode
 	// Build the list of files and directories within this directory.
 	void BuildTree(const Rml::String& root = "")
 	{
-#ifdef WIN32
+#ifdef RMLUI_PLATFORM_WIN32
 		_finddata_t find_data;
 		intptr_t find_handle = _findfirst((root + name + "/*.*").c_str(), &find_data);
 		if (find_handle != -1)

--- a/Samples/shell/include/win32/IncludeWindows.h
+++ b/Samples/shell/include/win32/IncludeWindows.h
@@ -36,7 +36,9 @@
 #define UNICODE
 #define _UNICODE
 #define WIN32_LEAN_AND_MEAN
+#ifndef NOMINMAX
 #define NOMINMAX
+#endif
 
 #include <windows.h>
 

--- a/Samples/shell/src/win32/ShellWin32.cpp
+++ b/Samples/shell/src/win32/ShellWin32.cpp
@@ -34,7 +34,6 @@
 #include <stdio.h>
 #include <stdarg.h>
 #include <shlwapi.h>
-#pragma comment( lib  , "Shlwapi.lib"  )
 
 static LRESULT CALLBACK WindowProcedure(HWND window_handle, UINT message, WPARAM w_param, LPARAM l_param);
 


### PR DESCRIPTION
I have tried to build RmiUI with mingw/gcc today, and I found

1.  The samples need link shlwapi, but  https://github.com/mikke89/RmlUi/blob/master/Samples/shell/src/win32/ShellWin32.cpp#L37 only works for msvc.
2. mingw/gcc has already defined the macro `NOMINMAX`.
3. mingw/gcc has not defined the macro `WIN32`. (Only used in https://github.com/mikke89/RmlUi/blob/master/Samples/basic/treeview/src/FileSystem.cpp , and I guess using `RMLUI_PLATFORM_WIN32` instead would be better ? )

This PR may fixes these issues.