### PR TITLE
Add ability for user to override container types

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,6 +145,8 @@ endif()
 
 option(BUILD_SAMPLES "Build samples" OFF)
 
+option(MATRIX_ROW_MAJOR "Use row-major matrices. Column-major matrices are used by default." OFF)
+
 if(APPLE)
 	if(IOS)
 		if(BUILD_SHARED_LIBS)
@@ -181,6 +183,19 @@ if( NO_THIRDPARTY_CONTAINERS )
 	add_definitions(-DRMLUI_NO_THIRDPARTY_CONTAINERS)
 	message("-- No third-party containers will be used: Make sure to #define RMLUI_NO_THIRDPARTY_CONTAINERS before including RmlUi in your project.")
 endif()
+
+set(CUSTOM_CONFIG_FILE "" CACHE STRING "Custom configuration file to be included in place of default one.")
+if( CUSTOM_CONFIG_FILE )
+	add_definitions(-DRML_USER_CONFIG_FILE="${CUSTOM_CONFIG_FILE}")
+	message("-- Including ${CUSTOM_CONFIG_FILE} instead of RmlUi/UserConfig.h")
+endif ()
+
+set(CUSTOM_INCLUDE_DIRS "" CACHE STRING "Extra include directories (use with CUSTOM_CONFIG_FILE).")
+if( CUSTOM_INCLUDE_DIRS )
+	include_directories(${CUSTOM_INCLUDE_DIRS})
+endif ()
+
+set(CUSTOM_LINK_LIBRARIES "" CACHE STRING "Extra link libraries (use with CUSTOM_LINK_LIBRARIES).")
 
 option(ENABLE_TRACY_PROFILING "Enable profiling with Tracy. Source files can be placed in Dependencies/tracy." OFF)
 if( ENABLE_TRACY_PROFILING )
@@ -282,17 +297,34 @@ foreach(library ${LIBRARIES})
 	if (MSVC)
 		target_compile_options(${NAME} PUBLIC "/MP")
 	endif(MSVC)
-	
+
+	if( MATRIX_ROW_MAJOR )
+		target_compile_definitions(${NAME} -DRMLUI_MATRIX_ROW_MAJOR=1)
+	endif ()
+
+	if( CUSTOM_LINK_LIBRARIES )
+		target_link_libraries(${NAME} ${CUSTOM_LINK_LIBRARIES})
+	endif ()
+
 	install(TARGETS ${NAME}
 		EXPORT RmlUiTargets
 		LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
 		ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
 		RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 	)
-	
 
 	set(RMLUI_EXPORTED_TARGETS ${RMLUI_EXPORTED_TARGETS} ${NAME})
 endforeach(library)
+
+foreach(library ${CUSTOM_LINK_LIBRARIES})
+	install(TARGETS ${library}
+		EXPORT RmlUiTargets
+		LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+		ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+		RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+	)
+	set(RMLUI_EXPORTED_TARGETS ${RMLUI_EXPORTED_TARGETS} ${library})
+endforeach(library ${CUSTOM_LINK_LIBRARIES})
 
 target_compile_definitions(RmlCore PRIVATE RMLUI_VERSION="${RMLUI_VERSION_SHORT}")
 
@@ -517,6 +549,10 @@ endif(NOT BUILD_FRAMEWORK)
 	if (WIN32)
 		target_link_libraries(shell PUBLIC shlwapi)
 	endif()
+
+	if( CUSTOM_LINK_LIBRARIES )
+		target_link_libraries(shell PUBLIC ${CUSTOM_LINK_LIBRARIES})
+	endif ()
 
 	# Build and install the basic samples
 	foreach(sample ${samples})

--- a/Include/RmlUi/Config/Config.h
+++ b/Include/RmlUi/Config/Config.h
@@ -33,9 +33,12 @@
  * This file provides means to configure various types used across RmlUi. It is possible to override container types
  * with your own, provided they are compatible with STL, or customize STL containers, for example use a custom
  * allocator. This file may be edited directly, or can be copied to alternate location, modified, and included by
- * setting CMake option USER_CONFIG_FILE (RML_USER_CONFIG_FILE preprocessor define) to path of that file.
+ * setting CMake option USER_CONFIG_FILE (RMLUI_USER_CONFIG_FILE preprocessor define) to path of that file.
  */
 
+#ifdef RMLUI_USER_CONFIG_FILE
+#include RMLUI_USER_CONFIG_FILE
+#else
 #include <utility>
 #include <vector>
 #include <string>
@@ -45,14 +48,15 @@
 #include <queue>
 #include <array>
 #include <unordered_map>
+#include <memory>
 
 #ifdef RMLUI_NO_THIRDPARTY_CONTAINERS
 #include <set>
 #include <unordered_set>
 #else
-#include "Core/Containers/chobo/flat_map.hpp"
-#include "Core/Containers/chobo/flat_set.hpp"
-#include "Core/Containers/robin_hood.h"
+#include "../Core/Containers/chobo/flat_map.hpp"
+#include "../Core/Containers/chobo/flat_set.hpp"
+#include "../Core/Containers/robin_hood.h"
 #endif	// RMLUI_NO_THIRDPARTY_CONTAINERS
 
 namespace Rml {
@@ -64,6 +68,9 @@ namespace Rml {
 #else
 #define RMLUI_MATRIX4_TYPE ColumnMajorMatrix4f
 #endif
+
+// A way to disable 'final' specified for Rml::Releaser class. It breaks EASTL.
+#define RMLUI_RELEASER_FINAL final
 
 // Containers types.
 template<typename T>
@@ -120,6 +127,8 @@ using U16String = std::u16string;
 // Smart pointer types.
 template<typename T>
 using UniquePtr = std::unique_ptr<T>;
+template<typename T>
+class Releaser;
 template<typename T>
 using UniqueReleaserPtr = std::unique_ptr<T, Releaser<T>>;
 template<typename T>
@@ -183,6 +192,6 @@ inline UniquePtr<T> MakeUnique(Args... args) { return std::make_unique<T, Args..
 // Extra code to be inserted into RmlUi::Matrix4<> class body.
 // #define RMLUI_MATRIX4_USER_EXTRA operator MyMatrix4() const { return MyMatrix4(data()); }
 
-
+#endif	// RMLUI_USER_CONFIG_FILE
 
 #endif  // RMLUI_USER_CONFIG_H

--- a/Include/RmlUi/Core/Animation.h
+++ b/Include/RmlUi/Core/Animation.h
@@ -57,10 +57,10 @@ struct Transition {
 struct TransitionList {
 	bool none = true;
 	bool all = false;
-	std::vector<Transition> transitions;
+	Vector<Transition> transitions;
 
 	TransitionList() {}
-	TransitionList(bool none, bool all, std::vector<Transition> transitions) :
+	TransitionList(bool none, bool all, Vector<Transition> transitions) :
 		none(none), all(all), transitions(transitions) {}
 };
 

--- a/Include/RmlUi/Core/Colour.h
+++ b/Include/RmlUi/Core/Colour.h
@@ -109,6 +109,10 @@ public:
 	inline operator ColourType*() { return &red; }
 
 	ColourType red, green, blue, alpha;
+
+#ifdef RMLUI_COLOUR_USER_EXTRA
+	RMLUI_COLOUR_USER_EXTRA
+#endif
 };
 
 } // namespace Rml

--- a/Include/RmlUi/Core/Context.h
+++ b/Include/RmlUi/Core/Context.h
@@ -250,7 +250,7 @@ private:
 	ContextInstancer* instancer;
 
 	using ElementSet = SmallOrderedSet< Element* > ;
-	using ElementList = std::vector< Element* >;
+	using ElementList = Vector< Element* >;
 	// Set of elements that are currently in hover state.
 	ElementSet hover_chain;
 	// List of elements that are currently in active state.

--- a/Include/RmlUi/Core/DataController.h
+++ b/Include/RmlUi/Core/DataController.h
@@ -32,7 +32,6 @@
 #include "Header.h"
 #include "Types.h"
 #include "Traits.h"
-#include <unordered_map>
 
 namespace Rml {
 
@@ -111,7 +110,7 @@ public:
     void OnElementRemove(Element* element);
 
 private:
-    using ElementControllersMap = std::unordered_multimap<Element*, DataControllerPtr>;
+    using ElementControllersMap = UnorderedMultimap<Element*, DataControllerPtr>;
     ElementControllersMap controllers;
 };
 

--- a/Include/RmlUi/Core/DataModel.h
+++ b/Include/RmlUi/Core/DataModel.h
@@ -34,6 +34,7 @@
 #include "Traits.h"
 #include "DataTypes.h"
 #include "DataTypeRegister.h"
+#include <functional>
 
 namespace Rml {
 

--- a/Include/RmlUi/Core/DataTypeRegister.h
+++ b/Include/RmlUi/Core/DataTypeRegister.h
@@ -89,7 +89,7 @@ public:
 		static_assert(std::is_class<T>::value, "Type must be a struct or class type.");
 		FamilyId id = Family<T>::Id();
 
-		auto struct_variable = std::make_unique<StructDefinition>();
+		auto struct_variable = MakeUnique<StructDefinition>();
 		StructDefinition* struct_variable_raw = struct_variable.get();
 
 		bool inserted = type_register.emplace(id, std::move(struct_variable)).second;
@@ -113,7 +113,7 @@ public:
 
 		FamilyId container_id = Family<Container>::Id();
 
-		auto array_variable = std::make_unique<ArrayDefinition<Container>>(value_variable);
+		auto array_variable = MakeUnique<ArrayDefinition<Container>>(value_variable);
 
 		bool inserted = type_register.emplace(container_id, std::move(array_variable)).second;
 		if (!inserted)
@@ -135,7 +135,7 @@ public:
 		bool inserted = result.second;
 
 		if (inserted)
-			it->second = std::make_unique<MemberFuncDefinition<T>>(get_func, set_func);
+			it->second = MakeUnique<MemberFuncDefinition<T>>(get_func, set_func);
 
 		return it->second.get();
 	}
@@ -150,7 +150,7 @@ public:
 		UniquePtr<VariableDefinition>& definition = result.first->second;
 
 		if (inserted)
-			definition = std::make_unique<ScalarDefinition<T>>();
+			definition = MakeUnique<ScalarDefinition<T>>();
 
 		return definition.get();
 	}
@@ -190,13 +190,13 @@ template<typename Object>
 template<typename MemberType>
 inline StructHandle<Object>& StructHandle<Object>::RegisterMember(const String& name, MemberType Object::* member_ptr) {
 	VariableDefinition* member_type = type_register->GetOrAddScalar<MemberType>();
-	struct_definition->AddMember(name, std::make_unique<StructMemberObject<Object, MemberType>>(member_type, member_ptr));
+	struct_definition->AddMember(name, MakeUnique<StructMemberObject<Object, MemberType>>(member_type, member_ptr));
 	return *this;
 }
 template<typename Object>
 inline StructHandle<Object>& StructHandle<Object>::RegisterMemberFunc(const String& name, MemberGetFunc<Object> get_func, MemberSetFunc<Object> set_func) {
 	VariableDefinition* definition = type_register->RegisterMemberFunc<Object>(get_func, set_func);
-	struct_definition->AddMember(name, std::make_unique<StructMemberFunc>(definition));
+	struct_definition->AddMember(name, MakeUnique<StructMemberFunc>(definition));
 	return *this;
 }
 

--- a/Include/RmlUi/Core/DataTypes.h
+++ b/Include/RmlUi/Core/DataTypes.h
@@ -31,7 +31,6 @@
 
 #include "Header.h"
 #include "Types.h"
-#include <functional>
 
 namespace Rml {
 
@@ -41,10 +40,10 @@ class TransformFuncRegister;
 class DataModelHandle;
 class DataVariable;
 
-using DataGetFunc = std::function<void(Variant&)>;
-using DataSetFunc = std::function<void(const Variant&)>;
-using DataTransformFunc = std::function<bool(Variant&, const VariantList&)>;
-using DataEventFunc = std::function<void(DataModelHandle, Event&, const VariantList&)>;
+using DataGetFunc = Function<void(Variant&)>;
+using DataSetFunc = Function<void(const Variant&)>;
+using DataTransformFunc = Function<bool(Variant&, const VariantList&)>;
+using DataEventFunc = Function<void(DataModelHandle, Event&, const VariantList&)>;
 
 template<typename T> using MemberGetFunc = void(T::*)(Variant&);
 template<typename T> using MemberSetFunc = void(T::*)(const Variant&);
@@ -57,7 +56,7 @@ struct DataAddressEntry {
 	String name;
 	int index;
 };
-using DataAddress = std::vector<DataAddressEntry>;
+using DataAddress = Vector<DataAddressEntry>;
 
 } // namespace Rml
 #endif

--- a/Include/RmlUi/Core/DataView.h
+++ b/Include/RmlUi/Core/DataView.h
@@ -33,7 +33,6 @@
 #include "Types.h"
 #include "Traits.h"
 #include "DataTypes.h"
-#include <unordered_map>
 
 namespace Rml {
 
@@ -117,14 +116,14 @@ public:
 	bool Update(DataModel& model, const DirtyVariables& dirty_variables);
 
 private:
-	using DataViewList = std::vector<DataViewPtr>;
+	using DataViewList = Vector<DataViewPtr>;
 
 	DataViewList views;
 	
 	DataViewList views_to_add;
 	DataViewList views_to_remove;
 
-	using NameViewMap = std::unordered_multimap<String, DataView*>;
+	using NameViewMap = UnorderedMultimap<String, DataView*>;
 	NameViewMap name_view_map;
 };
 

--- a/Include/RmlUi/Core/Decorator.h
+++ b/Include/RmlUi/Core/Decorator.h
@@ -29,7 +29,6 @@
 #ifndef RMLUI_CORE_DECORATOR_H
 #define RMLUI_CORE_DECORATOR_H
 
-#include <vector>
 #include "Header.h"
 #include "Texture.h"
 #include "Types.h"
@@ -91,7 +90,7 @@ private:
 	// Stores a list of textures in use by this decorator.
 	// Optimized for the common case of a single texture.
 	Texture first_texture;
-	std::vector< Texture > additional_textures;
+	Vector< Texture > additional_textures;
 };
 
 } // namespace Rml

--- a/Include/RmlUi/Core/Element.h
+++ b/Include/RmlUi/Core/Element.h
@@ -700,7 +700,7 @@ private:
 	Vector2f scroll_offset;
 
 	// The size of the element.
-	using BoxList = std::vector< Box >;
+	using BoxList = Vector< Box >;
 	Box main_box;
 	BoxList additional_boxes;
 

--- a/Include/RmlUi/Core/Elements/DataQuery.h
+++ b/Include/RmlUi/Core/Elements/DataQuery.h
@@ -122,7 +122,7 @@ private:
 	int offset;
 	int limit;
 
-	typedef std::vector< StringList > Rows;
+	typedef Vector< StringList > Rows;
 	Rows rows;    
 	typedef UnorderedMap< String, size_t > FieldIndices;
 	FieldIndices field_indices;

--- a/Include/RmlUi/Core/Elements/DataSource.h
+++ b/Include/RmlUi/Core/Elements/DataSource.h
@@ -31,7 +31,6 @@
 
 #include "../Header.h"
 #include "../Types.h"
-#include <list>
 
 namespace Rml {
 
@@ -101,7 +100,7 @@ class RMLUICORE_API DataSource
 	private:
 		String name;
 
-		using ListenerList = std::list< DataSourceListener* >;
+		using ListenerList = List< DataSourceListener* >;
 		ListenerList listeners;
 };
 

--- a/Include/RmlUi/Core/Elements/ElementDataGrid.h
+++ b/Include/RmlUi/Core/Elements/ElementDataGrid.h
@@ -129,8 +129,8 @@ protected:
 	void GetInnerRML(String& content) const override;
 
 private:
-	typedef std::vector< Column > ColumnList;
-	typedef std::vector< ElementDataGridRow* > RowList;
+	typedef Vector< Column > ColumnList;
+	typedef Vector< ElementDataGridRow* > RowList;
 
 	ColumnList columns;
 	String column_fields;

--- a/Include/RmlUi/Core/Elements/ElementDataGridRow.h
+++ b/Include/RmlUi/Core/Elements/ElementDataGridRow.h
@@ -33,7 +33,6 @@
 #include "../Element.h"
 #include "DataSourceListener.h"
 #include "DataQuery.h"
-#include <queue>
 
 namespace Rml {
 
@@ -97,8 +96,8 @@ protected:
 	void OnRowChange(DataSource* data_source, const String& table) override;
 
 private:
-	typedef std::queue< ElementDataGridRow* > RowQueue;
-	typedef std::vector< ElementDataGridRow* > RowList;
+	typedef Queue< ElementDataGridRow* > RowQueue;
+	typedef Vector< ElementDataGridRow* > RowList;
 
 	// Called when a row change (addition or removal) occurs in one of our
 	// children. Causes the table row index to be dirtied on all following

--- a/Include/RmlUi/Core/Geometry.h
+++ b/Include/RmlUi/Core/Geometry.h
@@ -71,10 +71,10 @@ public:
 
 	/// Returns the geometry's vertices. If these are written to, Release() should be called to force a recompile.
 	/// @return The geometry's vertex array.
-	std::vector< Vertex >& GetVertices();
+	Vector< Vertex >& GetVertices();
 	/// Returns the geometry's indices. If these are written to, Release() should be called to force a recompile.
 	/// @return The geometry's index array.
-	std::vector< int >& GetIndices();
+	Vector< int >& GetIndices();
 
 	/// Gets the geometry's texture.
 	/// @return The geometry's texture.
@@ -96,8 +96,8 @@ private:
 	Context* host_context = nullptr;
 	Element* host_element = nullptr;
 
-	std::vector< Vertex > vertices;
-	std::vector< int > indices;
+	Vector< Vertex > vertices;
+	Vector< int > indices;
 	const Texture* texture = nullptr;
 
 	CompiledGeometryHandle compiled_geometry = 0;
@@ -106,7 +106,7 @@ private:
 	GeometryDatabaseHandle database_handle;
 };
 
-using GeometryList = std::vector< Geometry >;
+using GeometryList = Vector< Geometry >;
 
 } // namespace Rml
 #endif

--- a/Include/RmlUi/Core/Matrix4.h
+++ b/Include/RmlUi/Core/Matrix4.h
@@ -499,6 +499,9 @@ class Matrix4
 		static ThisType Compose(const Vector3< Component >& translation, const Vector3< Component >& scale,
 			const Vector3< Component >& skew, const Vector4< Component >& perspective, const Vector4< Component >& quaternion) noexcept;
 
+#ifdef RMLUI_MATRIX4_USER_EXTRA
+		RMLUI_MATRIX4_USER_EXTRA
+#endif
 };
 
 } // namespace Rml

--- a/Include/RmlUi/Core/ObserverPtr.h
+++ b/Include/RmlUi/Core/ObserverPtr.h
@@ -53,7 +53,7 @@ class EnableObserverPtr;
 
 	Usage: Given a class T, derive from EnableObserverPtr<T>. Then, we can use the observer pointer as follows:
 
-		auto object = std::make_unique<T>();
+		auto object = MakeUnique<T>();
 		ObserverPtr<T> observer_ptr = object->GetObserverPtr();
 		// ...
 		if(obserer_ptr) { 

--- a/Include/RmlUi/Core/PropertyDefinition.h
+++ b/Include/RmlUi/Core/PropertyDefinition.h
@@ -97,7 +97,7 @@ private:
 		ParameterMap parameters;
 	};
 
-	std::vector< ParserState > parsers;
+	Vector< ParserState > parsers;
 
 	RelativeTarget relative_target;
 };

--- a/Include/RmlUi/Core/PropertySpecification.h
+++ b/Include/RmlUi/Core/PropertySpecification.h
@@ -121,8 +121,8 @@ public:
 	String PropertiesToString(const PropertyDictionary& dictionary) const;
 
 private:
-	using Properties = std::vector< UniquePtr<PropertyDefinition> >;
-	using Shorthands = std::vector< UniquePtr<ShorthandDefinition> >;
+	using Properties = Vector< UniquePtr<PropertyDefinition> >;
+	using Shorthands = Vector< UniquePtr<ShorthandDefinition> >;
 
 	Properties properties;
 	Shorthands shorthands;

--- a/Include/RmlUi/Core/Spritesheet.h
+++ b/Include/RmlUi/Core/Spritesheet.h
@@ -64,7 +64,7 @@ struct Spritesheet {
 };
 
 using SpritesheetMap = SmallUnorderedMap<String, SharedPtr<const Spritesheet>>; // key: spritesheet name (as given in @spritesheet)
-using SpriteDefinitionList = std::vector<std::pair<String, Rectangle>>; // Sprite name and rectangle
+using SpriteDefinitionList = Vector<Pair<String, Rectangle>>; // Sprite name and rectangle
 
 
 /**

--- a/Include/RmlUi/Core/StyleSheet.h
+++ b/Include/RmlUi/Core/StyleSheet.h
@@ -51,8 +51,8 @@ struct KeyframeBlock {
 	PropertyDictionary properties;
 };
 struct Keyframes {
-	std::vector<PropertyId> property_ids;
-	std::vector<KeyframeBlock> blocks;
+	Vector<PropertyId> property_ids;
+	Vector<KeyframeBlock> blocks;
 };
 using KeyframesMap = UnorderedMap<String, Keyframes>;
 
@@ -73,7 +73,7 @@ using DecoratorSpecificationMap = UnorderedMap<String, DecoratorSpecification>;
 class RMLUICORE_API StyleSheet : public NonCopyMoveable
 {
 public:
-	typedef std::vector< StyleSheetNode* > NodeList;
+	typedef Vector< StyleSheetNode* > NodeList;
 	typedef UnorderedMap< size_t, NodeList > NodeIndex;
 
 	StyleSheet();

--- a/Include/RmlUi/Core/Texture.h
+++ b/Include/RmlUi/Core/Texture.h
@@ -31,7 +31,6 @@
 
 #include "Header.h"
 #include "Types.h"
-#include <functional>
 
 namespace Rml {
 
@@ -45,7 +44,7 @@ class RenderInterface;
 	/// @param[out] dimensions The width and height of the generated texture.
 	/// @return True on success.
 */
-using TextureCallback = std::function<bool(const String& name, UniquePtr<const byte[]>& data, Vector2i& dimensions)>;
+using TextureCallback = Function<bool(const String& name, UniquePtr<const byte[]>& data, Vector2i& dimensions)>;
 
 
 /**

--- a/Include/RmlUi/Core/Traits.h
+++ b/Include/RmlUi/Core/Traits.h
@@ -30,6 +30,7 @@
 #define RMLUI_CORE_TRAITS_H
 
 #include "Header.h"
+#include "../Config/Config.h"
 #include <type_traits>
 
 namespace Rml {
@@ -155,7 +156,6 @@ const char* rmlui_type_name(const T& var)
 	return typeid(var).name();
 }
 
-#endif
+#endif	// RMLUI_USE_CUSTOM_RTTI
 
-
-#endif
+#endif	// RMLUI_CORE_TRAITS_H

--- a/Include/RmlUi/Core/Traits.h
+++ b/Include/RmlUi/Core/Traits.h
@@ -62,7 +62,7 @@ protected:
 };
 
 template<typename T>
-class RMLUICORE_API Releaser final : public ReleaserBase {
+class RMLUICORE_API Releaser : public ReleaserBase {
 public:
 	void operator()(T* target) const {
 		static_assert(std::is_base_of<Releasable, T>::value, "Rml::Releaser can only operate with classes derived from ::Rml::Releasable.");

--- a/Include/RmlUi/Core/Transform.h
+++ b/Include/RmlUi/Core/Transform.h
@@ -52,7 +52,7 @@ class Property;
 class RMLUICORE_API Transform
 {
 public:
-	using PrimitiveList = std::vector< TransformPrimitive >;
+	using PrimitiveList = Vector< TransformPrimitive >;
 
 	/// Default constructor, initializes an identity transform
 	Transform();

--- a/Include/RmlUi/Core/TransformPrimitive.h
+++ b/Include/RmlUi/Core/TransformPrimitive.h
@@ -32,7 +32,6 @@
 #include "Header.h"
 #include "Types.h"
 #include "Property.h"
-#include <array>
 
 namespace Rml {
 namespace Transforms {
@@ -49,25 +48,25 @@ struct RMLUICORE_API NumericValue {
 template< size_t N >
 struct RMLUICORE_API ResolvedPrimitive
 {
-	std::array<float, N> values;
+	Array<float, N> values;
 
 protected:
 	ResolvedPrimitive(const float* values) noexcept;
 	ResolvedPrimitive(const NumericValue* values) noexcept;
-	ResolvedPrimitive(const NumericValue* values, std::array<Property::Unit, N> base_units) noexcept;
-	ResolvedPrimitive(std::array<NumericValue, N> values, std::array<Property::Unit, N> base_units) noexcept;
-	ResolvedPrimitive(std::array<float, N> values) noexcept;
+	ResolvedPrimitive(const NumericValue* values, Array<Property::Unit, N> base_units) noexcept;
+	ResolvedPrimitive(Array<NumericValue, N> values, Array<Property::Unit, N> base_units) noexcept;
+	ResolvedPrimitive(Array<float, N> values) noexcept;
 };
 
 // An unresolved primitive may have values that depend on the final layout of a given element, such as its width.
 template< size_t N >
-struct RMLUICORE_API UnresolvedPrimitive
+struct UnresolvedPrimitive
 {
-	std::array<NumericValue, N> values;
+	Array<NumericValue, N> values;
 
 protected:
 	UnresolvedPrimitive(const NumericValue* values) noexcept;
-	UnresolvedPrimitive(std::array<NumericValue, N> values) noexcept;
+	UnresolvedPrimitive(Array<NumericValue, N> values) noexcept;
 };
 
 

--- a/Include/RmlUi/Core/Tween.h
+++ b/Include/RmlUi/Core/Tween.h
@@ -28,12 +28,10 @@
 #ifndef RMLUI_CORE_TWEEN_H
 #define RMLUI_CORE_TWEEN_H
 
-#include <string>
+#include "Types.h"
 #include "Header.h"
 
 namespace Rml {
-
-using String = std::string;
 
 class RMLUICORE_API Tween {
 public:

--- a/Include/RmlUi/Core/Types.h
+++ b/Include/RmlUi/Core/Types.h
@@ -29,16 +29,12 @@
 #ifndef RMLUI_CORE_TYPES_H
 #define RMLUI_CORE_TYPES_H
 
+#include "../Config/Config.h"
+
 #include <cstdlib>
 #include <memory>
 
 #include "Traits.h"
-
-#ifdef RMLUI_USER_CONFIG_FILE
-#include RMLUI_USER_CONFIG_FILE
-#else
-#include "../UserConfig.h"
-#endif
 
 namespace Rml {
 

--- a/Include/RmlUi/Core/Types.h
+++ b/Include/RmlUi/Core/Types.h
@@ -34,8 +34,8 @@
 
 #include "Traits.h"
 
-#ifdef RML_USER_CONFIG_FILE
-#include RML_USER_CONFIG_FILE
+#ifdef RMLUI_USER_CONFIG_FILE
+#include RMLUI_USER_CONFIG_FILE
 #else
 #include "../UserConfig.h"
 #endif

--- a/Include/RmlUi/Core/Types.h
+++ b/Include/RmlUi/Core/Types.h
@@ -29,22 +29,15 @@
 #ifndef RMLUI_CORE_TYPES_H
 #define RMLUI_CORE_TYPES_H
 
-#include <string>
 #include <cstdlib>
 #include <memory>
-#include <utility>
-#include <vector>
 
 #include "Traits.h"
 
-#ifdef RMLUI_NO_THIRDPARTY_CONTAINERS
-#include <set>
-#include <unordered_set>
-#include <unordered_map>
+#ifdef RML_USER_CONFIG_FILE
+#include RML_USER_CONFIG_FILE
 #else
-#include "Containers/chobo/flat_map.hpp"
-#include "Containers/chobo/flat_set.hpp"
-#include "Containers/robin_hood.h"
+#include "../UserConfig.h"
 #endif
 
 namespace Rml {
@@ -58,7 +51,6 @@ using std::size_t;
 enum class Character : char32_t { Null, Replacement = 0xfffd };
 
 }
-
 
 #include "Colour.h"
 #include "Vector2.h"
@@ -80,8 +72,7 @@ using Vector4i = Vector4< int >;
 using Vector4f = Vector4< float >;
 using ColumnMajorMatrix4f = Matrix4< float, ColumnMajorStorage< float > >;
 using RowMajorMatrix4f = Matrix4< float, RowMajorStorage< float > >;
-using Matrix4f = ColumnMajorMatrix4f;
-
+using Matrix4f = RMLUI_MATRIX4_TYPE;
 
 // Common classes
 class Element;
@@ -111,56 +102,15 @@ using DecoratorDataHandle = uintptr_t;
 using FontFaceHandle = uintptr_t;
 using FontEffectsHandle = uintptr_t;
 
-// Strings
-using String = std::string;
-using StringList = std::vector< String >;
-using U16String = std::u16string;
-
-// Smart pointer types
-template<typename T>
-using UniquePtr = std::unique_ptr<T>;
-template<typename T>
-using UniqueReleaserPtr = std::unique_ptr<T, Releaser<T>>;
-template<typename T>
-using SharedPtr = std::shared_ptr<T>;
-template<typename T>
-using WeakPtr = std::weak_ptr<T>;
-
 using ElementPtr = UniqueReleaserPtr<Element>;
 using ContextPtr = UniqueReleaserPtr<Context>;
 using EventPtr = UniqueReleaserPtr<Event>;
 
-// Containers
-#ifdef RMLUI_NO_THIRDPARTY_CONTAINERS
-template <typename Key, typename Value>
-using UnorderedMap = std::unordered_map< Key, Value >;
-template <typename Key, typename Value>
-using SmallUnorderedMap = UnorderedMap< Key, Value >;
-template <typename T>
-using UnorderedSet = std::unordered_set< T >;
-template <typename T>
-using SmallUnorderedSet = std::unordered_set< T >;
-template <typename T>
-using SmallOrderedSet = std::set< T >;
-#else
-template < typename Key, typename Value>
-using UnorderedMap = robin_hood::unordered_flat_map< Key, Value >;
-template <typename Key, typename Value>
-using SmallUnorderedMap = chobo::flat_map< Key, Value >;
-template <typename T>
-using UnorderedSet = robin_hood::unordered_flat_set< T >;
-template <typename T>
-using SmallUnorderedSet = chobo::flat_set< T >;
-template <typename T>
-using SmallOrderedSet = chobo::flat_set< T >;
-#endif
-
-
 // Container types for common classes
-using ElementList = std::vector< Element* >;
-using OwnedElementList = std::vector< ElementPtr >;
-using VariantList = std::vector< Variant >;
-using ElementAnimationList = std::vector< ElementAnimation >;
+using ElementList = Vector< Element* >;
+using OwnedElementList = Vector< ElementPtr >;
+using VariantList = Vector< Variant >;
+using ElementAnimationList = Vector< ElementAnimation >;
 
 using PseudoClassList = SmallUnorderedSet< String >;
 using AttributeNameList = SmallUnorderedSet< String >;
@@ -170,9 +120,9 @@ using Dictionary = SmallUnorderedMap< String, Variant >;
 using ElementAttributes = Dictionary;
 using XMLAttributes = Dictionary;
 
-using AnimationList = std::vector<Animation>;
-using DecoratorList = std::vector<SharedPtr<const Decorator>>;
-using FontEffectList = std::vector<SharedPtr<const FontEffect>>;
+using AnimationList = Vector<Animation>;
+using DecoratorList = Vector<SharedPtr<const Decorator>>;
+using FontEffectList = Vector<SharedPtr<const FontEffect>>;
 
 struct Decorators {
 	DecoratorList list;
@@ -201,11 +151,11 @@ namespace std {
 // Hash specialization for enum class types (required on some older compilers)
 template <> struct hash<::Rml::PropertyId> {
 	using utype = typename ::std::underlying_type<::Rml::PropertyId>::type;
-	size_t operator() (const ::Rml::PropertyId& t) const { ::std::hash<utype> h; return h(static_cast<utype>(t)); }
+	size_t operator() (const ::Rml::PropertyId& t) const { ::Rml::Hash<utype> h; return h(static_cast<utype>(t)); }
 };
 template <> struct hash<::Rml::Character> {
-    using utype = typename ::std::underlying_type<::Rml::Character>::type;
-    size_t operator() (const ::Rml::Character& t) const { ::std::hash<utype> h; return h(static_cast<utype>(t)); }
+	using utype = typename ::std::underlying_type<::Rml::Character>::type;
+	size_t operator() (const ::Rml::Character& t) const { ::Rml::Hash<utype> h; return h(static_cast<utype>(t)); }
 };
 template <> struct hash<::Rml::FamilyId> {
 	using utype = typename ::std::underlying_type<::Rml::FamilyId>::type;

--- a/Include/RmlUi/Core/Vector2.h
+++ b/Include/RmlUi/Core/Vector2.h
@@ -147,6 +147,10 @@ class Vector2
 		// The components of the vector.
 		Type x;
 		Type y;
+
+#ifdef RMLUI_VECTOR2_USER_EXTRA
+		RMLUI_VECTOR2_USER_EXTRA
+#endif
 };
 
 } // namespace Rml

--- a/Include/RmlUi/Core/Vector3.h
+++ b/Include/RmlUi/Core/Vector3.h
@@ -133,6 +133,10 @@ class Vector3
 		Type x;
 		Type y;
 		Type z;
+
+#ifdef RMLUI_VECTOR3_USER_EXTRA
+		RMLUI_VECTOR3_USER_EXTRA
+#endif
 };
 
 } // namespace Rml

--- a/Include/RmlUi/Core/Vector4.h
+++ b/Include/RmlUi/Core/Vector4.h
@@ -138,6 +138,10 @@ class Vector4
 		Type y;
 		Type z;
 		Type w;
+
+#ifdef RMLUI_VECTOR4_USER_EXTRA
+		RMLUI_VECTOR4_USER_EXTRA
+#endif
 };
 
 } // namespace Rml

--- a/Include/RmlUi/Core/XMLParser.h
+++ b/Include/RmlUi/Core/XMLParser.h
@@ -109,7 +109,7 @@ private:
 	XMLNodeHandler* active_handler;
 
 	// The parser stack.
-	using ParserStack = std::stack< ParseFrame >;
+	using ParserStack = Stack< ParseFrame >;
 	ParserStack stack;
 };
 

--- a/Include/RmlUi/UserConfig.h
+++ b/Include/RmlUi/UserConfig.h
@@ -133,18 +133,56 @@ inline UniquePtr<T> MakeUnique(Args... args) { return std::make_unique<T, Args..
 
 }
 
-// Following defines should be used for insering custom type cast operators for conversion of
-// RmlUi types to user types.
+// Following defines should be used for insering custom type cast operators for conversion of RmlUi types
+// to user types. RmlUi uses template math types, therefore conversion operators to non-templated types
+// should be done using SFINAE as in example below.
 
-// Extra code to be inserted into RmlUi::Color<> class body.
-// #define RMLUI_COLOUR_USER_EXTRA operator MyColorType() const { return MyColorType(red, green, blue, alpha); }
+// Extra code to be inserted into RmlUi::Color<> class body. Node: be mindful of colorspaces used by different
+// color types. RmlUi assumes that float colors are interpreted in linear colorspace while byte colors are 
+// interpreted as SRGB.
+// #define RMLUI_COLOUR_USER_EXTRA                                                                         \
+//     template<typename U = ColourType, typename std::enable_if_t<std::is_same_v<U, byte>>* = nullptr>    \
+//     operator MyColor() const { return MyColor(                                                          \
+//         (float)red / 256.0f, (float)green / 255.0f, (float)blue / 255.0f, (float)alpha / 255.0f); }     \
+//     template<typename U = ColourType, typename std::enable_if_t<std::is_same_v<U, float>>* = nullptr>   \
+//     operator MyColor() const { return MyColor(red, green, blue, alpha); }                               \
+
 // Extra code to be inserted into RmlUi::Vector2<> class body.
-// #define RMLUI_VECTOR2_USER_EXTRA operator MyVector2() const { return MyVector2(x, y); }
+// #define RMLUI_VECTOR2_USER_EXTRA                                                                        \
+//     template<typename U = Type, typename std::enable_if_t<std::is_same_v<U, int>>* = nullptr>           \
+//     operator typename MyIntVector2() const { return MyIntVector2(x, y); }                               \
+//     template<typename U = Type, typename std::enable_if_t<std::is_same_v<U, float>>* = nullptr>         \
+//     operator MyVector2() const { return MyVector2(x, y); }                                              \
+//     template<typename U = Type, typename std::enable_if_t<std::is_same_v<U, int>>* = nullptr>           \
+//     Vector2(MyIntVector2 value) : Vector2(value.x_, value.y_) { }                                       \
+//     template<typename U = Type, typename std::enable_if_t<std::is_same_v<U, float>>* = nullptr>         \
+//     Vector2(MyVector2 value) : Vector2(value.x_, value.y_) { }                                          \
+
 // Extra code to be inserted into RmlUi::Vector3<> class body.
-// #define RMLUI_VECTOR3_USER_EXTRA operator MyVector3() const { return MyVector3(x, y, z); }
+// #define RMLUI_VECTOR3_USER_EXTRA                                                                        \
+//     template<typename U = Type, typename std::enable_if_t<std::is_same_v<U, int>>* = nullptr>           \
+//     operator typename MyIntVector3() const { return MyIntVector3(x, y, z); }                            \
+//     template<typename U = Type, typename std::enable_if_t<std::is_same_v<U, float>>* = nullptr>         \
+//     operator MyVector3() const { return MyVector3(x, y, z); }                                           \
+//     template<typename U = Type, typename std::enable_if_t<std::is_same_v<U, int>>* = nullptr>           \
+//     Vector3(MyIntVector3 value) : Vector3(value.x_, value.y_, value.z_) { }                             \
+//     template<typename U = Type, typename std::enable_if_t<std::is_same_v<U, float>>* = nullptr>         \
+//     Vector3(MyVector3 value) : Vector3(value.x_, value.y_, value.z_) { }                                \
+
 // Extra code to be inserted into RmlUi::Vector4<> class body.
-// #define RMLUI_VECTOR4_USER_EXTRA operator MyVector4() const { return MyVector4(x, y, z, w); }
+// #define RMLUI_VECTOR4_USER_EXTRA                                                                        \
+//     template<typename U = Type, typename std::enable_if_t<std::is_same_v<U, int>>* = nullptr>           \
+//     operator typename MyIntVector4() const { return MyIntVector4(x, y, z, w); }                         \
+//     template<typename U = Type, typename std::enable_if_t<std::is_same_v<U, float>>* = nullptr>         \
+//     operator MyVector4() const { return MyVector4(x, y, z, w); }                                        \
+//     template<typename U = Type, typename std::enable_if_t<std::is_same_v<U, int>>* = nullptr>           \
+//     Vector4(MyIntVector4 value) : Vector4(value.x_, value.y_, value.z_, value.w_) { }                   \
+//     template<typename U = Type, typename std::enable_if_t<std::is_same_v<U, float>>* = nullptr>         \
+//     Vector4(MyVector4 value) : Vector4(value.x_, value.y_, value.z_, value.w_) { }                      \
+
 // Extra code to be inserted into RmlUi::Matrix4<> class body.
 // #define RMLUI_MATRIX4_USER_EXTRA operator MyMatrix4() const { return MyMatrix4(data()); }
+
+
 
 #endif  // RMLUI_USER_CONFIG_H

--- a/Include/RmlUi/UserConfig.h
+++ b/Include/RmlUi/UserConfig.h
@@ -133,11 +133,11 @@ inline UniquePtr<T> MakeUnique(Args... args) { return std::make_unique<T, Args..
 
 }
 
-// Following defines should be used for insering custom type cast operators for conversion of RmlUi types
+// The following defines should be used for inserting custom type cast operators for conversion of RmlUi types
 // to user types. RmlUi uses template math types, therefore conversion operators to non-templated types
 // should be done using SFINAE as in example below.
 
-// Extra code to be inserted into RmlUi::Color<> class body. Node: be mindful of colorspaces used by different
+// Extra code to be inserted into RmlUi::Color<> class body. Note: be mindful of colorspaces used by different
 // color types. RmlUi assumes that float colors are interpreted in linear colorspace while byte colors are 
 // interpreted as SRGB.
 // #define RMLUI_COLOUR_USER_EXTRA                                                                         \

--- a/Include/RmlUi/UserConfig.h
+++ b/Include/RmlUi/UserConfig.h
@@ -1,0 +1,150 @@
+/*
+ * This source file is part of RmlUi, the HTML/CSS Interface Middleware
+ *
+ * For the latest information, see http://github.com/mikke89/RmlUi
+ *
+ * Copyright (c) 2008-2010 CodePoint Ltd, Shift Technology Ltd
+ * Copyright (c) 2019 The RmlUi Team, and contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+#ifndef RMLUI_USER_CONFIG_H
+#define RMLUI_USER_CONFIG_H
+
+/*
+ * This file provides means to configure various types used across RmlUi. It is possible to override container types
+ * with your own, provided they are compatible with STL, or customize STL containers, for example use a custom
+ * allocator. This file may be edited directly, or can be copied to alternate location, modified, and included by
+ * setting CMake option USER_CONFIG_FILE (RML_USER_CONFIG_FILE preprocessor define) to path of that file.
+ */
+
+#include <utility>
+#include <vector>
+#include <string>
+#include <stack>
+#include <list>
+#include <functional>
+#include <queue>
+#include <array>
+#include <unordered_map>
+
+#ifdef RMLUI_NO_THIRDPARTY_CONTAINERS
+#include <set>
+#include <unordered_set>
+#else
+#include "Core/Containers/chobo/flat_map.hpp"
+#include "Core/Containers/chobo/flat_set.hpp"
+#include "Core/Containers/robin_hood.h"
+#endif	// RMLUI_NO_THIRDPARTY_CONTAINERS
+
+namespace Rml {
+
+// Default matrix type to be used. This alias may be set to ColumnMajorMatrix4f or RowMajorMatrix4f. This alias can not
+// be set here because matrix types are defined after this include in Core/Types.h.
+#ifdef RMLUI_MATRIX_ROW_MAJOR
+#define RMLUI_MATRIX4_TYPE RowMajorMatrix4f
+#else
+#define RMLUI_MATRIX4_TYPE ColumnMajorMatrix4f
+#endif
+
+// Containers types.
+template<typename T>
+using Vector = std::vector<T>;
+template<typename T, size_t N = 1>
+using Array = std::array<T, N>;
+template<typename T>
+using Stack = std::stack<T>;
+template<typename T>
+using List = std::list<T>;
+template<typename T>
+using Queue = std::queue<T>;
+template<typename T1, typename T2>
+using Pair = std::pair<T1, T2>;
+template <typename Key, typename Value>
+using UnorderedMultimap = std::unordered_multimap< Key, Value >;
+#ifdef RMLUI_NO_THIRDPARTY_CONTAINERS
+template <typename Key, typename Value>
+using UnorderedMap = std::unordered_map< Key, Value >;
+template <typename Key, typename Value>
+using SmallUnorderedMap = UnorderedMap< Key, Value >;
+template <typename T>
+using UnorderedSet = std::unordered_set< T >;
+template <typename T>
+using SmallUnorderedSet = std::unordered_set< T >;
+template <typename T>
+using SmallOrderedSet = std::set< T >;
+#else
+template < typename Key, typename Value>
+using UnorderedMap = robin_hood::unordered_flat_map< Key, Value >;
+template <typename Key, typename Value>
+using SmallUnorderedMap = chobo::flat_map< Key, Value >;
+template <typename T>
+using UnorderedSet = robin_hood::unordered_flat_set< T >;
+template <typename T>
+using SmallUnorderedSet = chobo::flat_set< T >;
+template <typename T>
+using SmallOrderedSet = chobo::flat_set< T >;
+#endif	// RMLUI_NO_THIRDPARTY_CONTAINERS
+template<typename Iterator>
+inline std::move_iterator<Iterator> MakeMoveIterator(Iterator it) { return std::make_move_iterator(it); }
+
+// Utilities.
+template <typename T>
+using Hash = std::hash<T>;
+template<typename T>
+using Function = std::function<T>;
+
+// Strings.
+using String = std::string;
+using StringList = Vector< String >;
+using U16String = std::u16string;
+
+// Smart pointer types.
+template<typename T>
+using UniquePtr = std::unique_ptr<T>;
+template<typename T>
+using UniqueReleaserPtr = std::unique_ptr<T, Releaser<T>>;
+template<typename T>
+using SharedPtr = std::shared_ptr<T>;
+template<typename T>
+using WeakPtr = std::weak_ptr<T>;
+template<typename T, typename... Args>
+inline SharedPtr<T> MakeShared(Args... args) { return std::make_shared<T, Args...>(std::forward<Args>(args)...); }
+template<typename T, typename... Args>
+inline UniquePtr<T> MakeUnique(Args... args) { return std::make_unique<T, Args...>(std::forward<Args>(args)...); }
+
+}
+
+// Following defines should be used for insering custom type cast operators for conversion of
+// RmlUi types to user types.
+
+// Extra code to be inserted into RmlUi::Color<> class body.
+// #define RMLUI_COLOUR_USER_EXTRA operator MyColorType() const { return MyColorType(red, green, blue, alpha); }
+// Extra code to be inserted into RmlUi::Vector2<> class body.
+// #define RMLUI_VECTOR2_USER_EXTRA operator MyVector2() const { return MyVector2(x, y); }
+// Extra code to be inserted into RmlUi::Vector3<> class body.
+// #define RMLUI_VECTOR3_USER_EXTRA operator MyVector3() const { return MyVector3(x, y, z); }
+// Extra code to be inserted into RmlUi::Vector4<> class body.
+// #define RMLUI_VECTOR4_USER_EXTRA operator MyVector4() const { return MyVector4(x, y, z, w); }
+// Extra code to be inserted into RmlUi::Matrix4<> class body.
+// #define RMLUI_MATRIX4_USER_EXTRA operator MyMatrix4() const { return MyMatrix4(data()); }
+
+#endif  // RMLUI_USER_CONFIG_H

--- a/Samples/basic/bitmapfont/src/FontEngineBitmap.cpp
+++ b/Samples/basic/bitmapfont/src/FontEngineBitmap.cpp
@@ -33,7 +33,7 @@
 
 namespace FontProviderBitmap
 {
-	static std::vector<std::unique_ptr<FontFaceBitmap>> fonts;
+	static Rml::Vector<Rml::UniquePtr<FontFaceBitmap>> fonts;
 
 
 	void Initialise()
@@ -48,7 +48,7 @@ namespace FontProviderBitmap
 	bool LoadFontFace(const String& file_name)
 	{
 		// Load the xml meta file into memory
-		std::unique_ptr<byte[]> data;
+		Rml::UniquePtr<byte[]> data;
 		size_t length = 0;
 
 		{
@@ -73,7 +73,7 @@ namespace FontProviderBitmap
 		FontParserBitmap parser;
 
 		{
-			auto stream = std::make_unique<Rml::StreamMemory>(data.get(), length);
+			auto stream = Rml::MakeUnique<Rml::StreamMemory>(data.get(), length);
 			stream->SetSourceURL(file_name);
 
 			parser.Parse(stream.get());
@@ -91,7 +91,7 @@ namespace FontProviderBitmap
 
 		// Construct and add the font face
 		fonts.push_back(
-			std::make_unique<FontFaceBitmap>( 
+			Rml::MakeUnique<FontFaceBitmap>( 
 				parser.family, parser.style, parser.weight, parser.metrics, texture, parser.texture_dimensions, std::move(parser.glyphs), std::move(parser.kerning)
 		));
 

--- a/Samples/basic/databinding/src/main.cpp
+++ b/Samples/basic/databinding/src/main.cpp
@@ -75,9 +75,9 @@ namespace EventsExample {
 		Rml::String mouse_detector = "Mouse-move <em>Detector</em>.";
 		int rating = 99;
 
-		std::vector<float> list = { 1, 2, 3, 4, 5 };
+		Rml::Vector<float> list = { 1, 2, 3, 4, 5 };
 
-		std::vector<Rml::Vector2f> positions;
+		Rml::Vector<Rml::Vector2f> positions;
 
 		void AddMousePos(Rml::DataModelHandle model, Rml::Event& ev, const Rml::VariantList& /*arguments*/)
 		{
@@ -108,14 +108,14 @@ namespace EventsExample {
 			return false;
 
 		// Register all the types first
-		constructor.RegisterArray<std::vector<float>>();
+		constructor.RegisterArray<Rml::Vector<float>>();
 
 		if (auto vec2_handle = constructor.RegisterStruct<Vector2f>())
 		{
 			vec2_handle.RegisterMember("x", &Vector2f::x);
 			vec2_handle.RegisterMember("y", &Vector2f::y);
 		}
-		constructor.RegisterArray<std::vector<Vector2f>>();
+		constructor.RegisterArray<Rml::Vector<Vector2f>>();
 
 		// Bind the variables to the data model
 		constructor.Bind("hello_world", &my_data.hello_world);
@@ -169,7 +169,7 @@ namespace InvadersExample {
 		Rml::String name;
 		Rml::String sprite;
 		Rml::Colourb color{ 255, 255, 255 };
-		std::vector<int> damage;
+		Rml::Vector<int> damage;
 		float danger_rating = 50;
 
 		void GetColor(Rml::Variant& variant) {
@@ -190,7 +190,7 @@ namespace InvadersExample {
 
 		float incoming_invaders_rate = 10; // Per minute
 
-		std::vector<Invader> invaders = {
+		Rml::Vector<Invader> invaders = {
 			Invader{"Angry invader", "icon-invader", {255, 40, 30}, {3, 6, 7}, 80}
 		};
 
@@ -209,7 +209,7 @@ namespace InvadersExample {
 			return false;
 
 		// Since Invader::damage is an array type.
-		constructor.RegisterArray<std::vector<int>>();
+		constructor.RegisterArray<Rml::Vector<int>>();
 
 		// Structs are registered by adding all its members through the returned handle.
 		if (auto invader_handle = constructor.RegisterStruct<Invader>())
@@ -225,7 +225,7 @@ namespace InvadersExample {
 
 		// We can even have an Array of Structs, infinitely nested if we so desire.
 		// Make sure the underlying type (here Invader) is registered before the array.
-		constructor.RegisterArray<std::vector<Invader>>();
+		constructor.RegisterArray<Rml::Vector<Invader>>();
 
 		// Now we can bind the variables to the model.
 		constructor.Bind("incoming_invaders_rate", &invaders_data.incoming_invaders_rate);
@@ -424,7 +424,7 @@ int main(int RMLUI_UNUSED_PARAMETER(argc), char** RMLUI_UNUSED_PARAMETER(argv))
 	
 	Shell::LoadFonts("assets/");
 
-	auto demo_window = std::make_unique<DemoWindow>("Data binding", Rml::Vector2f(150, 50), context);
+	auto demo_window = Rml::MakeUnique<DemoWindow>("Data binding", Rml::Vector2f(150, 50), context);
 	demo_window->GetDocument()->AddEventListener(Rml::EventId::Keydown, demo_window.get());
 	demo_window->GetDocument()->AddEventListener(Rml::EventId::Keyup, demo_window.get());
 

--- a/Samples/basic/demo/src/main.cpp
+++ b/Samples/basic/demo/src/main.cpp
@@ -102,7 +102,7 @@ public:
 				Rml::StreamMemory stream((Rml::byte*)style_sheet_content.data(), style_sheet_content.size());
 				stream.SetSourceURL("sandbox://default_rcss");
 
-				rml_basic_style_sheet = std::make_shared<Rml::StyleSheet>();
+				rml_basic_style_sheet = MakeShared<Rml::StyleSheet>();
 				rml_basic_style_sheet->LoadStyleSheet(&stream);
 			}
 
@@ -224,7 +224,7 @@ public:
 	{
 		if (iframe && rml_basic_style_sheet)
 		{
-			auto style = std::make_shared<Rml::StyleSheet>();
+			auto style = Rml::MakeShared<Rml::StyleSheet>();
 			Rml::StreamMemory stream((const Rml::byte*)string.data(), string.size());
 			stream.SetSourceURL("sandbox://rcss");
 
@@ -256,7 +256,7 @@ private:
 
 Rml::Context* context = nullptr;
 ShellRenderInterfaceExtensions *shell_renderer;
-std::unique_ptr<DemoWindow> demo_window;
+Rml::UniquePtr<DemoWindow> demo_window;
 
 struct TweeningParameters {
 	Rml::Tween::Type type = Rml::Tween::Linear;
@@ -507,7 +507,7 @@ int main(int RMLUI_UNUSED_PARAMETER(argc), char** RMLUI_UNUSED_PARAMETER(argv))
 
 	Shell::LoadFonts("assets/");
 
-	demo_window = std::make_unique<DemoWindow>("Demo sample", Rml::Vector2f(150, 50), context);
+	demo_window = Rml::MakeUnique<DemoWindow>("Demo sample", Rml::Vector2f(150, 50), context);
 	demo_window->GetDocument()->AddEventListener(Rml::EventId::Keydown, demo_window.get());
 	demo_window->GetDocument()->AddEventListener(Rml::EventId::Keyup, demo_window.get());
 	demo_window->GetDocument()->AddEventListener(Rml::EventId::Animationend, demo_window.get());

--- a/Samples/basic/sdl2/src/RenderInterfaceSDL2.cpp
+++ b/Samples/basic/sdl2/src/RenderInterfaceSDL2.cpp
@@ -49,9 +49,9 @@ void RmlUiSDL2Renderer::RenderGeometry(Rml::Vertex* vertices, int num_vertices, 
     glPushMatrix();
     glTranslatef(translation.x, translation.y, 0);
  
-    std::vector<Rml::Vector2f> Positions(num_vertices);
-    std::vector<Rml::Colourb> Colors(num_vertices);
-    std::vector<Rml::Vector2f> TexCoords(num_vertices);
+    Rml::Vector<Rml::Vector2f> Positions(num_vertices);
+    Rml::Vector<Rml::Colourb> Colors(num_vertices);
+    Rml::Vector<Rml::Vector2f> TexCoords(num_vertices);
     float texw = 0.0f;
     float texh = 0.0f;
  

--- a/Samples/basic/treeview/src/FileSystem.cpp
+++ b/Samples/basic/treeview/src/FileSystem.cpp
@@ -117,7 +117,7 @@ struct FileSystemNode
 		}
 	}
 
-	typedef std::vector< FileSystemNode* > NodeList;
+	typedef Rml::Vector< FileSystemNode* > NodeList;
 
 	Rml::String id;
 	Rml::String name;

--- a/Samples/invaders/src/DecoratorInstancerDefender.cpp
+++ b/Samples/invaders/src/DecoratorInstancerDefender.cpp
@@ -43,7 +43,7 @@ DecoratorInstancerDefender::~DecoratorInstancerDefender()
 }
 
 // Instances a decorator given the property tag and attributes from the RCSS file.
-std::shared_ptr<Rml::Decorator> DecoratorInstancerDefender::InstanceDecorator(const Rml::String& /*name*/,
+Rml::SharedPtr<Rml::Decorator> DecoratorInstancerDefender::InstanceDecorator(const Rml::String& /*name*/,
 	const Rml::PropertyDictionary& properties, const Rml::DecoratorInstancerInterface& /*interface*/)
 {
 	const Rml::Property* image_source_property = properties.GetProperty(id_image_src);
@@ -52,7 +52,7 @@ std::shared_ptr<Rml::Decorator> DecoratorInstancerDefender::InstanceDecorator(co
 	if (auto & source = image_source_property->source)
 		source_path = source->path;
 
-	auto decorator = std::make_shared<DecoratorDefender>();
+	auto decorator = Rml::MakeShared<DecoratorDefender>();
 	if (decorator->Initialise(image_source, source_path))
 		return decorator;
 	

--- a/Samples/invaders/src/DecoratorInstancerDefender.h
+++ b/Samples/invaders/src/DecoratorInstancerDefender.h
@@ -45,7 +45,7 @@ public:
 	/// @param[in] name The type of decorator desired. For example, "background-decorator: simple;" is declared as type "simple".
 	/// @param[in] properties All RCSS properties associated with the decorator.
 	/// @return The decorator if it was instanced successful, nullptr if an error occured.
-	std::shared_ptr<Rml::Decorator> InstanceDecorator(const Rml::String& name, const Rml::PropertyDictionary& properties, const Rml::DecoratorInstancerInterface& interface) override;
+	Rml::SharedPtr<Rml::Decorator> InstanceDecorator(const Rml::String& name, const Rml::PropertyDictionary& properties, const Rml::DecoratorInstancerInterface& interface) override;
 
 private:
 	Rml::PropertyId id_image_src;

--- a/Samples/invaders/src/DecoratorInstancerStarfield.cpp
+++ b/Samples/invaders/src/DecoratorInstancerStarfield.cpp
@@ -47,7 +47,7 @@ DecoratorInstancerStarfield::~DecoratorInstancerStarfield()
 }
 
 // Instances a decorator given the property tag and attributes from the RCSS file.
-std::shared_ptr<Rml::Decorator> DecoratorInstancerStarfield::InstanceDecorator(const Rml::String& /*name*/,
+Rml::SharedPtr<Rml::Decorator> DecoratorInstancerStarfield::InstanceDecorator(const Rml::String& /*name*/,
 	const Rml::PropertyDictionary& properties, const Rml::DecoratorInstancerInterface& /*interface*/)
 {
 	int num_layers = Rml::Math::RealToInteger(properties.GetProperty(id_num_layers)->Get< float >());
@@ -58,7 +58,7 @@ std::shared_ptr<Rml::Decorator> DecoratorInstancerStarfield::InstanceDecorator(c
 	int top_density = Rml::Math::RealToInteger(properties.GetProperty(id_top_density)->Get< float >());
 	int bottom_density = Rml::Math::RealToInteger(properties.GetProperty(id_bottom_density)->Get< float >());
 
-	auto decorator = std::make_shared<DecoratorStarfield>();
+	auto decorator = Rml::MakeShared<DecoratorStarfield>();
 	if (decorator->Initialise(num_layers, top_colour, bottom_colour, top_speed, bottom_speed, top_density, bottom_density))
 		return decorator;
 

--- a/Samples/invaders/src/DecoratorInstancerStarfield.h
+++ b/Samples/invaders/src/DecoratorInstancerStarfield.h
@@ -46,7 +46,7 @@ public:
 	/// @param name The type of decorator desired. For example, "background-decorator: simple;" is declared as type "simple".
 	/// @param properties All RCSS properties associated with the decorator.
 	/// @return The decorator if it was instanced successful, nullptr if an error occured.
-	std::shared_ptr<Rml::Decorator> InstanceDecorator(const Rml::String& name, const Rml::PropertyDictionary& properties, const Rml::DecoratorInstancerInterface& interface) override;
+	Rml::SharedPtr<Rml::Decorator> InstanceDecorator(const Rml::String& name, const Rml::PropertyDictionary& properties, const Rml::DecoratorInstancerInterface& interface) override;
 
 private:
 	Rml::PropertyId id_num_layers, id_top_colour, id_bottom_colour, id_top_speed, id_bottom_speed, id_top_density, id_bottom_density;

--- a/Samples/luainvaders/src/DecoratorInstancerDefender.cpp
+++ b/Samples/luainvaders/src/DecoratorInstancerDefender.cpp
@@ -43,7 +43,7 @@ DecoratorInstancerDefender::~DecoratorInstancerDefender()
 }
 
 // Instances a decorator given the property tag and attributes from the RCSS file.
-std::shared_ptr<Rml::Decorator> DecoratorInstancerDefender::InstanceDecorator(const Rml::String& /*name*/,
+Rml::SharedPtr<Rml::Decorator> DecoratorInstancerDefender::InstanceDecorator(const Rml::String& /*name*/,
 	const Rml::PropertyDictionary& properties, const Rml::DecoratorInstancerInterface& /*interface*/)
 {
 	const Rml::Property* image_source_property = properties.GetProperty(id_image_src);
@@ -52,7 +52,7 @@ std::shared_ptr<Rml::Decorator> DecoratorInstancerDefender::InstanceDecorator(co
 	if (auto & source = image_source_property->source)
 		source_path = source->path;
 
-	auto decorator = std::make_shared<DecoratorDefender>();
+	auto decorator = Rml::MakeShared<DecoratorDefender>();
 	if (decorator->Initialise(image_source, source_path))
 		return decorator;
 

--- a/Samples/luainvaders/src/DecoratorInstancerDefender.h
+++ b/Samples/luainvaders/src/DecoratorInstancerDefender.h
@@ -45,7 +45,7 @@ public:
 	/// @param[in] name The type of decorator desired. For example, "background-decorator: simple;" is declared as type "simple".
 	/// @param[in] properties All RCSS properties associated with the decorator.
 	/// @return The decorator if it was instanced successful, nullptr if an error occured.
-	std::shared_ptr<Rml::Decorator> InstanceDecorator(const Rml::String& name, const Rml::PropertyDictionary& properties, const Rml::DecoratorInstancerInterface& interface) override;
+	Rml::SharedPtr<Rml::Decorator> InstanceDecorator(const Rml::String& name, const Rml::PropertyDictionary& properties, const Rml::DecoratorInstancerInterface& interface) override;
 
 private:
 	Rml::PropertyId id_image_src;

--- a/Samples/luainvaders/src/DecoratorInstancerStarfield.cpp
+++ b/Samples/luainvaders/src/DecoratorInstancerStarfield.cpp
@@ -47,7 +47,7 @@ DecoratorInstancerStarfield::~DecoratorInstancerStarfield()
 }
 
 // Instances a decorator given the property tag and attributes from the RCSS file.
-std::shared_ptr<Rml::Decorator> DecoratorInstancerStarfield::InstanceDecorator(const Rml::String& /*name*/,
+Rml::SharedPtr<Rml::Decorator> DecoratorInstancerStarfield::InstanceDecorator(const Rml::String& /*name*/,
 	const Rml::PropertyDictionary& properties, const Rml::DecoratorInstancerInterface& /*interface*/)
 {
 	int num_layers = Rml::Math::RealToInteger(properties.GetProperty(id_num_layers)->Get< float >());
@@ -58,7 +58,7 @@ std::shared_ptr<Rml::Decorator> DecoratorInstancerStarfield::InstanceDecorator(c
 	int top_density = Rml::Math::RealToInteger(properties.GetProperty(id_top_density)->Get< float >());
 	int bottom_density = Rml::Math::RealToInteger(properties.GetProperty(id_bottom_density)->Get< float >());
 
-	auto decorator = std::make_shared<DecoratorStarfield>();
+	auto decorator = Rml::MakeShared<DecoratorStarfield>();
 	if (decorator->Initialise(num_layers, top_colour, bottom_colour, top_speed, bottom_speed, top_density, bottom_density))
 		return decorator;
 

--- a/Samples/luainvaders/src/DecoratorInstancerStarfield.h
+++ b/Samples/luainvaders/src/DecoratorInstancerStarfield.h
@@ -46,7 +46,7 @@ public:
 	/// @param name The type of decorator desired. For example, "background-decorator: simple;" is declared as type "simple".
 	/// @param properties All RCSS properties associated with the decorator.
 	/// @return The decorator if it was instanced successful, nullptr if an error occured.
-	std::shared_ptr<Rml::Decorator> InstanceDecorator(const Rml::String& name, const Rml::PropertyDictionary& properties, const Rml::DecoratorInstancerInterface& interface) override;
+	Rml::SharedPtr<Rml::Decorator> InstanceDecorator(const Rml::String& name, const Rml::PropertyDictionary& properties, const Rml::DecoratorInstancerInterface& interface) override;
 
 private:
 	Rml::PropertyId id_num_layers, id_top_colour, id_bottom_colour, id_top_speed, id_bottom_speed, id_top_density, id_bottom_density;

--- a/Samples/shell/src/macosx/ShellMacOSX.cpp
+++ b/Samples/shell/src/macosx/ShellMacOSX.cpp
@@ -57,7 +57,7 @@ static WindowRef window;
 static timeval start_time;
 static Rml::String clipboard_text;
 
-static std::unique_ptr<ShellFileInterface> file_interface;
+static Rml::UniquePtr<ShellFileInterface> file_interface;
 
 static void IdleTimerCallback(EventLoopTimerRef timer, EventLoopIdleTimerMessage inState, void* p);
 static OSStatus EventHandler(EventHandlerCallRef next_handler, EventRef event, void* p);
@@ -70,7 +70,7 @@ bool Shell::Initialise()
 
 	Rml::String root = FindSamplesRoot();
 
-	file_interface = std::make_unique<ShellFileInterface>(root);
+	file_interface = Rml::MakeUnique<ShellFileInterface>(root);
 	Rml::SetFileInterface(file_interface.get());
 
 	return true;

--- a/Samples/shell/src/win32/ShellWin32.cpp
+++ b/Samples/shell/src/win32/ShellWin32.cpp
@@ -46,7 +46,7 @@ static HINSTANCE instance_handle = nullptr;
 static double time_frequency;
 static LARGE_INTEGER time_startup;
 
-static std::unique_ptr<ShellFileInterface> file_interface;
+static Rml::UniquePtr<ShellFileInterface> file_interface;
 
 static HCURSOR cursor_default = nullptr;
 static HCURSOR cursor_move = nullptr;
@@ -80,7 +80,7 @@ bool Shell::Initialise()
 	Rml::String root = FindSamplesRoot();
 	bool result = !root.empty();
 	
-	file_interface = std::make_unique<ShellFileInterface>(root);
+	file_interface = Rml::MakeUnique<ShellFileInterface>(root);
 	Rml::SetFileInterface(file_interface.get());
 
 	return result;

--- a/Samples/shell/src/x11/ShellX11.cpp
+++ b/Samples/shell/src/x11/ShellX11.cpp
@@ -50,7 +50,7 @@ static int screen = -1;
 static timeval start_time;
 static Rml::String clipboard_text;
 
-static std::unique_ptr<ShellFileInterface> file_interface;
+static Rml::UniquePtr<ShellFileInterface> file_interface;
 
 static Cursor cursor_default = 0;
 static Cursor cursor_move = 0;
@@ -74,7 +74,7 @@ bool Shell::Initialise()
 	Rml::String root = FindSamplesRoot();
 	bool result = !root.empty();
 
-	file_interface = std::make_unique<ShellFileInterface>(root);
+	file_interface = Rml::MakeUnique<ShellFileInterface>(root);
 	Rml::SetFileInterface(file_interface.get());
 
 	return result;

--- a/Samples/tutorial/datagrid/src/DecoratorInstancerDefender.cpp
+++ b/Samples/tutorial/datagrid/src/DecoratorInstancerDefender.cpp
@@ -26,7 +26,7 @@ DecoratorInstancerDefender::~DecoratorInstancerDefender()
 }
 
 // Instances a decorator given the property tag and attributes from the RCSS file.
-std::shared_ptr<Rml::Decorator> DecoratorInstancerDefender::InstanceDecorator(const Rml::String& /*name*/,
+Rml::SharedPtr<Rml::Decorator> DecoratorInstancerDefender::InstanceDecorator(const Rml::String& /*name*/,
 	const Rml::PropertyDictionary& properties, const Rml::DecoratorInstancerInterface& /*interface*/)
 {
 	const Rml::Property* image_source_property = properties.GetProperty(id_image_src);
@@ -35,7 +35,7 @@ std::shared_ptr<Rml::Decorator> DecoratorInstancerDefender::InstanceDecorator(co
 	if (auto & source = image_source_property->source)
 		source_path = source->path;
 
-	auto decorator = std::make_shared<DecoratorDefender>();
+	auto decorator = Rml::MakeShared<DecoratorDefender>();
 	if (decorator->Initialise(image_source, source_path))
 		return decorator;
 

--- a/Samples/tutorial/datagrid/src/DecoratorInstancerDefender.h
+++ b/Samples/tutorial/datagrid/src/DecoratorInstancerDefender.h
@@ -30,7 +30,7 @@ public:
 	/// @param[in] properties All RCSS properties associated with the decorator.
 	/// @param[in] interface An interface for querying the active style sheet.
 	/// @return A shared_ptr to the decorator if it was instanced successfully.
-	std::shared_ptr<Rml::Decorator> InstanceDecorator(const Rml::String& name, const Rml::PropertyDictionary& properties, const Rml::DecoratorInstancerInterface& interface) override;
+	Rml::SharedPtr<Rml::Decorator> InstanceDecorator(const Rml::String& name, const Rml::PropertyDictionary& properties, const Rml::DecoratorInstancerInterface& interface) override;
 
 private:
 	Rml::PropertyId id_image_src;

--- a/Samples/tutorial/datagrid_tree/src/DecoratorInstancerDefender.cpp
+++ b/Samples/tutorial/datagrid_tree/src/DecoratorInstancerDefender.cpp
@@ -26,7 +26,7 @@ DecoratorInstancerDefender::~DecoratorInstancerDefender()
 }
 
 // Instances a decorator given the property tag and attributes from the RCSS file.
-std::shared_ptr<Rml::Decorator> DecoratorInstancerDefender::InstanceDecorator(const Rml::String& /*name*/,
+Rml::SharedPtr<Rml::Decorator> DecoratorInstancerDefender::InstanceDecorator(const Rml::String& /*name*/,
 	const Rml::PropertyDictionary& properties, const Rml::DecoratorInstancerInterface& /*interface*/)
 {
 	const Rml::Property* image_source_property = properties.GetProperty(id_image_src);
@@ -35,7 +35,7 @@ std::shared_ptr<Rml::Decorator> DecoratorInstancerDefender::InstanceDecorator(co
 	if (auto & source = image_source_property->source)
 		source_path = source->path;
 
-	auto decorator = std::make_shared<DecoratorDefender>();
+	auto decorator = Rml::MakeShared<DecoratorDefender>();
 	if (decorator->Initialise(image_source, source_path))
 		return decorator;
 

--- a/Samples/tutorial/datagrid_tree/src/DecoratorInstancerDefender.h
+++ b/Samples/tutorial/datagrid_tree/src/DecoratorInstancerDefender.h
@@ -30,7 +30,7 @@ public:
 	/// @param[in] properties All RCSS properties associated with the decorator.
 	/// @param[in] interface An interface for querying the active style sheet.
 	/// @return A shared_ptr to the decorator if it was instanced successfully.
-	std::shared_ptr<Rml::Decorator> InstanceDecorator(const Rml::String& name, const Rml::PropertyDictionary& properties, const Rml::DecoratorInstancerInterface& interface) override;
+	Rml::SharedPtr<Rml::Decorator> InstanceDecorator(const Rml::String& name, const Rml::PropertyDictionary& properties, const Rml::DecoratorInstancerInterface& interface) override;
 
 private:
 	Rml::PropertyId id_image_src;

--- a/Source/Core/Context.cpp
+++ b/Source/Core/Context.cpp
@@ -242,7 +242,7 @@ ElementDocument* Context::CreateDocument(const String& tag)
 // Load a document into the context.
 ElementDocument* Context::LoadDocument(const String& document_path)
 {	
-	auto stream = std::make_unique<StreamFile>();
+	auto stream = MakeUnique<StreamFile>();
 
 	if (!stream->Open(document_path))
 		return nullptr;
@@ -283,7 +283,7 @@ ElementDocument* Context::LoadDocument(Stream* stream)
 ElementDocument* Context::LoadDocumentFromMemory(const String& string)
 {
 	// Open the stream based on the string contents.
-	auto stream = std::make_unique<StreamMemory>((byte*)string.c_str(), string.size());
+	auto stream = MakeUnique<StreamMemory>((byte*)string.c_str(), string.size());
 	stream->SetSourceURL("[document from memory]");
 
 	// Load the document from the stream.
@@ -800,9 +800,9 @@ void Context::SetInstancer(ContextInstancer* _instancer)
 DataModelConstructor Context::CreateDataModel(const String& name)
 {
 	if (!data_type_register)
-		data_type_register = std::make_unique<DataTypeRegister>();
+		data_type_register = MakeUnique<DataTypeRegister>();
 
-	auto result = data_models.emplace(name, std::make_unique<DataModel>(data_type_register->GetTransformFuncRegister()));
+	auto result = data_models.emplace(name, MakeUnique<DataModel>(data_type_register->GetTransformFuncRegister()));
 	bool inserted = result.second;
 	if (inserted)
 		return DataModelConstructor(result.first->second.get(), data_type_register.get());
@@ -1253,7 +1253,7 @@ void Context::ReleaseUnloadedDocuments()
 	}
 }
 
-using ElementObserverList = std::vector< ObserverPtr<Element> >;
+using ElementObserverList = Vector< ObserverPtr<Element> >;
 
 class ElementObserverListBackInserter {
 public:

--- a/Source/Core/Core.cpp
+++ b/Source/Core/Core.cpp
@@ -88,7 +88,7 @@ bool Initialise()
 	if (!file_interface)
 	{		
 #ifndef RMLUI_NO_FILE_INTERFACE_DEFAULT
-		default_file_interface = std::make_unique<FileInterfaceDefault>();
+		default_file_interface = MakeUnique<FileInterfaceDefault>();
 		file_interface = default_file_interface.get();
 #else
 		Log::Message(Log::LT_ERROR, "No file interface set!");
@@ -105,7 +105,7 @@ bool Initialise()
 	if (!font_interface)
 	{
 #ifndef RMLUI_NO_FONT_INTERFACE_DEFAULT
-		default_font_interface = std::make_unique<FontEngineInterfaceDefault>();
+		default_font_interface = MakeUnique<FontEngineInterfaceDefault>();
 		font_interface = default_font_interface.get();
 #else
 		Log::Message(Log::LT_ERROR, "No font interface set!");

--- a/Source/Core/DataControllerDefault.cpp
+++ b/Source/Core/DataControllerDefault.cpp
@@ -117,7 +117,7 @@ bool DataControllerEvent::Initialize(DataModel& model, Element* element, const S
 {
 	RMLUI_ASSERT(element);
 
-	expression = std::make_unique<DataExpression>(expression_str);
+	expression = MakeUnique<DataExpression>(expression_str);
 	DataExpressionInterface interface(&model, element);
 
 	if (!expression->Parse(interface, true))

--- a/Source/Core/DataExpression.cpp
+++ b/Source/Core/DataExpression.cpp
@@ -803,8 +803,8 @@ public:
 
 private:
 	Variant R, L, C;
-	std::stack<Variant> stack;
-	std::vector<Variant> arguments;
+	Stack<Variant> stack;
+	Vector<Variant> arguments;
 
 	const Program& program;
 	const AddressList& addresses;

--- a/Source/Core/DataExpression.h
+++ b/Source/Core/DataExpression.h
@@ -38,8 +38,8 @@ namespace Rml {
 class Element;
 class DataModel;
 struct InstructionData;
-using Program = std::vector<InstructionData>;
-using AddressList = std::vector<DataAddress>;
+using Program = Vector<InstructionData>;
+using AddressList = Vector<DataAddress>;
 
 class DataExpressionInterface {
 public:

--- a/Source/Core/DataModel.cpp
+++ b/Source/Core/DataModel.cpp
@@ -30,7 +30,6 @@
 #include "../../Include/RmlUi/Core/DataController.h"
 #include "../../Include/RmlUi/Core/DataView.h"
 #include "../../Include/RmlUi/Core/Element.h"
-#include <array>
 
 namespace Rml {
 
@@ -122,8 +121,8 @@ static String DataAddressToString(const DataAddress& address)
 
 DataModel::DataModel(const TransformFuncRegister* transform_register) : transform_register(transform_register)
 {
-	views = std::make_unique<DataViews>();
-	controllers = std::make_unique<DataControllers>();
+	views = MakeUnique<DataViews>();
+	controllers = MakeUnique<DataControllers>();
 }
 
 DataModel::~DataModel()
@@ -175,7 +174,7 @@ bool DataModel::BindFunc(const String& name, DataGetFunc get_func, DataSetFunc s
 		return false;
 	}
 	auto& func_definition_ptr = it->second;
-	func_definition_ptr = std::make_unique<FuncDefinition>(std::move(get_func), std::move(set_func));
+	func_definition_ptr = MakeUnique<FuncDefinition>(std::move(get_func), std::move(set_func));
 
 	return BindVariable(name, DataVariable(func_definition_ptr.get(), nullptr));
 }
@@ -380,7 +379,7 @@ bool DataModel::Update()
 static struct TestDataVariables {
 	TestDataVariables() 
 	{
-		using IntVector = std::vector<int>;
+		using IntVector = Vector<int>;
 
 		struct FunData {
 			int i = 99;
@@ -388,7 +387,7 @@ static struct TestDataVariables {
 			IntVector magic = { 3, 5, 7, 11, 13 };
 		};
 
-		using FunArray = std::array<FunData, 3>;
+		using FunArray = Array<FunData, 3>;
 
 		struct SmartData {
 			bool valid = true;
@@ -427,10 +426,10 @@ static struct TestDataVariables {
 		handle.Bind("data", &data);
 
 		{
-			std::vector<String> test_addresses = { "data.more_fun[1].magic[3]", "data.more_fun[1].magic.size", "data.fun.x", "data.valid" };
-			std::vector<String> expected_results = { ToString(data.more_fun[1].magic[3]), ToString(int(data.more_fun[1].magic.size())), ToString(data.fun.x), ToString(data.valid) };
+			Vector<String> test_addresses = { "data.more_fun[1].magic[3]", "data.more_fun[1].magic.size", "data.fun.x", "data.valid" };
+			Vector<String> expected_results = { ToString(data.more_fun[1].magic[3]), ToString(int(data.more_fun[1].magic.size())), ToString(data.fun.x), ToString(data.valid) };
 
-			std::vector<String> results;
+			Vector<String> results;
 
 			for (auto& str_address : test_addresses)
 			{

--- a/Source/Core/DataView.cpp
+++ b/Source/Core/DataView.cpp
@@ -93,7 +93,7 @@ bool DataViews::Update(DataModel& model, const DirtyVariables& dirty_variables)
 	//   Without the loop, newly added views won't be updated until the next Update() call.
 	for(int i = 0; i == 0 || (!views_to_add.empty() && i < 10); i++)
 	{
-		std::vector<DataView*> dirty_views;
+		Vector<DataView*> dirty_views;
 
 		if (!views_to_add.empty())
 		{

--- a/Source/Core/DataViewDefault.cpp
+++ b/Source/Core/DataViewDefault.cpp
@@ -45,7 +45,7 @@ bool DataViewCommon::Initialize(DataModel& model, Element* element, const String
 	if (modifier.empty())
 		modifier = in_modifier;
 
-	expression = std::make_unique<DataExpression>(expression_str);
+	expression = MakeUnique<DataExpression>(expression_str);
 	DataExpressionInterface interface(&model, element);
 
 	bool result = expression->Parse(interface, false);
@@ -265,7 +265,7 @@ bool DataViewText::Initialize(DataModel& model, Element* element, const String& 
 
 		DataEntry entry;
 		entry.index = text.size();
-		entry.data_expression = std::make_unique<DataExpression>(String(in_text.begin() + begin_name, in_text.begin() + end_name));
+		entry.data_expression = MakeUnique<DataExpression>(String(in_text.begin() + begin_name, in_text.begin() + end_name));
 
 		if (entry.data_expression->Parse(expression_interface, false))
 			data_entries.push_back(std::move(entry));
@@ -336,8 +336,8 @@ StringList DataViewText::GetVariableNameList() const
 
 		StringList entry_list = entry.data_expression->GetVariableNameList();
 		full_list.insert(full_list.end(),
-			std::make_move_iterator(entry_list.begin()),
-			std::make_move_iterator(entry_list.end())
+			MakeMoveIterator(entry_list.begin()),
+			MakeMoveIterator(entry_list.end())
 		);
 	}
 

--- a/Source/Core/DataViewDefault.h
+++ b/Source/Core/DataViewDefault.h
@@ -142,7 +142,7 @@ private:
 	};
 
 	String text;
-	std::vector<DataEntry> data_entries;
+	Vector<DataEntry> data_entries;
 };
 
 

--- a/Source/Core/DecoratorGradient.cpp
+++ b/Source/Core/DecoratorGradient.cpp
@@ -130,7 +130,7 @@ SharedPtr<Decorator> DecoratorGradientInstancer::InstanceDecorator(const String 
 	Colourb start = properties_.GetProperty(ids.start)->Get<Colourb>();
 	Colourb stop = properties_.GetProperty(ids.stop)->Get<Colourb>();
 
-	auto decorator = std::make_shared<DecoratorGradient>();
+	auto decorator = MakeShared<DecoratorGradient>();
 	if (decorator->Initialise(dir, start, stop)) {
 		return decorator;
 	}

--- a/Source/Core/DecoratorNinePatch.cpp
+++ b/Source/Core/DecoratorNinePatch.cpp
@@ -31,7 +31,6 @@
 #include "../../Include/RmlUi/Core/Geometry.h"
 #include "../../Include/RmlUi/Core/ElementUtilities.h"
 #include "../../Include/RmlUi/Core/PropertyDefinition.h"
-#include <array>
 
 namespace Rml {
 
@@ -43,13 +42,13 @@ DecoratorNinePatch::~DecoratorNinePatch()
 {
 }
 
-bool DecoratorNinePatch::Initialise(const Rectangle& _rect_outer, const Rectangle& _rect_inner, const std::array<Property, 4>* _edges, const Texture& _texture)
+bool DecoratorNinePatch::Initialise(const Rectangle& _rect_outer, const Rectangle& _rect_inner, const Array<Property, 4>* _edges, const Texture& _texture)
 {
 	rect_outer = _rect_outer;
 	rect_inner = _rect_inner;
 
 	if (_edges)
-		edges = std::make_unique< std::array<Property, 4> >(*_edges);
+		edges = MakeUnique< Array<Property, 4> >(*_edges);
 
 	int texture_index = AddTexture(_texture);
 	return (texture_index >= 0);
@@ -128,8 +127,8 @@ DecoratorDataHandle DecoratorNinePatch::GenerateElementData(Element* element) co
 
 	/* Now we have all the coordinates we need. Expand the diagonal vertices to the 16 individual vertices. */
 
-	std::vector<Vertex>& vertices = data->GetVertices();
-	std::vector<int>& indices = data->GetIndices();
+	Vector<Vertex>& vertices = data->GetVertices();
+	Vector<int>& indices = data->GetIndices();
 
 	vertices.resize(4 * 4);
 
@@ -202,7 +201,7 @@ SharedPtr<Decorator> DecoratorNinePatchInstancer::InstanceDecorator(const String
 	RMLUI_UNUSED(name);
 
 	bool edges_set = false;
-	std::array<Property,4> edges;
+	Array<Property,4> edges;
 	for (int i = 0; i < 4; i++)
 	{
 		edges[i] = *properties.GetProperty(edge_ids[i]);
@@ -240,7 +239,7 @@ SharedPtr<Decorator> DecoratorNinePatchInstancer::InstanceDecorator(const String
 		return nullptr;
 	}
 
-	auto decorator = std::make_shared<DecoratorNinePatch>();
+	auto decorator = MakeShared<DecoratorNinePatch>();
 
 	if (!decorator->Initialise(sprite_outer->rectangle, sprite_inner->rectangle, (edges_set ? &edges : nullptr), sprite_outer->sprite_sheet->texture))
 		return nullptr;

--- a/Source/Core/DecoratorNinePatch.h
+++ b/Source/Core/DecoratorNinePatch.h
@@ -42,7 +42,7 @@ public:
 	DecoratorNinePatch();
 	virtual ~DecoratorNinePatch();
 
-	bool Initialise(const Rectangle& rect_outer, const Rectangle& rect_inner, const std::array<Property, 4>* _edges, const Texture& texture);
+	bool Initialise(const Rectangle& rect_outer, const Rectangle& rect_inner, const Array<Property, 4>* _edges, const Texture& texture);
 
 	DecoratorDataHandle GenerateElementData(Element* element) const override;
 	void ReleaseElementData(DecoratorDataHandle element_data) const override;
@@ -51,7 +51,7 @@ public:
 
 private:
 	Rectangle rect_outer, rect_inner;
-	UniquePtr<std::array<Property,4>> edges;
+	UniquePtr<Array<Property,4>> edges;
 };
 
 

--- a/Source/Core/DecoratorTiled.cpp
+++ b/Source/Core/DecoratorTiled.cpp
@@ -106,7 +106,7 @@ Vector2f DecoratorTiled::Tile::GetDimensions(Element* element) const
 }
 
 // Generates geometry to render this tile across a surface.
-void DecoratorTiled::Tile::GenerateGeometry(std::vector< Vertex >& vertices, std::vector< int >& indices, Element* element, const Vector2f& surface_origin, const Vector2f& surface_dimensions, const Vector2f& tile_dimensions) const
+void DecoratorTiled::Tile::GenerateGeometry(Vector< Vertex >& vertices, Vector< int >& indices, Element* element, const Vector2f& surface_origin, const Vector2f& surface_dimensions, const Vector2f& tile_dimensions) const
 {
 	if (surface_dimensions.x <= 0 || surface_dimensions.y <= 0)
 		return;

--- a/Source/Core/DecoratorTiled.h
+++ b/Source/Core/DecoratorTiled.h
@@ -94,7 +94,7 @@ public:
 		/// @param[in] surface_origin The starting point of the first tile to generate.
 		/// @param[in] surface_dimensions The dimensions of the surface to be tiled.
 		/// @param[in] tile_dimensions The dimensions to render this tile at.
-		void GenerateGeometry(std::vector< Vertex >& vertices, std::vector< int >& indices, Element* element, const Vector2f& surface_origin, const Vector2f& surface_dimensions, const Vector2f& tile_dimensions) const;
+		void GenerateGeometry(Vector< Vertex >& vertices, Vector< int >& indices, Element* element, const Vector2f& surface_origin, const Vector2f& surface_dimensions, const Vector2f& tile_dimensions) const;
 
 		struct TileData
 		{

--- a/Source/Core/DecoratorTiledBoxInstancer.cpp
+++ b/Source/Core/DecoratorTiledBoxInstancer.cpp
@@ -65,7 +65,7 @@ SharedPtr<Decorator>DecoratorTiledBoxInstancer::InstanceDecorator(const String& 
 	if (!GetTileProperties(tiles, textures, num_tiles, properties, interface))
 		return nullptr;
 
-	auto decorator = std::make_shared<DecoratorTiledBox>();
+	auto decorator = MakeShared<DecoratorTiledBox>();
 	if (!decorator->Initialise(tiles, textures))
 		return nullptr;
 

--- a/Source/Core/DecoratorTiledHorizontalInstancer.cpp
+++ b/Source/Core/DecoratorTiledHorizontalInstancer.cpp
@@ -55,7 +55,7 @@ SharedPtr<Decorator> DecoratorTiledHorizontalInstancer::InstanceDecorator(const 
 	if (!GetTileProperties(tiles, textures, num_tiles, properties, interface))
 		return nullptr;
 
-	auto decorator = std::make_shared<DecoratorTiledHorizontal>();
+	auto decorator = MakeShared<DecoratorTiledHorizontal>();
 	if (!decorator->Initialise(tiles, textures))
 		return nullptr;
 

--- a/Source/Core/DecoratorTiledImageInstancer.cpp
+++ b/Source/Core/DecoratorTiledImageInstancer.cpp
@@ -52,7 +52,7 @@ SharedPtr<Decorator> DecoratorTiledImageInstancer::InstanceDecorator(const Strin
 	if (!GetTileProperties(&tile, &texture, 1, properties, interface))
 		return nullptr;
 	
-	auto decorator = std::make_shared<DecoratorTiledImage>();
+	auto decorator = MakeShared<DecoratorTiledImage>();
 
 	if (!decorator->Initialise(tile, texture))
 		return nullptr;

--- a/Source/Core/DecoratorTiledInstancer.h
+++ b/Source/Core/DecoratorTiledInstancer.h
@@ -64,7 +64,7 @@ private:
 		PropertyId src, fit, align_x, align_y, orientation;
 	};
 
-	std::vector<TilePropertyIds> tile_property_ids;
+	Vector<TilePropertyIds> tile_property_ids;
 };
 
 } // namespace Rml

--- a/Source/Core/DecoratorTiledVerticalInstancer.cpp
+++ b/Source/Core/DecoratorTiledVerticalInstancer.cpp
@@ -55,7 +55,7 @@ SharedPtr<Decorator> DecoratorTiledVerticalInstancer::InstanceDecorator(const St
 	if (!GetTileProperties(tiles, textures, num_tiles, properties, interface))
 		return nullptr;
 
-	auto decorator = std::make_shared<DecoratorTiledVertical>();
+	auto decorator = MakeShared<DecoratorTiledVertical>();
 	if (!decorator->Initialise(tiles, textures))
 		return nullptr;
 

--- a/Source/Core/DocumentHeader.h
+++ b/Source/Core/DocumentHeader.h
@@ -33,7 +33,7 @@
 
 namespace Rml {
 
-using LineNumberList = std::vector<int>;
+using LineNumberList = Vector<int>;
 
 /**
 	The document header struct contains the

--- a/Source/Core/Element.cpp
+++ b/Source/Core/Element.cpp
@@ -74,7 +74,7 @@ namespace Rml {
 class ElementSortZOrder
 {
 public:
-	bool operator()(const std::pair< Element*, float >& lhs, const std::pair< Element*, float >& rhs) const
+	bool operator()(const Pair< Element*, float >& lhs, const Pair< Element*, float >& rhs) const
 	{
 		return lhs.second < rhs.second;
 	}
@@ -775,7 +775,7 @@ bool Element::Project(Vector2f& point) const noexcept
 
 PropertiesIteratorView Element::IterateLocalProperties() const
 {
-	return PropertiesIteratorView(std::make_unique<PropertiesIterator>(meta->style.Iterate()));
+	return PropertiesIteratorView(MakeUnique<PropertiesIterator>(meta->style.Iterate()));
 }
 
 
@@ -2181,7 +2181,7 @@ void Element::BuildStackingContext(ElementList* new_stacking_context)
 	// Build the list of ordered children. Our child list is sorted within the stacking context so stacked elements
 	// will render in the right order; ie, positioned elements will render on top of inline elements, which will render
 	// on top of floated elements, which will render on top of block elements.
-	std::vector< std::pair< Element*, float > > ordered_children;
+	Vector< Pair< Element*, float > > ordered_children;
 	for (size_t i = 0; i < children.size(); ++i)
 	{
 		Element* child = children[i].get();
@@ -2189,7 +2189,7 @@ void Element::BuildStackingContext(ElementList* new_stacking_context)
 		if (!child->IsVisible())
 			continue;
 
-		std::pair< Element*, float > ordered_child;
+		Pair< Element*, float > ordered_child;
 		ordered_child.first = child;
 
 		if (child->GetPosition() != Style::Position::Static)
@@ -2521,8 +2521,8 @@ void Element::AdvanceAnimations()
 		// Move all completed animations to the end of the list
 		auto it_completed = std::partition(animations.begin(), animations.end(), [](const ElementAnimation& animation) { return !animation.IsComplete(); });
 
-		std::vector<Dictionary> dictionary_list;
-		std::vector<bool> is_transition;
+		Vector<Dictionary> dictionary_list;
+		Vector<bool> is_transition;
 		dictionary_list.reserve(animations.end() - it_completed);
 		is_transition.reserve(animations.end() - it_completed);
 
@@ -2606,7 +2606,7 @@ void Element::UpdateTransformState()
 			);
 
 			if (!transform_state)
-				transform_state = std::make_unique<TransformState>();
+				transform_state = MakeUnique<TransformState>();
 
 			perspective_or_transform_changed |= transform_state->SetLocalPerspective(&perspective);
 		}
@@ -2687,7 +2687,7 @@ void Element::UpdateTransformState()
 		if (have_transform)
 		{
 			if (!transform_state)
-				transform_state = std::make_unique<TransformState>();
+				transform_state = MakeUnique<TransformState>();
 
 			perspective_or_transform_changed |= transform_state->SetTransform(&transform);
 		}

--- a/Source/Core/ElementAnimation.cpp
+++ b/Source/Core/ElementAnimation.cpp
@@ -225,7 +225,7 @@ static PrepareTransformResult PrepareTransformPair(Transform& t0, Transform& t1,
 		auto& small = (prims0_smallest ? prims0 : prims1);
 		auto& big = (prims0_smallest ? prims1 : prims0);
 
-		std::vector<size_t> matching_indices; // Indices into 'big' for matching types
+		Vector<size_t> matching_indices; // Indices into 'big' for matching types
 		matching_indices.reserve(small.size() + 1);
 
 		size_t i_big = 0;
@@ -304,7 +304,7 @@ static PrepareTransformResult PrepareTransformPair(Transform& t0, Transform& t1,
 }
 
 
-static bool PrepareTransforms(std::vector<AnimationKey>& keys, Element& element, int start_index)
+static bool PrepareTransforms(Vector<AnimationKey>& keys, Element& element, int start_index)
 {
 	bool result = true;
 
@@ -315,7 +315,7 @@ static bool PrepareTransforms(std::vector<AnimationKey>& keys, Element& element,
 		RMLUI_ASSERT(property.value.GetType() == Variant::TRANSFORMPTR);
 
 		if (!property.value.GetReference<TransformPtr>())
-			property.value = std::make_shared<Transform>();
+			property.value = MakeShared<Transform>();
 
 		bool must_decompose = false;
 		Transform& transform = *property.value.GetReference<TransformPtr>();
@@ -346,7 +346,7 @@ static bool PrepareTransforms(std::vector<AnimationKey>& keys, Element& element,
 	int count_iterations = -1;
 	const int max_iterations = 3 * N;
 
-	std::vector<bool> dirty_list(N + 1, false);
+	Vector<bool> dirty_list(N + 1, false);
 	dirty_list[start_index] = true;
 
 	// For each pair of keys, match the transform primitives such that they can be interpolated during animation update

--- a/Source/Core/ElementAnimation.h
+++ b/Source/Core/ElementAnimation.h
@@ -57,7 +57,7 @@ private:
 	int num_iterations = 0;       // -1 for infinity
 	bool alternate_direction = 0; // between iterations
 
-	std::vector<AnimationKey> keys;
+	Vector<AnimationKey> keys;
 
 	double last_update_world_time = 0;
 	float time_since_iteration_start = 0;

--- a/Source/Core/ElementBackground.cpp
+++ b/Source/Core/ElementBackground.cpp
@@ -97,8 +97,8 @@ void ElementBackground::GenerateBackground()
 			num_boxes++;
 	}
 
-	std::vector< Vertex >& vertices = geometry.GetVertices();
-	std::vector< int >& indices = geometry.GetIndices();
+	Vector< Vertex >& vertices = geometry.GetVertices();
+	Vector< int >& indices = geometry.GetIndices();
 
 	int index_offset = 0;
 	vertices.resize(4 * num_boxes);

--- a/Source/Core/ElementBorder.cpp
+++ b/Source/Core/ElementBorder.cpp
@@ -78,8 +78,8 @@ void ElementBorder::GenerateBorder()
 		}
 	}
 
-	std::vector< Vertex >& vertices = geometry.GetVertices();
-	std::vector< int >& indices = geometry.GetIndices();
+	Vector< Vertex >& vertices = geometry.GetVertices();
+	Vector< int >& indices = geometry.GetIndices();
 
 	int index_offset = 0;
 	vertices.resize(4 * num_edges);

--- a/Source/Core/ElementDecoration.h
+++ b/Source/Core/ElementDecoration.h
@@ -70,7 +70,7 @@ private:
 		DecoratorDataHandle decorator_data;
 	};
 
-	using DecoratorHandleList = std::vector< DecoratorHandle >;
+	using DecoratorHandleList = Vector< DecoratorHandle >;
 
 	// The element this decorator belongs to
 	Element* element;

--- a/Source/Core/ElementDefinition.cpp
+++ b/Source/Core/ElementDefinition.cpp
@@ -32,7 +32,7 @@
 
 namespace Rml {
 
-ElementDefinition::ElementDefinition(const std::vector< const StyleSheetNode* >& style_sheet_nodes)
+ElementDefinition::ElementDefinition(const Vector< const StyleSheetNode* >& style_sheet_nodes)
 {
 	// Initialises the element definition from the list of style sheet nodes.
 	for (size_t i = 0; i < style_sheet_nodes.size(); ++i)

--- a/Source/Core/ElementDefinition.h
+++ b/Source/Core/ElementDefinition.h
@@ -47,7 +47,7 @@ class ElementDefinitionIterator;
 class ElementDefinition : public NonCopyMoveable
 {
 public:
-	ElementDefinition(const std::vector< const StyleSheetNode* >& style_sheet_nodes);
+	ElementDefinition(const Vector< const StyleSheetNode* >& style_sheet_nodes);
 
 	/// Returns a specific property from the element definition.
 	/// @param[in] id The id of the property to return.

--- a/Source/Core/ElementDocument.cpp
+++ b/Source/Core/ElementDocument.cpp
@@ -104,8 +104,8 @@ void ElementDocument::ProcessHeader(const DocumentHeader* document_header)
 	{			
 		for (size_t i = 0;i < header.rcss_inline.size(); i++)
 		{			
-			UniquePtr<StyleSheet> inline_sheet = std::make_unique<StyleSheet>();
-			auto stream = std::make_unique<StreamMemory>((const byte*) header.rcss_inline[i].c_str(), header.rcss_inline[i].size());
+			UniquePtr<StyleSheet> inline_sheet = MakeUnique<StyleSheet>();
+			auto stream = MakeUnique<StreamMemory>((const byte*) header.rcss_inline[i].c_str(), header.rcss_inline[i].size());
 			stream->SetSourceURL(document_header->source);
 
 			if (inline_sheet->LoadStyleSheet(stream.get(), header.rcss_inline_line_numbers[i]))
@@ -132,7 +132,7 @@ void ElementDocument::ProcessHeader(const DocumentHeader* document_header)
 	// Load external scripts.
 	for (size_t i = 0; i < header.scripts_external.size(); i++)
 	{
-		auto stream = std::make_unique<StreamFile>();
+		auto stream = MakeUnique<StreamFile>();
 		if (stream->Open(header.scripts_external[i]))
 			LoadScript(stream.get(), header.scripts_external[i]);
 	}
@@ -140,7 +140,7 @@ void ElementDocument::ProcessHeader(const DocumentHeader* document_header)
 	// Load internal scripts.
 	for (size_t i = 0; i < header.scripts_inline.size(); i++)
 	{
-		auto stream = std::make_unique<StreamMemory>((const byte*) header.scripts_inline[i].c_str(), header.scripts_inline[i].size());
+		auto stream = MakeUnique<StreamMemory>((const byte*) header.scripts_inline[i].c_str(), header.scripts_inline[i].size());
 		LoadScript(stream.get(), "");
 	}
 

--- a/Source/Core/ElementTextDefault.cpp
+++ b/Source/Core/ElementTextDefault.cpp
@@ -363,7 +363,7 @@ void ElementTextDefault::OnPropertyChange(const PropertyIdSet& changed_propertie
 		geometry_dirty = true;
 
 		// Re-colour the decoration geometry.
-		std::vector< Vertex >& vertices = decoration.GetVertices();
+		Vector< Vertex >& vertices = decoration.GetVertices();
 		for (size_t i = 0; i < vertices.size(); ++i)
 			vertices[i].colour = colour;
 

--- a/Source/Core/ElementTextDefault.h
+++ b/Source/Core/ElementTextDefault.h
@@ -108,7 +108,7 @@ private:
 
 	String text;
 
-	typedef std::vector< Line > LineList;
+	typedef Vector< Line > LineList;
 	LineList lines;
 
 	bool dirty_layout_on_change;

--- a/Source/Core/ElementUtilities.cpp
+++ b/Source/Core/ElementUtilities.cpp
@@ -40,7 +40,6 @@
 #include "ElementStyle.h"
 #include "LayoutEngine.h"
 #include "TransformState.h"
-#include <queue>
 #include <limits>
 
 namespace Rml {
@@ -78,7 +77,7 @@ static void SetElementOffset(Element* element, const Vector2f& offset)
 Element* ElementUtilities::GetElementById(Element* root_element, const String& id)
 {
 	// Breadth first search on elements for the corresponding id
-	typedef std::queue<Element*> SearchQueue;
+	typedef Queue<Element*> SearchQueue;
 	SearchQueue search_queue;
 	search_queue.push(root_element);
 
@@ -103,7 +102,7 @@ Element* ElementUtilities::GetElementById(Element* root_element, const String& i
 void ElementUtilities::GetElementsByTagName(ElementList& elements, Element* root_element, const String& tag)
 {
 	// Breadth first search on elements for the corresponding id
-	typedef std::queue< Element* > SearchQueue;
+	typedef Queue< Element* > SearchQueue;
 	SearchQueue search_queue;
 	for (int i = 0; i < root_element->GetNumChildren(); ++i)
 		search_queue.push(root_element->GetChild(i));
@@ -125,7 +124,7 @@ void ElementUtilities::GetElementsByTagName(ElementList& elements, Element* root
 void ElementUtilities::GetElementsByClassName(ElementList& elements, Element* root_element, const String& class_name)
 {
 	// Breadth first search on elements for the corresponding id
-	typedef std::queue< Element* > SearchQueue;
+	typedef Queue< Element* > SearchQueue;
 	SearchQueue search_queue;
 	for (int i = 0; i < root_element->GetNumChildren(); ++i)
 		search_queue.push(root_element->GetChild(i));
@@ -404,7 +403,7 @@ static bool ApplyDataViewsControllersInternal(Element* element, const bool const
 		// Since data views and controllers may modify the element's attributes during initialization, we 
 		// need to iterate over all the attributes _before_ initializing any views or controllers. We store
 		// the information needed to initialize them in the following container.
-		std::vector<ViewControllerInitializer> initializer_list;
+		Vector<ViewControllerInitializer> initializer_list;
 
 		for (auto& attribute : element->GetAttributes())
 		{

--- a/Source/Core/Elements/ElementImage.cpp
+++ b/Source/Core/Elements/ElementImage.cpp
@@ -147,8 +147,8 @@ void ElementImage::GenerateGeometry()
 	// Release the old geometry before specifying the new vertices.
 	geometry.Release(true);
 
-	std::vector< Vertex >& vertices = geometry.GetVertices();
-	std::vector< int >& indices = geometry.GetIndices();
+	Vector< Vertex >& vertices = geometry.GetVertices();
+	Vector< int >& indices = geometry.GetIndices();
 
 	vertices.resize(4);
 	indices.resize(6);

--- a/Source/Core/Elements/ElementProgressBar.cpp
+++ b/Source/Core/Elements/ElementProgressBar.cpp
@@ -36,7 +36,6 @@
 #include "../../../Include/RmlUi/Core/ElementUtilities.h"
 #include "../../../Include/RmlUi/Core/URL.h"
 #include <algorithm>
-#include <array>
 
 namespace Rml {
 
@@ -87,7 +86,7 @@ void ElementProgressBar::OnAttributeChange(const ElementAttributes& changed_attr
 
 	if (changed_attributes.find("direction") != changed_attributes.end())
 	{
-		using DirectionNameList = std::array<String, size_t(Direction::Count)>;
+		using DirectionNameList = Array<String, size_t(Direction::Count)>;
 		static const DirectionNameList names = { "top", "right", "bottom", "left", "clockwise", "counter-clockwise" };
 
 		direction = DefaultDirection;
@@ -104,7 +103,7 @@ void ElementProgressBar::OnAttributeChange(const ElementAttributes& changed_attr
 
 	if (changed_attributes.find("start-edge") != changed_attributes.end())
 	{
-		using StartEdgeNameList = std::array<String, size_t(StartEdge::Count)>;
+		using StartEdgeNameList = Array<String, size_t(StartEdge::Count)>;
 		static const StartEdgeNameList names = { "top", "right", "bottom", "left" };
 
 		start_edge = DefaultStartEdge;

--- a/Source/Core/Elements/WidgetDropDown.h
+++ b/Source/Core/Elements/WidgetDropDown.h
@@ -31,7 +31,6 @@
 
 #include "../../../Include/RmlUi/Core/EventListener.h"
 #include "../../../Include/RmlUi/Core/Elements/SelectOption.h"
-#include <vector>
 
 namespace Rml {
 
@@ -102,7 +101,7 @@ public:
 	void ProcessEvent(Event& event) override;
 
 private:
-	typedef std::vector< SelectOption > OptionList;
+	typedef Vector< SelectOption > OptionList;
 
 	// Shows or hides the selection box.
 	void ShowSelectBox(bool show);

--- a/Source/Core/Elements/WidgetTextInput.cpp
+++ b/Source/Core/Elements/WidgetTextInput.cpp
@@ -982,8 +982,8 @@ Vector2f WidgetTextInput::FormatText()
 	// Clear the selection background geometry, and get the vertices and indices so the new geo can
 	// be generated.
 	selection_geometry.Release(true);
-	std::vector< Vertex >& selection_vertices = selection_geometry.GetVertices();
-	std::vector< int >& selection_indices = selection_geometry.GetIndices();
+	Vector< Vertex >& selection_vertices = selection_geometry.GetVertices();
+	Vector< int >& selection_indices = selection_geometry.GetIndices();
 
 	// Determine the line-height of the text element.
 	float line_height = parent->GetLineHeight();
@@ -1114,10 +1114,10 @@ void WidgetTextInput::GenerateCursor()
 	// Generates the cursor.
 	cursor_geometry.Release();
 
-	std::vector< Vertex >& vertices = cursor_geometry.GetVertices();
+	Vector< Vertex >& vertices = cursor_geometry.GetVertices();
 	vertices.resize(4);
 
-	std::vector< int >& indices = cursor_geometry.GetIndices();
+	Vector< int >& indices = cursor_geometry.GetIndices();
 	indices.resize(6);
 
 	cursor_size.x = ElementUtilities::GetDensityIndependentPixelRatio(text_element);

--- a/Source/Core/Elements/WidgetTextInput.cpp
+++ b/Source/Core/Elements/WidgetTextInput.cpp
@@ -526,7 +526,7 @@ bool WidgetTextInput::AddCharacters(String string)
 
 	String value = GetElement()->GetAttribute< String >("value", "");
 	
-	value.insert(std::min(size_t(GetCursorIndex()), value.size()), string);
+	value.insert(std::min<size_t>(GetCursorIndex(), value.size()), string);
 
 	edit_index += (int)string.size();
 
@@ -563,7 +563,7 @@ bool WidgetTextInput::DeleteCharacters(CursorMovement direction)
 void WidgetTextInput::CopySelection()
 {
 	const String& value = GetElement()->GetAttribute< String >("value", "");
-	const String snippet = value.substr(std::min(size_t(selection_begin_index), value.size()), selection_length);
+	const String snippet = value.substr(std::min(size_t(selection_begin_index), size_t(value.size())), selection_length);
 	GetSystemInterface()->SetClipboardText(snippet);
 }
 
@@ -1186,7 +1186,7 @@ void WidgetTextInput::DeleteSelection()
 	{
 		const String& value = GetElement()->GetAttribute< String >("value", "");
 
-		String new_value = value.substr(0, selection_begin_index) + value.substr(std::min(size_t(selection_begin_index + selection_length), value.size()));
+		String new_value = value.substr(0, selection_begin_index) + value.substr(std::min(size_t(selection_begin_index + selection_length), size_t(value.size())));
 		GetElement()->SetAttribute("value", new_value);
 
 		// Move the cursor to the beginning of the old selection.

--- a/Source/Core/Elements/WidgetTextInput.h
+++ b/Source/Core/Elements/WidgetTextInput.h
@@ -196,7 +196,7 @@ private:
 	Vector2f internal_dimensions;
 	Vector2f scroll_offset;
 
-	typedef std::vector< Line > LineList;
+	typedef Vector< Line > LineList;
 	LineList lines;
 
 	// Length in number of characters.

--- a/Source/Core/EventDispatcher.cpp
+++ b/Source/Core/EventDispatcher.cpp
@@ -140,8 +140,8 @@ bool EventDispatcher::DispatchEvent(Element* target_element, const EventId id, c
 {
 	RMLUI_ASSERTMSG(!((int)default_action_phase & (int)EventPhase::Capture), "We assume here that the default action phases cannot include capture phase.");
 
-	std::vector<CollectedListener> listeners;
-	std::vector<ObserverPtr<Element>> default_action_elements;
+	Vector<CollectedListener> listeners;
+	Vector<ObserverPtr<Element>> default_action_elements;
 
 	const EventPhase phases_to_execute = EventPhase((int)EventPhase::Capture | (int)EventPhase::Target | (bubbles ? (int)EventPhase::Bubble : 0));
 	
@@ -226,7 +226,7 @@ bool EventDispatcher::DispatchEvent(Element* target_element, const EventId id, c
 }
 
 
-void EventDispatcher::CollectListeners(int dom_distance_from_target, const EventId event_id, const EventPhase event_executes_in_phases, std::vector<CollectedListener>& collect_listeners)
+void EventDispatcher::CollectListeners(int dom_distance_from_target, const EventId event_id, const EventPhase event_executes_in_phases, Vector<CollectedListener>& collect_listeners)
 {
 	// Find all the entries with a matching id, given that listeners are sorted by id first.
 	Listeners::iterator begin, end;

--- a/Source/Core/EventDispatcher.h
+++ b/Source/Core/EventDispatcher.h
@@ -98,11 +98,11 @@ private:
 
 	// Listeners are sorted first by (id, phase) and then by the order in which the listener was inserted.
 	// All listeners added are unique.
-	typedef std::vector< EventListenerEntry > Listeners;
+	typedef Vector< EventListenerEntry > Listeners;
 	Listeners listeners;
 
 	// Collect all the listeners from this dispatcher that are allowed to execute given the input arguments.
-	void CollectListeners(int dom_distance_from_target, EventId event_id, EventPhase phases_to_execute, std::vector<CollectedListener>& collect_listeners);
+	void CollectListeners(int dom_distance_from_target, EventId event_id, EventPhase phases_to_execute, Vector<CollectedListener>& collect_listeners);
 };
 
 

--- a/Source/Core/EventSpecification.cpp
+++ b/Source/Core/EventSpecification.cpp
@@ -33,7 +33,7 @@
 namespace Rml {
 
 // An EventId is an index into the specifications vector.
-static std::vector<EventSpecification> specifications = { { EventId::Invalid, "invalid", false, false, DefaultActionPhase::None } };
+static Vector<EventSpecification> specifications = { { EventId::Invalid, "invalid", false, false, DefaultActionPhase::None } };
 
 // Reverse lookup map from event type to id.
 static UnorderedMap<String, EventId> type_lookup;

--- a/Source/Core/Factory.cpp
+++ b/Source/Core/Factory.cpp
@@ -199,19 +199,19 @@ Factory::~Factory()
 
 bool Factory::Initialise()
 {
-	default_instancers = std::make_unique<DefaultInstancers>();
+	default_instancers = MakeUnique<DefaultInstancers>();
 
 	// Default context instancer
 	if (!context_instancer)
 	{
-		default_instancers->context_default = std::make_unique<ContextInstancerDefault>();
+		default_instancers->context_default = MakeUnique<ContextInstancerDefault>();
 		context_instancer = default_instancers->context_default.get();
 	}
 
 	// Default event instancer
 	if (!event_instancer)
 	{
-		default_instancers->event_default = std::make_unique<EventInstancerDefault>();
+		default_instancers->event_default = MakeUnique<EventInstancerDefault>();
 		event_instancer = default_instancers->event_default.get();
 	}
 
@@ -273,15 +273,15 @@ bool Factory::Initialise()
 	RegisterDataControllerInstancer(&default_instancers->data_controller_event, "event");
 
 	// XML node handlers
-	XMLParser::RegisterNodeHandler("", std::make_shared<XMLNodeHandlerDefault>());
-	XMLParser::RegisterNodeHandler("body", std::make_shared<XMLNodeHandlerBody>());
-	XMLParser::RegisterNodeHandler("head", std::make_shared<XMLNodeHandlerHead>());
-	XMLParser::RegisterNodeHandler("template", std::make_shared<XMLNodeHandlerTemplate>());
+	XMLParser::RegisterNodeHandler("", MakeShared<XMLNodeHandlerDefault>());
+	XMLParser::RegisterNodeHandler("body", MakeShared<XMLNodeHandlerBody>());
+	XMLParser::RegisterNodeHandler("head", MakeShared<XMLNodeHandlerHead>());
+	XMLParser::RegisterNodeHandler("template", MakeShared<XMLNodeHandlerTemplate>());
 
 	// XML node handlers for control elements
-	XMLParser::RegisterNodeHandler("datagrid", std::make_shared<XMLNodeHandlerDataGrid>());
-	XMLParser::RegisterNodeHandler("tabset", std::make_shared<XMLNodeHandlerTabSet>());
-	XMLParser::RegisterNodeHandler("textarea", std::make_shared<XMLNodeHandlerTextArea>());
+	XMLParser::RegisterNodeHandler("datagrid", MakeShared<XMLNodeHandlerDataGrid>());
+	XMLParser::RegisterNodeHandler("tabset", MakeShared<XMLNodeHandlerTabSet>());
+	XMLParser::RegisterNodeHandler("textarea", MakeShared<XMLNodeHandlerTextArea>());
 
 	return true;
 }
@@ -409,7 +409,7 @@ bool Factory::InstanceElementText(Element* parent, const String& in_text)
 	if (parse_as_rml)
 	{
 		RMLUI_ZoneScopedNC("InstanceStream", 0xDC143C);
-		auto stream = std::make_unique<StreamMemory>(text.size() + 32);
+		auto stream = MakeUnique<StreamMemory>(text.size() + 32);
 		stream->Write("<body>", 6);
 		stream->Write(text);
 		stream->Write("</body>", 7);
@@ -525,14 +525,14 @@ FontEffectInstancer* Factory::GetFontEffectInstancer(const String& name)
 // Creates a style sheet containing the passed in styles.
 SharedPtr<StyleSheet> Factory::InstanceStyleSheetString(const String& string)
 {
-	auto memory_stream = std::make_unique<StreamMemory>((const byte*) string.c_str(), string.size());
+	auto memory_stream = MakeUnique<StreamMemory>((const byte*) string.c_str(), string.size());
 	return InstanceStyleSheetStream(memory_stream.get());
 }
 
 // Creates a style sheet from a file.
 SharedPtr<StyleSheet> Factory::InstanceStyleSheetFile(const String& file_name)
 {
-	auto file_stream = std::make_unique<StreamFile>();
+	auto file_stream = MakeUnique<StreamFile>();
 	file_stream->Open(file_name);
 	return InstanceStyleSheetStream(file_stream.get());
 }
@@ -540,7 +540,7 @@ SharedPtr<StyleSheet> Factory::InstanceStyleSheetFile(const String& file_name)
 // Creates a style sheet from an Stream.
 SharedPtr<StyleSheet> Factory::InstanceStyleSheetStream(Stream* stream)
 {
-	SharedPtr<StyleSheet> style_sheet = std::make_shared<StyleSheet>();
+	SharedPtr<StyleSheet> style_sheet = MakeShared<StyleSheet>();
 	if (style_sheet->LoadStyleSheet(stream))
 	{
 		return style_sheet;

--- a/Source/Core/FontEffectBlur.cpp
+++ b/Source/Core/FontEffectBlur.cpp
@@ -135,7 +135,7 @@ SharedPtr<FontEffect> FontEffectBlurInstancer::InstanceFontEffect(const String& 
 	float width = properties.GetProperty(id_width)->Get< float >();
 	Colourb color = properties.GetProperty(id_color)->Get< Colourb >();
 
-	auto font_effect = std::make_shared<FontEffectBlur>();
+	auto font_effect = MakeShared<FontEffectBlur>();
 	if (font_effect->Initialise(Math::RealToInteger(width)))
 	{
 		font_effect->SetColour(color);

--- a/Source/Core/FontEffectGlow.cpp
+++ b/Source/Core/FontEffectGlow.cpp
@@ -173,7 +173,7 @@ SharedPtr<FontEffect> FontEffectGlowInstancer::InstanceFontEffect(const String& 
 	if (width_blur < 0)
 		width_blur = width_outline;
 
-	auto font_effect = std::make_shared<FontEffectGlow>();
+	auto font_effect = MakeShared<FontEffectGlow>();
 	if (font_effect->Initialise(width_outline, width_blur, offset))
 	{
 		font_effect->SetColour(color);

--- a/Source/Core/FontEffectOutline.cpp
+++ b/Source/Core/FontEffectOutline.cpp
@@ -117,7 +117,7 @@ SharedPtr<FontEffect> FontEffectOutlineInstancer::InstanceFontEffect(const Strin
 	float width = properties.GetProperty(id_width)->Get< float >();
 	Colourb color = properties.GetProperty(id_color)->Get< Colourb >();
 
-	auto font_effect = std::make_shared<FontEffectOutline>();
+	auto font_effect = MakeShared<FontEffectOutline>();
 	if (font_effect->Initialise(Math::RealToInteger(width)))
 	{
 		font_effect->SetColour(color);

--- a/Source/Core/FontEffectShadow.cpp
+++ b/Source/Core/FontEffectShadow.cpp
@@ -84,7 +84,7 @@ SharedPtr<FontEffect> FontEffectShadowInstancer::InstanceFontEffect(const String
 	offset.y = Math::RealToInteger(properties.GetProperty(id_offset_y)->Get< float >());
 	Colourb color = properties.GetProperty(id_color)->Get< Colourb >();
 
-	auto font_effect = std::make_shared<FontEffectShadow>();
+	auto font_effect = MakeShared<FontEffectShadow>();
 	if (font_effect->Initialise(offset))
 	{
 		font_effect->SetColour(color);

--- a/Source/Core/FontEngineDefault/FontFace.cpp
+++ b/Source/Core/FontEngineDefault/FontFace.cpp
@@ -77,7 +77,7 @@ FontFaceHandleDefault* FontFace::GetHandle(int size) {
 	}
 
 	// Construct and initialise the new handle.
-	auto handle = std::make_unique<FontFaceHandleDefault>();
+	auto handle = MakeUnique<FontFaceHandleDefault>();
 	if (!handle->Initialize(face, size))
 	{
 		handles[size] = nullptr;

--- a/Source/Core/FontEngineDefault/FontFaceHandleDefault.cpp
+++ b/Source/Core/FontEngineDefault/FontFaceHandleDefault.cpp
@@ -403,7 +403,7 @@ FontFaceLayer* FontFaceHandleDefault::GetOrCreateLayer(const SharedPtr<const Fon
 	layers.push_back(EffectLayerPair{ font_effect_ptr, nullptr });
 	auto& layer = layers.back().layer;
 	
-	layer = std::make_unique<FontFaceLayer>(font_effect);
+	layer = MakeUnique<FontFaceLayer>(font_effect);
 	GenerateLayer(layer.get());
 
 	return layer.get();

--- a/Source/Core/FontEngineDefault/FontFaceHandleDefault.h
+++ b/Source/Core/FontEngineDefault/FontFaceHandleDefault.h
@@ -126,10 +126,10 @@ private:
 		const FontEffect* font_effect;
 		UniquePtr<FontFaceLayer> layer; 
 	};
-	using FontLayerMap = std::vector< EffectLayerPair >;
+	using FontLayerMap = Vector< EffectLayerPair >;
 	using FontLayerCache = SmallUnorderedMap< size_t, FontFaceLayer* >;
-	using LayerConfiguration = std::vector< FontFaceLayer* >;
-	using LayerConfigurationList = std::vector< LayerConfiguration >;
+	using LayerConfiguration = Vector< FontFaceLayer* >;
+	using LayerConfigurationList = Vector< LayerConfiguration >;
 
 	// The list of all font layers, index by the effect that instanced them.
 	FontFaceLayer* base_layer;

--- a/Source/Core/FontEngineDefault/FontFaceLayer.h
+++ b/Source/Core/FontEngineDefault/FontFaceLayer.h
@@ -84,8 +84,8 @@ public:
 			return;
 
 		// Generate the geometry for the character.
-		std::vector< Vertex >& character_vertices = geometry[box.texture_index].GetVertices();
-		std::vector< int >& character_indices = geometry[box.texture_index].GetIndices();
+		Vector< Vertex >& character_vertices = geometry[box.texture_index].GetVertices();
+		Vector< int >& character_indices = geometry[box.texture_index].GetIndices();
 
 		character_vertices.resize(character_vertices.size() + 4);
 		character_indices.resize(character_indices.size() + 6);
@@ -131,7 +131,7 @@ private:
 	};
 
 	using CharacterMap = UnorderedMap<Character, TextureBox>;
-	using TextureList = std::vector<Texture>;
+	using TextureList = Vector<Texture>;
 
 	SharedPtr<const FontEffect> effect;
 

--- a/Source/Core/FontEngineDefault/FontFamily.cpp
+++ b/Source/Core/FontEngineDefault/FontFamily.cpp
@@ -63,7 +63,7 @@ FontFaceHandleDefault* FontFamily::GetFaceHandle(Style::FontStyle style, Style::
 // Adds a new face to the family.
 FontFace* FontFamily::AddFace(FontFaceHandleFreetype ft_face, Style::FontStyle style, Style::FontWeight weight, bool release_stream)
 {
-	auto face = std::make_unique<FontFace>(ft_face, style, weight, release_stream);
+	auto face = MakeUnique<FontFace>(ft_face, style, weight, release_stream);
 	FontFace* result = face.get();
 
 	font_faces.push_back(std::move(face));

--- a/Source/Core/FontEngineDefault/FontFamily.h
+++ b/Source/Core/FontEngineDefault/FontFamily.h
@@ -64,7 +64,7 @@ public:
 protected:
 	String name;
 
-	using FontFaceList = std::vector< UniquePtr<FontFace> >;
+	using FontFaceList = Vector< UniquePtr<FontFace> >;
 	FontFaceList font_faces;
 };
 

--- a/Source/Core/FontEngineDefault/FontProvider.cpp
+++ b/Source/Core/FontEngineDefault/FontProvider.cpp
@@ -174,7 +174,7 @@ bool FontProvider::AddFace(FontFaceHandleFreetype face, const String& family, St
 	}
 	else
 	{
-		auto font_family_ptr = std::make_unique<FontFamily>(family_lower);
+		auto font_family_ptr = MakeUnique<FontFamily>(family_lower);
 		font_family = font_family_ptr.get();
 		font_families[family_lower] = std::move(font_family_ptr);
 	}

--- a/Source/Core/FontEngineDefault/FontProvider.h
+++ b/Source/Core/FontEngineDefault/FontProvider.h
@@ -83,7 +83,7 @@ private:
 
 	bool AddFace(FontFaceHandleFreetype face, const String& family, Style::FontStyle style, Style::FontWeight weight, bool fallback_face, bool release_stream);
 
-	using FontFaceList = std::vector<FontFace*>;
+	using FontFaceList = Vector<FontFace*>;
 	using FontFamilyMap = UnorderedMap< String, UniquePtr<FontFamily>>;
 
 	FontFamilyMap font_families;

--- a/Source/Core/Geometry.cpp
+++ b/Source/Core/Geometry.cpp
@@ -140,13 +140,13 @@ void Geometry::Render(const Vector2f& translation)
 }
 
 // Returns the geometry's vertices. If these are written to, Release() should be called to force a recompile.
-std::vector< Vertex >& Geometry::GetVertices()
+Vector< Vertex >& Geometry::GetVertices()
 {
 	return vertices;
 }
 
 // Returns the geometry's indices. If these are written to, Release() should be called to force a recompile.
-std::vector< int >& Geometry::GetIndices()
+Vector< int >& Geometry::GetIndices()
 {
 	return indices;
 }

--- a/Source/Core/GeometryDatabase.cpp
+++ b/Source/Core/GeometryDatabase.cpp
@@ -99,9 +99,9 @@ public:
 private:
 	// List of all active geometry, in addition to free slots.
 	// Free slots (as defined by the 'free_list') may contain dangling pointers and must not be dereferenced.
-	std::vector<Geometry*> geometry_list;
+	Vector<Geometry*> geometry_list;
 	// Declares free slots in the 'geometry_list' as indices.
-	std::vector<GeometryDatabaseHandle> free_list;
+	Vector<GeometryDatabaseHandle> free_list;
 };
 
 
@@ -130,7 +130,7 @@ void ReleaseAll()
 
 static class TestGeometryDatabase {
 private:
-	std::vector<Geometry> geometry_list;
+	Vector<Geometry> geometry_list;
 
 	bool list_database_equivalent()
 	{

--- a/Source/Core/GeometryUtilities.cpp
+++ b/Source/Core/GeometryUtilities.cpp
@@ -79,8 +79,8 @@ void GeometryUtilities::GenerateQuad(Vertex* vertices, int* indices, const Vecto
 // Generates the geometry required to render a line above, below or through a line of text.
 void GeometryUtilities::GenerateLine(FontFaceHandle font_face_handle, Geometry* geometry, const Vector2f& position, int width, Style::TextDecoration height, const Colourb& colour)
 {
-	std::vector< Vertex >& line_vertices = geometry->GetVertices();
-	std::vector< int >& line_indices = geometry->GetIndices();
+	Vector< Vertex >& line_vertices = geometry->GetVertices();
+	Vector< int >& line_indices = geometry->GetIndices();
 	float underline_thickness = 0;
 	float underline_position = GetFontEngineInterface()->GetUnderline(font_face_handle, underline_thickness);
 	int size = GetFontEngineInterface()->GetSize(font_face_handle);

--- a/Source/Core/IdNameMap.h
+++ b/Source/Core/IdNameMap.h
@@ -37,7 +37,7 @@ namespace Rml {
 
 template <typename ID>
 class IdNameMap {
-	std::vector<String> name_map;  // IDs are indices into the name_map
+	Vector<String> name_map;  // IDs are indices into the name_map
 	UnorderedMap<String, ID> reverse_map;
 
 protected:

--- a/Source/Core/LayoutBlockBox.h
+++ b/Source/Core/LayoutBlockBox.h
@@ -179,9 +179,9 @@ private:
 	// overflow occured, false if it did.
 	bool CatchVerticalOverflow(float cursor = -1);
 
-	typedef std::vector< AbsoluteElement > AbsoluteElementList;
-	typedef std::vector< LayoutBlockBox* > BlockBoxList;
-	typedef std::vector< LayoutLineBox* > LineBoxList;
+	typedef Vector< AbsoluteElement > AbsoluteElementList;
+	typedef Vector< LayoutBlockBox* > BlockBoxList;
+	typedef Vector< LayoutLineBox* > LineBoxList;
 
 	// The object managing our space, as occupied by floating elements of this box and our ancestors.
 	LayoutBlockBoxSpace* space;

--- a/Source/Core/LayoutBlockBoxSpace.h
+++ b/Source/Core/LayoutBlockBoxSpace.h
@@ -110,7 +110,7 @@ private:
 		Vector2f dimensions;
 	};
 
-	typedef std::vector< SpaceBox > SpaceBoxList;
+	typedef Vector< SpaceBox > SpaceBoxList;
 
 	// Our block-box parent.
 	LayoutBlockBox* parent;

--- a/Source/Core/LayoutInlineBox.h
+++ b/Source/Core/LayoutInlineBox.h
@@ -164,7 +164,7 @@ protected:
 	// This inline box's line.
 	LayoutLineBox* line;
 
-	std::vector< LayoutInlineBox* > children;
+	Vector< LayoutInlineBox* > children;
 
 	// The next link in our element's chain of inline boxes.
 	LayoutInlineBox* chain;

--- a/Source/Core/LayoutLineBox.cpp
+++ b/Source/Core/LayoutLineBox.cpp
@@ -315,7 +315,7 @@ LayoutInlineBox* LayoutLineBox::AddBox(LayoutInlineBox* box)
 // Adds an inline box as a chained hierarchy overflowing to this line.
 void LayoutLineBox::AddChainedBox(LayoutInlineBox* chained_box)
 {
-	std::stack< LayoutInlineBox* > hierarchy;
+	Stack< LayoutInlineBox* > hierarchy;
 	LayoutInlineBox* chain = chained_box;
 	while (chain != nullptr)
 	{

--- a/Source/Core/LayoutLineBox.h
+++ b/Source/Core/LayoutLineBox.h
@@ -97,7 +97,7 @@ private:
 	/// Appends an inline box to the end of the line box's list of inline boxes.
 	void AppendBox(LayoutInlineBox* box);
 
-	typedef std::vector< LayoutInlineBox* > InlineBoxList;
+	typedef Vector< LayoutInlineBox* > InlineBoxList;
 
 	// The block box containing this line.
 	LayoutBlockBox* parent;

--- a/Source/Core/PluginRegistry.cpp
+++ b/Source/Core/PluginRegistry.cpp
@@ -31,7 +31,7 @@
 
 namespace Rml {
 
-typedef std::vector< Plugin* > PluginList;
+typedef Vector< Plugin* > PluginList;
 static PluginList basic_plugins;
 static PluginList document_plugins;
 static PluginList element_plugins;

--- a/Source/Core/PropertiesIterator.h
+++ b/Source/Core/PropertiesIterator.h
@@ -37,7 +37,7 @@ namespace Rml {
 // Note: Modifying the underlying style invalidates the iterator.
 class PropertiesIterator {
 public:
-	using ValueType = std::pair<PropertyId, const Property&>;
+	using ValueType = Pair<PropertyId, const Property&>;
 	using PropertyIt = PropertyMap::const_iterator;
 
 	PropertiesIterator(PropertyIt it_style, PropertyIt it_style_end, PropertyIt it_definition, PropertyIt it_definition_end)

--- a/Source/Core/PropertyParserTransform.cpp
+++ b/Source/Core/PropertyParserTransform.cpp
@@ -54,7 +54,7 @@ bool PropertyParserTransform::ParseValue(Property& property, const String& value
 		return true;
 	}
 
-	TransformPtr transform = std::make_shared<Transform>();
+	TransformPtr transform = MakeShared<Transform>();
 
 	char const* next = value.c_str();
 
@@ -192,7 +192,7 @@ bool PropertyParserTransform::Scan(int& out_bytes_read, const char* str, const c
 	/* use the quicker stack-based argument buffer, if possible */
 	char *arg = 0;
 	char arg_stack[1024];
-	std::string arg_heap;
+	String arg_heap;
 	if (strlen(str) < sizeof(arg_stack))
 	{
 		arg = arg_stack;

--- a/Source/Core/PropertyShorthandDefinition.h
+++ b/Source/Core/PropertyShorthandDefinition.h
@@ -58,7 +58,7 @@ struct ShorthandItem {
 };
 
 // A list of shorthands or properties
-using ShorthandItemList = std::vector< ShorthandItem >;
+using ShorthandItemList = Vector< ShorthandItem >;
 
 struct ShorthandDefinition
 {

--- a/Source/Core/PropertySpecification.cpp
+++ b/Source/Core/PropertySpecification.cpp
@@ -33,16 +33,15 @@
 #include "../../Include/RmlUi/Core/PropertyDictionary.h"
 #include "PropertyShorthandDefinition.h"
 #include "IdNameMap.h"
-#include <array>
 #include <limits.h>
 #include <stdint.h>
 
 namespace Rml {
 
-PropertySpecification::PropertySpecification(size_t reserve_num_properties, size_t reserve_num_shorthands) : 
+PropertySpecification::PropertySpecification(size_t reserve_num_properties, size_t reserve_num_shorthands) :
 	// Increment reserve numbers by one because the 'invalid' property occupies the first element
 	properties(reserve_num_properties + 1), shorthands(reserve_num_shorthands + 1),
-	property_map(std::make_unique<PropertyIdNameMap>(reserve_num_properties + 1)), shorthand_map(std::make_unique<ShorthandIdNameMap>(reserve_num_shorthands + 1))
+	property_map(MakeUnique<PropertyIdNameMap>(reserve_num_properties + 1)), shorthand_map(MakeUnique<ShorthandIdNameMap>(reserve_num_shorthands + 1))
 {
 }
 
@@ -83,7 +82,7 @@ PropertyDefinition& PropertySpecification::RegisterProperty(const String& proper
 	}
 
 	// Create and insert the new property
-	properties[index] = std::make_unique<PropertyDefinition>(id, default_value, inherited, forces_layout);
+	properties[index] = MakeUnique<PropertyDefinition>(id, default_value, inherited, forces_layout);
 	property_ids.Insert(id);
 	if (inherited)
 		property_ids_inherited.Insert(id);
@@ -274,7 +273,7 @@ bool PropertySpecification::ParseShorthandDeclaration(PropertyDictionary& dictio
 		property_values.size() < 4)
 	{
 		// This array tells which property index each side is parsed from
-		std::array<int, 4> box_side_to_value_index = { 0,0,0,0 };
+		Array<int, 4> box_side_to_value_index = { 0,0,0,0 };
 		switch (property_values.size())
 		{
 		case 1:

--- a/Source/Core/Spritesheet.cpp
+++ b/Source/Core/Spritesheet.cpp
@@ -38,7 +38,7 @@ bool SpritesheetList::AddSpriteSheet(const String& name, const String& image_sou
 	Texture texture;
 	texture.Set(image_source, definition_source);
 
-	auto sprite_sheet = std::make_shared<Spritesheet>(name, image_source, definition_source, definition_line_number, texture);
+	auto sprite_sheet = MakeShared<Spritesheet>(name, image_source, definition_source, definition_line_number, texture);
 	auto result = spritesheet_map.emplace(name, sprite_sheet);
 	if (!result.second)
 	{

--- a/Source/Core/StringUtilities.cpp
+++ b/Source/Core/StringUtilities.cpp
@@ -568,7 +568,7 @@ StringView::StringView(const String& string) : p_begin(string.data()), p_end(str
 {}
 StringView::StringView(const String& string, size_t offset) : p_begin(string.data() + offset), p_end(string.data() + string.size())
 {}
-StringView::StringView(const String& string, size_t offset, size_t count) : p_begin(string.data() + offset), p_end(string.data() + std::min(offset + count, string.size()))
+StringView::StringView(const String& string, size_t offset, size_t count) : p_begin(string.data() + offset), p_end(string.data() + std::min<size_t>(offset + count, string.size()))
 {}
 
 bool StringView::operator==(const StringView& other) const { 

--- a/Source/Core/StringUtilities.cpp
+++ b/Source/Core/StringUtilities.cpp
@@ -468,7 +468,7 @@ U16String StringUtilities::ToUTF16(const String& input)
 	if (input.empty())
 		return result;
 
-	std::vector<Character> characters;
+	Vector<Character> characters;
 	characters.reserve(input.size());
 
 	for (auto it = StringIteratorU8(input); it; ++it)
@@ -509,7 +509,7 @@ U16String StringUtilities::ToUTF16(const String& input)
 
 String StringUtilities::ToUTF8(const U16String& input)
 {
-	std::vector<Character> characters;
+	Vector<Character> characters;
 	characters.reserve(input.size());
 
 	bool valid_input = true;

--- a/Source/Core/StyleSheet.cpp
+++ b/Source/Core/StyleSheet.cpp
@@ -41,7 +41,6 @@
 #include "../../Include/RmlUi/Core/StyleSheetSpecification.h"
 #include "../../Include/RmlUi/Core/FontEffectInstancer.h"
 #include <algorithm>
-#include <array>
 
 namespace Rml {
 
@@ -53,7 +52,7 @@ inline static bool StyleSheetNodeSort(const StyleSheetNode* lhs, const StyleShee
 
 StyleSheet::StyleSheet()
 {
-	root = std::make_unique<StyleSheetNode>();
+	root = MakeUnique<StyleSheetNode>();
 	specificity_offset = 0;
 }
 
@@ -73,7 +72,7 @@ SharedPtr<StyleSheet> StyleSheet::CombineStyleSheet(const StyleSheet& other_shee
 {
 	RMLUI_ZoneScoped;
 
-	SharedPtr<StyleSheet> new_sheet = std::make_shared<StyleSheet>();
+	SharedPtr<StyleSheet> new_sheet = MakeShared<StyleSheet>();
 	if (!new_sheet->root->MergeHierarchy(root.get()) ||
 		!new_sheet->root->MergeHierarchy(other_sheet.root.get(), specificity_offset))
 	{
@@ -218,7 +217,7 @@ DecoratorsPtr StyleSheet::InstanceDecoratorsFromString(const String& decorator_s
 		}
 	}
 
-	return std::make_shared<Decorators>(std::move(decorators));
+	return MakeShared<Decorators>(std::move(decorators));
 }
 
 FontEffectsPtr StyleSheet::InstanceFontEffectsFromString(const String& font_effect_string_value, const SharedPtr<const PropertySource>& source) const
@@ -288,7 +287,7 @@ FontEffectsPtr StyleSheet::InstanceFontEffectsFromString(const String& font_effe
 			if (font_effect)
 			{
 				// Create a unique hash value for the given type and values
-				size_t fingerprint = std::hash<String>{}(type);
+				size_t fingerprint = Hash<String>{}(type);
 				for (const auto& id_value : properties.GetProperties())
 					Utilities::HashCombine(fingerprint, id_value.second.Get<String>());
 
@@ -309,14 +308,14 @@ FontEffectsPtr StyleSheet::InstanceFontEffectsFromString(const String& font_effe
 		[](const SharedPtr<const FontEffect>& effect) { return effect->GetLayer() == FontEffect::Layer::Back; }
 	);
 
-	return std::make_shared<FontEffects>(std::move(font_effects));
+	return MakeShared<FontEffects>(std::move(font_effects));
 }
 
 size_t StyleSheet::NodeHash(const String& tag, const String& id)
 {
 	size_t seed = 0;
 	if (!tag.empty())
-		seed = std::hash<String>()(tag);
+		seed = Hash<String>()(tag);
 	if(!id.empty())
 		Utilities::HashCombine(seed, id);
 	return seed;
@@ -329,7 +328,7 @@ SharedPtr<ElementDefinition> StyleSheet::GetElementDefinition(const Element* ele
 
 	// See if there are any styles defined for this element.
 	// Using static to avoid allocations. Make sure we don't call this function recursively.
-	static std::vector< const StyleSheetNode* > applicable_nodes;
+	static Vector< const StyleSheetNode* > applicable_nodes;
 	applicable_nodes.clear();
 
 	const String& tag = element->GetTagName();
@@ -337,7 +336,7 @@ SharedPtr<ElementDefinition> StyleSheet::GetElementDefinition(const Element* ele
 
 	// The styled_node_index is hashed with the tag and id of the RCSS rule. However, we must also check
 	// the rules which don't have them defined, because they apply regardless of tag and id.
-	std::array<size_t, 4> node_hash;
+	Array<size_t, 4> node_hash;
 	int num_hashes = 2;
 
 	node_hash[0] = 0;
@@ -391,7 +390,7 @@ SharedPtr<ElementDefinition> StyleSheet::GetElementDefinition(const Element* ele
 	}
 
 	// Create the new definition and add it to our cache.
-	auto new_definition = std::make_shared<ElementDefinition>(applicable_nodes);
+	auto new_definition = MakeShared<ElementDefinition>(applicable_nodes);
 	node_cache[seed] = new_definition;
 
 	return new_definition;

--- a/Source/Core/StyleSheetFactory.cpp
+++ b/Source/Core/StyleSheetFactory.cpp
@@ -246,10 +246,10 @@ SharedPtr<StyleSheet> StyleSheetFactory::LoadStyleSheet(const String& sheet)
 
 	// Open stream, construct new sheet and pass the stream into the sheet
 	// TODO: Make this support ASYNC
-	auto stream = std::make_unique<StreamFile>();
+	auto stream = MakeUnique<StreamFile>();
 	if (stream->Open(sheet))
 	{
-		new_style_sheet = std::make_shared<StyleSheet>();
+		new_style_sheet = MakeShared<StyleSheet>();
 		if (!new_style_sheet->LoadStyleSheet(stream.get()))
 		{
 			new_style_sheet = nullptr;

--- a/Source/Core/StyleSheetNode.cpp
+++ b/Source/Core/StyleSheetNode.cpp
@@ -62,7 +62,7 @@ StyleSheetNode* StyleSheetNode::GetOrCreateChildNode(const StyleSheetNode& other
 	}
 
 	// We don't, so create a new child
-	auto child = std::make_unique<StyleSheetNode>(this, other.tag, other.id, other.class_names, other.pseudo_class_names, other.structural_selectors, other.child_combinator);
+	auto child = MakeUnique<StyleSheetNode>(this, other.tag, other.id, other.class_names, other.pseudo_class_names, other.structural_selectors, other.child_combinator);
 	StyleSheetNode* result = child.get();
 
 	children.push_back(std::move(child));
@@ -80,7 +80,7 @@ StyleSheetNode* StyleSheetNode::GetOrCreateChildNode(String&& tag, String&& id, 
 	}
 
 	// We don't, so create a new child
-	auto child = std::make_unique<StyleSheetNode>(this, std::move(tag), std::move(id), std::move(classes), std::move(pseudo_classes), std::move(structural_pseudo_classes), child_combinator);
+	auto child = MakeUnique<StyleSheetNode>(this, std::move(tag), std::move(id), std::move(classes), std::move(pseudo_classes), std::move(structural_pseudo_classes), child_combinator);
 	StyleSheetNode* result = child.get();
 
 	children.push_back(std::move(child));

--- a/Source/Core/StyleSheetNode.h
+++ b/Source/Core/StyleSheetNode.h
@@ -47,8 +47,8 @@ struct StructuralSelector {
 inline bool operator==(const StructuralSelector& a, const StructuralSelector& b) { return a.selector == b.selector && a.a == b.a && a.b == b.b; }
 inline bool operator<(const StructuralSelector& a, const StructuralSelector& b) { return std::tie(a.selector, a.a, a.b) < std::tie(b.selector, b.a, b.b); }
 
-using StructuralSelectorList = std::vector< StructuralSelector >;
-using StyleSheetNodeList = std::vector< UniquePtr<StyleSheetNode> >;
+using StructuralSelectorList = Vector< StructuralSelector >;
+using StyleSheetNodeList = Vector< UniquePtr<StyleSheetNode> >;
 
 
 /**

--- a/Source/Core/StyleSheetParser.cpp
+++ b/Source/Core/StyleSheetParser.cpp
@@ -211,7 +211,7 @@ bool StyleSheetParser::ParseKeyframeBlock(KeyframesMap& keyframes_map, const Str
 	StringList rule_list;
 	StringUtilities::ExpandString(rule_list, rules);
 
-	std::vector<float> rule_values;
+	Vector<float> rule_values;
 	rule_values.reserve(rule_list.size());
 
 	for (auto rule : rule_list)
@@ -365,7 +365,7 @@ int StyleSheetParser::Parse(StyleSheetNode* node, Stream* _stream, const StyleSh
 					// Add style nodes to the root of the tree
 					for (size_t i = 0; i < rule_name_list.size(); i++)
 					{
-						auto source = std::make_shared<PropertySource>(stream_file_name, rule_line_number, rule_name_list[i]);
+						auto source = MakeShared<PropertySource>(stream_file_name, rule_line_number, rule_name_list[i]);
 						properties.SetSourceOfAllProperties(source);
 						ImportProperties(node, rule_name_list[i], properties, rule_count);
 					}
@@ -395,7 +395,7 @@ int StyleSheetParser::Parse(StyleSheetNode* node, Stream* _stream, const StyleSh
 					}
 					else if (at_rule_identifier == "decorator")
 					{
-						auto source = std::make_shared<PropertySource>(stream_file_name, (int)line_number, pre_token_str);
+						auto source = MakeShared<PropertySource>(stream_file_name, (int)line_number, pre_token_str);
 						ParseDecoratorBlock(at_rule_name, decorator_map, style_sheet, source);
 						
 						at_rule_name.clear();

--- a/Source/Core/Template.cpp
+++ b/Source/Core/Template.cpp
@@ -93,7 +93,7 @@ bool Template::Load(Stream* stream)
 	}
 
 	// Create a stream around the header, parse it and store it
-	auto header_stream = std::make_unique<StreamMemory>((const byte*) head_start,head_end - head_start);
+	auto header_stream = MakeUnique<StreamMemory>((const byte*) head_start,head_end - head_start);
 	header_stream->SetSourceURL(stream->GetSourceURL());
 
 	XMLParser parser(nullptr);
@@ -104,7 +104,7 @@ bool Template::Load(Stream* stream)
 	header = *parser.GetDocumentHeader();
 
 	// Store the body in stream form
-	body = std::make_unique<StreamMemory>(body_end - body_start);	
+	body = MakeUnique<StreamMemory>(body_end - body_start);	
 	body->SetSourceURL(stream->GetSourceURL());
 	body->PushBack(body_start, body_end - body_start);
 

--- a/Source/Core/TemplateCache.cpp
+++ b/Source/Core/TemplateCache.cpp
@@ -72,7 +72,7 @@ Template* TemplateCache::LoadTemplate(const String& name)
 
 	// Nope, we better load it
 	Template* new_template = nullptr;
-	auto stream = std::make_unique<StreamFile>();
+	auto stream = MakeUnique<StreamFile>();
 	if (stream->Open(name))
 	{
 		new_template = new Template();

--- a/Source/Core/Texture.cpp
+++ b/Source/Core/Texture.cpp
@@ -40,7 +40,7 @@ void Texture::Set(const String& source, const String& source_path)
 
 void Texture::Set(const String& name, const TextureCallback& callback)
 {
-	resource = std::make_shared<TextureResource>();
+	resource = MakeShared<TextureResource>();
 	resource->Set(name, callback);
 }
 

--- a/Source/Core/TextureDatabase.cpp
+++ b/Source/Core/TextureDatabase.cpp
@@ -74,7 +74,7 @@ SharedPtr<TextureResource> TextureDatabase::Fetch(const String& source, const St
 		return iterator->second;
 	}
 
-	auto resource = std::make_shared<TextureResource>();
+	auto resource = MakeShared<TextureResource>();
 	resource->Set(path);
 
 	texture_database->textures[resource->GetSource()] = resource;

--- a/Source/Core/TextureLayout.h
+++ b/Source/Core/TextureLayout.h
@@ -75,8 +75,8 @@ public:
 	bool GenerateLayout(int max_texture_dimensions);
 
 private:
-	using RectangleList = std::vector< TextureLayoutRectangle >;
-	using TextureList = std::vector< TextureLayoutTexture >;
+	using RectangleList = Vector< TextureLayoutRectangle >;
+	using TextureList = Vector< TextureLayoutTexture >;
 
 	TextureList textures;
 	RectangleList rectangles;

--- a/Source/Core/TextureLayoutRow.h
+++ b/Source/Core/TextureLayoutRow.h
@@ -67,7 +67,7 @@ public:
 	void Unplace();
 
 private:
-	using RectangleList = std::vector< TextureLayoutRectangle* >;
+	using RectangleList = Vector< TextureLayoutRectangle* >;
 
 	int height;
 	RectangleList rectangles;

--- a/Source/Core/TextureLayoutTexture.h
+++ b/Source/Core/TextureLayoutTexture.h
@@ -66,7 +66,7 @@ public:
 	UniquePtr<byte[]> AllocateTexture();
 
 private:
-	using RowList = std::vector< TextureLayoutRow >;
+	using RowList = Vector< TextureLayoutRow >;
 
 	Vector2i dimensions;
 	RowList rows;

--- a/Source/Core/TextureResource.cpp
+++ b/Source/Core/TextureResource.cpp
@@ -53,7 +53,7 @@ void TextureResource::Set(const String& name, const TextureCallback& callback)
 {
 	Reset();
 	source = name;
-	texture_callback = std::make_unique<TextureCallback>(callback);
+	texture_callback = MakeUnique<TextureCallback>(callback);
 	TextureDatabase::AddCallbackTexture(this);
 }
 

--- a/Source/Core/TextureResource.h
+++ b/Source/Core/TextureResource.h
@@ -74,7 +74,7 @@ private:
 
 	String source;
 
-	using TextureData = std::pair< TextureHandle, Vector2i >;
+	using TextureData = Pair< TextureHandle, Vector2i >;
 	using TextureDataMap = SmallUnorderedMap< RenderInterface*, TextureData >;
 	TextureDataMap texture_data;
 

--- a/Source/Core/TransformPrimitive.cpp
+++ b/Source/Core/TransformPrimitive.cpp
@@ -79,21 +79,21 @@ inline ResolvedPrimitive<N>::ResolvedPrimitive(const NumericValue* values) noexc
 }
 
 template<size_t N>
-inline ResolvedPrimitive<N>::ResolvedPrimitive(const NumericValue* values, std::array<Property::Unit, N> base_units) noexcept
+inline ResolvedPrimitive<N>::ResolvedPrimitive(const NumericValue* values, Array<Property::Unit, N> base_units) noexcept
 {
 	for (size_t i = 0; i < N; ++i)
 		this->values[i] = ResolvePrimitiveAbsoluteValue(values[i], base_units[i]);
 }
 
 template<size_t N>
-inline ResolvedPrimitive<N>::ResolvedPrimitive(std::array<NumericValue, N> values, std::array<Property::Unit, N> base_units) noexcept
+inline ResolvedPrimitive<N>::ResolvedPrimitive(Array<NumericValue, N> values, Array<Property::Unit, N> base_units) noexcept
 {
 	for (size_t i = 0; i < N; ++i)
 		this->values[i] = ResolvePrimitiveAbsoluteValue(values[i], base_units[i]);
 }
 
 template<size_t N>
-inline ResolvedPrimitive<N>::ResolvedPrimitive(std::array<float, N> values) noexcept : values(values) { }
+inline ResolvedPrimitive<N>::ResolvedPrimitive(Array<float, N> values) noexcept : values(values) { }
 
 template<size_t N>
 inline UnresolvedPrimitive<N>::UnresolvedPrimitive(const NumericValue* values) noexcept
@@ -103,7 +103,7 @@ inline UnresolvedPrimitive<N>::UnresolvedPrimitive(const NumericValue* values) n
 }
 
 template<size_t N>
-inline UnresolvedPrimitive<N>::UnresolvedPrimitive(std::array<NumericValue, N> values) noexcept : values(values) { }
+inline UnresolvedPrimitive<N>::UnresolvedPrimitive(Array<NumericValue, N> values) noexcept : values(values) { }
 
 
 Matrix2D::Matrix2D(const NumericValue* values) noexcept : ResolvedPrimitive(values) { }

--- a/Source/Core/Tween.cpp
+++ b/Source/Core/Tween.cpp
@@ -28,7 +28,6 @@
 
 #include "../../Include/RmlUi/Core/Tween.h"
 #include "../../Include/RmlUi/Core/Math.h"
-#include <array>
 #include <utility>
 
 namespace Rml {
@@ -153,7 +152,7 @@ bool Tween::operator!=(const Tween& other) const
 
 String Tween::to_string() const
 {
-	static const std::array<String, size_t(Count)> type_str = { { "none", "back", "bounce", "circular", "cubic", "elastic", "exponential", "linear", "quadratic", "quartic", "quintic", "sine", "callback" } };
+	static const Array<String, size_t(Count)> type_str = { { "none", "back", "bounce", "circular", "cubic", "elastic", "exponential", "linear", "quadratic", "quartic", "quintic", "sine", "callback" } };
 
 	if (size_t(type_in) < type_str.size() && size_t(type_out) < type_str.size())
 	{

--- a/Source/Core/Utilities.h
+++ b/Source/Core/Utilities.h
@@ -36,7 +36,7 @@ namespace Utilities {
 template <class T>
 inline void HashCombine(std::size_t& seed, const T& v)
 {
-	std::hash<T> hasher;
+	Hash<T> hasher;
 	seed ^= hasher(v) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
 }
 

--- a/Source/Core/XMLParser.cpp
+++ b/Source/Core/XMLParser.cpp
@@ -56,7 +56,7 @@ XMLParser::XMLParser(Element* root)
 
 	active_handler = nullptr;
 
-	header = std::make_unique<DocumentHeader>();
+	header = MakeUnique<DocumentHeader>();
 }
 
 XMLParser::~XMLParser()

--- a/Source/Debugger/DebuggerPlugin.cpp
+++ b/Source/Debugger/DebuggerPlugin.cpp
@@ -90,7 +90,7 @@ bool DebuggerPlugin::Initialise(Context* context)
 		return false;
 	}
 
-	hook_element_instancer = std::make_unique< ElementInstancerGeneric<ElementContextHook> >();
+	hook_element_instancer = MakeUnique< ElementInstancerGeneric<ElementContextHook> >();
 	Factory::RegisterElementInstancer("debug-hook", hook_element_instancer.get());
 
 	return true;
@@ -173,7 +173,7 @@ void DebuggerPlugin::Render()
 			if (document->GetId().find("rmlui-debug-") == 0)
 				continue;
 
-			std::stack< Element* > element_stack;
+			Stack< Element* > element_stack;
 			element_stack.push(document);
 
 			while (!element_stack.empty())
@@ -325,7 +325,7 @@ bool DebuggerPlugin::LoadMenuElement()
 
 bool DebuggerPlugin::LoadInfoElement()
 {
-	info_element_instancer = std::make_unique< ElementInstancerGeneric<ElementInfo> >();
+	info_element_instancer = MakeUnique< ElementInstancerGeneric<ElementInfo> >();
 	Factory::RegisterElementInstancer("debug-info", info_element_instancer.get());
 	info_element = rmlui_dynamic_cast< ElementInfo* >(host_context->CreateDocument("debug-info"));
 	if (!info_element)
@@ -346,7 +346,7 @@ bool DebuggerPlugin::LoadInfoElement()
 
 bool DebuggerPlugin::LoadLogElement()
 {
-	log_element_instancer = std::make_unique< ElementInstancerGeneric<ElementLog> >();
+	log_element_instancer = MakeUnique< ElementInstancerGeneric<ElementLog> >();
 	Factory::RegisterElementInstancer("debug-log", log_element_instancer.get());
 	log_element = rmlui_dynamic_cast< ElementLog* >(host_context->CreateDocument("debug-log"));
 	if (!log_element)
@@ -364,7 +364,7 @@ bool DebuggerPlugin::LoadLogElement()
 
 	// Make the system interface; this will trap the log messages for us.
 	application_interface = Rml::GetSystemInterface();
-	log_interface = std::make_unique<DebuggerSystemInterface>(application_interface, log_element);
+	log_interface = MakeUnique<DebuggerSystemInterface>(application_interface, log_element);
 	Rml::SetSystemInterface(log_interface.get());
 
 	return true;

--- a/Source/Debugger/DebuggerPlugin.h
+++ b/Source/Debugger/DebuggerPlugin.h
@@ -116,9 +116,9 @@ private:
 	ElementContextHook* hook_element;
 
 	Rml::SystemInterface* application_interface;
-	std::unique_ptr<DebuggerSystemInterface> log_interface;
+	UniquePtr<DebuggerSystemInterface> log_interface;
 
-	std::unique_ptr<ElementInstancer> hook_element_instancer, info_element_instancer, log_element_instancer;
+	UniquePtr<ElementInstancer> hook_element_instancer, info_element_instancer, log_element_instancer;
 
 	bool render_outlines;
 

--- a/Source/Debugger/ElementInfo.h
+++ b/Source/Debugger/ElementInfo.h
@@ -35,8 +35,8 @@
 namespace Rml {
 namespace Debugger {
 
-typedef std::pair< String, const Property* > NamedProperty;
-typedef std::vector< NamedProperty > NamedPropertyList;
+typedef Pair< String, const Property* > NamedProperty;
+typedef Vector< NamedProperty > NamedPropertyList;
 
 /**
 	@author Robert Curry


### PR DESCRIPTION
This is an implementation of my ideas raised in #107. Please review and comment.

It was nice to find out that lua integration did not require any changes whatsoever. Yay!

Few unrelated observations:
* Project should adopt `.editorconfig`. I had to restore bunch of trailing spaces to avoid extra noise in commits. Editor was eager to get rid of them. This would also configure editors to use tabs.
* Project should adopt `.gitattributes` and normalize line endings. Most files use `\n` while some use `\r\n`. This puts us in a position where one line change may flag entire file as changed only because editor changed line endings.
* Changes to `CMakeLists.txt` are not proper, but then again entire build script is in a state where it just can not be fixed, but should be rewritten instead. I might do it in the future (no promises).
