### PR TITLE
Add ability to change the default base tag in documents

### DIFF
--- a/Include/RmlUi/Core/Context.h
+++ b/Include/RmlUi/Core/Context.h
@@ -88,10 +88,9 @@ public:
 	bool Render();
 
 	/// Creates a new, empty document and places it into this context.
-	/// @param[in] tag The document type to create.
+	/// @param[in] instancer_name The name of the instancer used to create the document.
 	/// @return The new document, or nullptr if no document could be created.
-	// FIXME - tag parameter should be named instancer_name, it references to instancer_name in InstanceElement(), not the tag name.
-	ElementDocument* CreateDocument(const String& tag = "body");
+	ElementDocument* CreateDocument(const String& instancer_name = "body");
 	/// Load a document into the context.
 	/// @param[in] document_path The path to the document to load.
 	/// @return The loaded document, or nullptr if no document was loaded.
@@ -246,7 +245,7 @@ public:
 
 	/// Gets the name of the documents base tag.
 	/// @return The current documents base tag name.
-	String GetDocumentsBaseTag();
+	const String& GetDocumentsBaseTag();
 
 protected:
 	void Release() override;

--- a/Include/RmlUi/Core/Context.h
+++ b/Include/RmlUi/Core/Context.h
@@ -90,6 +90,7 @@ public:
 	/// Creates a new, empty document and places it into this context.
 	/// @param[in] tag The document type to create.
 	/// @return The new document, or nullptr if no document could be created.
+	// FIXME - tag parameter should be named instancer_name, it references to instancer_name in InstanceElement(), not the tag name.
 	ElementDocument* CreateDocument(const String& tag = "body");
 	/// Load a document into the context.
 	/// @param[in] document_path The path to the document to load.
@@ -239,6 +240,14 @@ public:
 	/// @return True if succesfully removed, false if no data model was found.
 	bool RemoveDataModel(const String& name);
 
+	/// This will set the documents base <tag> before creation. Default = "body"
+	/// @param[in] tag The name of the base tag. Example: "html"
+	void SetDocumentsBaseTag(const String& tag);
+
+	/// Gets the name of the documents base tag.
+	/// @return The current documents base tag name.
+	String GetDocumentsBaseTag();
+
 protected:
 	void Release() override;
 
@@ -246,6 +255,7 @@ private:
 	String name;
 	Vector2i dimensions;
 	float density_independent_pixel_ratio;
+	String documents_base_tag = "body";
 
 	ContextInstancer* instancer;
 

--- a/Source/Core/Context.cpp
+++ b/Source/Core/Context.cpp
@@ -63,7 +63,7 @@ Context::Context(const String& name) : name(name), dimensions(0, 0), density_ind
 	root->SetOffset(Vector2f(0, 0), nullptr);
 	root->SetProperty(PropertyId::ZIndex, Property(0, Property::NUMBER));
 
-	cursor_proxy = Factory::InstanceElement(nullptr, "body", "body", XMLAttributes());
+	cursor_proxy = Factory::InstanceElement(nullptr, documents_base_tag, documents_base_tag, XMLAttributes());
 	ElementDocument* cursor_proxy_document = rmlui_dynamic_cast< ElementDocument* >(cursor_proxy.get());
 	if (cursor_proxy_document)
 		cursor_proxy_document->context = this;
@@ -214,10 +214,11 @@ bool Context::Render()
 	return true;
 }
 
-// Creates a new, empty document and places it into this context.
+// FIXME - tag parameter should be named instancer_name, it references to instancer_name in InstanceElement(), not the tag name.
+// Creates a new, empty document and places it into this context. 
 ElementDocument* Context::CreateDocument(const String& tag)
 {
-	ElementPtr element = Factory::InstanceElement(nullptr, tag, "body", XMLAttributes());
+	ElementPtr element = Factory::InstanceElement(nullptr, tag, documents_base_tag, XMLAttributes());
 	if (!element)
 	{
 		Log::Message(Log::LT_ERROR, "Failed to instance document on tag '%s', instancer returned nullptr.", tag.c_str());
@@ -1296,6 +1297,16 @@ void Context::Release()
 	{
 		instancer->ReleaseContext(this);
 	}
+}
+
+void Context::SetDocumentsBaseTag(const String& tag)
+{
+	documents_base_tag = tag;
+}
+
+String Context::GetDocumentsBaseTag()
+{
+	return documents_base_tag;
 }
 
 } // namespace Rml

--- a/Source/Core/Context.cpp
+++ b/Source/Core/Context.cpp
@@ -214,21 +214,20 @@ bool Context::Render()
 	return true;
 }
 
-// FIXME - tag parameter should be named instancer_name, it references to instancer_name in InstanceElement(), not the tag name.
 // Creates a new, empty document and places it into this context. 
-ElementDocument* Context::CreateDocument(const String& tag)
+ElementDocument* Context::CreateDocument(const String& instancer_name)
 {
-	ElementPtr element = Factory::InstanceElement(nullptr, tag, documents_base_tag, XMLAttributes());
+	ElementPtr element = Factory::InstanceElement(nullptr, instancer_name, documents_base_tag, XMLAttributes());
 	if (!element)
 	{
-		Log::Message(Log::LT_ERROR, "Failed to instance document on tag '%s', instancer returned nullptr.", tag.c_str());
+		Log::Message(Log::LT_ERROR, "Failed to instance document on instancer_name '%s', instancer returned nullptr.", instancer_name.c_str());
 		return nullptr;
 	}
 
 	ElementDocument* document = rmlui_dynamic_cast< ElementDocument* >(element.get());
 	if (!document)
 	{
-		Log::Message(Log::LT_ERROR, "Failed to instance document on tag '%s', Found type '%s', was expecting derivative of ElementDocument.", tag.c_str(), rmlui_type_name(*element));
+		Log::Message(Log::LT_ERROR, "Failed to instance document on instancer_name '%s', Found type '%s', was expecting derivative of ElementDocument.", instancer_name.c_str(), rmlui_type_name(*element));
 		return nullptr;
 	}
 
@@ -1304,7 +1303,7 @@ void Context::SetDocumentsBaseTag(const String& tag)
 	documents_base_tag = tag;
 }
 
-String Context::GetDocumentsBaseTag()
+const String& Context::GetDocumentsBaseTag()
 {
 	return documents_base_tag;
 }

--- a/Source/Core/Factory.cpp
+++ b/Source/Core/Factory.cpp
@@ -467,6 +467,7 @@ bool Factory::InstanceElementStream(Element* parent, Stream* stream)
 ElementPtr Factory::InstanceDocumentStream(Context* context, Stream* stream)
 {
 	RMLUI_ZoneScoped;
+	RMLUI_ASSERT(context);
 
 	ElementPtr element = Factory::InstanceElement(nullptr, context->GetDocumentsBaseTag(), context->GetDocumentsBaseTag(), XMLAttributes());
 	if (!element)

--- a/Source/Core/Factory.cpp
+++ b/Source/Core/Factory.cpp
@@ -410,9 +410,12 @@ bool Factory::InstanceElementText(Element* parent, const String& in_text)
 	{
 		RMLUI_ZoneScopedNC("InstanceStream", 0xDC143C);
 		auto stream = std::make_unique<StreamMemory>(text.size() + 32);
-		stream->Write("<body>", 6);
+		String tag = parent->GetContext()->GetDocumentsBaseTag();
+		String open_tag = "<" + tag + ">";
+		String close_tag = "</" + tag + ">";
+		stream->Write(open_tag.c_str(), open_tag.size());
 		stream->Write(text);
-		stream->Write("</body>", 7);
+		stream->Write(close_tag.c_str(), close_tag.size());
 		stream->Seek(0, SEEK_SET);
 
 		InstanceElementStream(parent, stream.get());
@@ -465,7 +468,7 @@ ElementPtr Factory::InstanceDocumentStream(Context* context, Stream* stream)
 {
 	RMLUI_ZoneScoped;
 
-	ElementPtr element = Factory::InstanceElement(nullptr, "body", "body", XMLAttributes());
+	ElementPtr element = Factory::InstanceElement(nullptr, context->GetDocumentsBaseTag(), context->GetDocumentsBaseTag(), XMLAttributes());
 	if (!element)
 	{
 		Log::Message(Log::LT_ERROR, "Failed to instance document, instancer returned nullptr.");

--- a/Source/Core/XMLNodeHandlerBody.cpp
+++ b/Source/Core/XMLNodeHandlerBody.cpp
@@ -45,7 +45,6 @@ XMLNodeHandlerBody::~XMLNodeHandlerBody()
 Element* XMLNodeHandlerBody::ElementStart(XMLParser* parser, const String& RMLUI_UNUSED_ASSERT_PARAMETER(name), const XMLAttributes& attributes)
 {
 	RMLUI_UNUSED_ASSERT(name);
-	RMLUI_ASSERT(name == "body");
 
 	Element* element = parser->GetParseFrame()->element;
 

--- a/Source/Debugger/MenuSource.h
+++ b/Source/Debugger/MenuSource.h
@@ -89,5 +89,5 @@ static const char* menu_rml = R"RML(
 	<button id="event-log-button">Event Log</button>
 	<button id="debug-info-button">Element Info</button>
 	<button id="outlines-button">Outlines</button>
-</div>;
+</div>
 )RML";


### PR DESCRIPTION
Currently, RmlUi hard codes `<body>` as the default base tag in documents.
This change allows the user to set the default base tag when creating documents.

**Added functions:**
```
/// This will set the documents base <tag> before creation. Default = "body"
/// @param[in] tag The name of the base tag. Example: "html"
void SetDocumentsBaseTag(const String& tag);

/// Gets the name of the documents base tag.
/// @return The current documents base tag name.
const String& GetDocumentsBaseTag();
```
