### PR TITLE
Allow user to include a file via RMLUI_*_USER_EXTRA macros.

### DIFF
--- a/Include/RmlUi/Core/Colour.h
+++ b/Include/RmlUi/Core/Colour.h
@@ -111,7 +111,11 @@ public:
 	ColourType red, green, blue, alpha;
 
 #ifdef RMLUI_COLOUR_USER_EXTRA
-	RMLUI_COLOUR_USER_EXTRA
+	#if defined(__has_include) && __has_include(RMLUI_COLOUR_USER_EXTRA)
+		#include RMLUI_COLOUR_USER_EXTRA
+	#else
+		RMLUI_COLOUR_USER_EXTRA
+	#endif
 #endif
 };
 

--- a/Include/RmlUi/Core/Matrix4.h
+++ b/Include/RmlUi/Core/Matrix4.h
@@ -500,7 +500,11 @@ class Matrix4
 			const Vector3< Component >& skew, const Vector4< Component >& perspective, const Vector4< Component >& quaternion) noexcept;
 
 #ifdef RMLUI_MATRIX4_USER_EXTRA
+	#if defined(__has_include) && __has_include(RMLUI_MATRIX4_USER_EXTRA)
+		#include RMLUI_MATRIX4_USER_EXTRA
+	#else
 		RMLUI_MATRIX4_USER_EXTRA
+	#endif
 #endif
 };
 

--- a/Include/RmlUi/Core/Vector2.h
+++ b/Include/RmlUi/Core/Vector2.h
@@ -149,7 +149,11 @@ class Vector2
 		Type y;
 
 #ifdef RMLUI_VECTOR2_USER_EXTRA
+	#if defined(__has_include) && __has_include(RMLUI_VECTOR2_USER_EXTRA)
+		#include RMLUI_VECTOR2_USER_EXTRA
+	#else
 		RMLUI_VECTOR2_USER_EXTRA
+	#endif
 #endif
 };
 

--- a/Include/RmlUi/Core/Vector3.h
+++ b/Include/RmlUi/Core/Vector3.h
@@ -135,7 +135,11 @@ class Vector3
 		Type z;
 
 #ifdef RMLUI_VECTOR3_USER_EXTRA
+	#if defined(__has_include) && __has_include(RMLUI_VECTOR3_USER_EXTRA)
+		#include RMLUI_VECTOR3_USER_EXTRA
+	#else
 		RMLUI_VECTOR3_USER_EXTRA
+	#endif
 #endif
 };
 

--- a/Include/RmlUi/Core/Vector4.h
+++ b/Include/RmlUi/Core/Vector4.h
@@ -140,7 +140,11 @@ class Vector4
 		Type w;
 
 #ifdef RMLUI_VECTOR4_USER_EXTRA
+	#if defined(__has_include) && __has_include(RMLUI_VECTOR4_USER_EXTRA)
+		#include RMLUI_VECTOR4_USER_EXTRA
+	#else
 		RMLUI_VECTOR4_USER_EXTRA
+	#endif
 #endif
 };
 


### PR DESCRIPTION
This change allows user to `#define RMLUI_VECTOR2_USER_EXTRA "Vector2.inl"` and have it included instead of pasting extra operators through preprocessor macro. `__has_include` is standard since C++17, but at least gcc/clang supported it even before. I do realize this is not a perfect solution if people are stuck with C++11, but it is something.

This change was prompted by a compiler bug which prevented me from defining required operators via preprocessor macro:  https://developercommunity.visualstudio.com/content/problem/1201396/sfinae-erorneously-discards-operator-when-too-much.html