### PR TITLE
Add optional name for LoadDocumentFromMemory()

### DIFF
--- a/Include/RmlUi/Core/Context.h
+++ b/Include/RmlUi/Core/Context.h
@@ -103,7 +103,7 @@ public:
 	/// @param[in] string The string containing the document RML.
 	/// @param[in] string Optional string used to name the document - mainly for Log Messages.
 	/// @return The loaded document, or nullptr if no document was loaded.
-	ElementDocument* LoadDocumentFromMemory(const String& string, const String* document_name = nullptr);
+	ElementDocument* LoadDocumentFromMemory(const String& string, const String& source_url = "[document from memory]");
 	/// Unload the given document.
 	/// @param[in] document The document to unload.
 	void UnloadDocument(ElementDocument* document);

--- a/Include/RmlUi/Core/Context.h
+++ b/Include/RmlUi/Core/Context.h
@@ -101,8 +101,9 @@ public:
 	ElementDocument* LoadDocument(Stream* document_stream);
 	/// Load a document into the context.
 	/// @param[in] string The string containing the document RML.
+	/// @param[in] string Optional string used to name the document - mainly for Log Messages.
 	/// @return The loaded document, or nullptr if no document was loaded.
-	ElementDocument* LoadDocumentFromMemory(const String& string);
+	ElementDocument* LoadDocumentFromMemory(const String& string, const String* document_name = nullptr);
 	/// Unload the given document.
 	/// @param[in] document The document to unload.
 	void UnloadDocument(ElementDocument* document);

--- a/Source/Core/Context.cpp
+++ b/Source/Core/Context.cpp
@@ -279,11 +279,15 @@ ElementDocument* Context::LoadDocument(Stream* stream)
 }
 
 // Load a document into the context.
-ElementDocument* Context::LoadDocumentFromMemory(const String& string)
+ElementDocument* Context::LoadDocumentFromMemory(const String& string, const String* document_name)
 {
 	// Open the stream based on the string contents.
 	auto stream = MakeUnique<StreamMemory>((byte*)string.c_str(), string.size());
-	stream->SetSourceURL("[document from memory]");
+
+	if (document_name)
+	    stream->SetSourceURL( document_name->c_str() );
+    else
+	    stream->SetSourceURL("[document from memory]");
 
 	// Load the document from the stream.
 	ElementDocument* document = LoadDocument(stream.get());

--- a/Source/Core/Context.cpp
+++ b/Source/Core/Context.cpp
@@ -279,15 +279,12 @@ ElementDocument* Context::LoadDocument(Stream* stream)
 }
 
 // Load a document into the context.
-ElementDocument* Context::LoadDocumentFromMemory(const String& string, const String* document_name)
+ElementDocument* Context::LoadDocumentFromMemory(const String& string, const String& source_url)
 {
 	// Open the stream based on the string contents.
 	auto stream = MakeUnique<StreamMemory>((byte*)string.c_str(), string.size());
 
-	if (document_name)
-	    stream->SetSourceURL( document_name->c_str() );
-    else
-	    stream->SetSourceURL("[document from memory]");
+	stream->SetSourceURL( source_url.c_str() );
 
 	// Load the document from the stream.
 	ElementDocument* document = LoadDocument(stream.get());


### PR DESCRIPTION
Hi, I add my documents via memory and sometimes it's hard to tell which one has an error.

I thought about maybe printing the lines next to the error, but being able to add a custom name seems better.

Let me know what you think.