### PR TITLE
Use standard pairs/ipairs implementation

### DIFF
--- a/Source/Core/Core.cpp
+++ b/Source/Core/Core.cpp
@@ -285,9 +285,9 @@ Context* GetContext(int index)
 {
 	ContextMap::iterator i = contexts.begin();
 	int count = 0;
-
-	if (index >= GetNumContexts())
-		index = GetNumContexts() - 1;
+	
+	if (index < 0 || index >= GetNumContexts())
+		return nullptr;
 
 	while (count < index)
 	{

--- a/Source/Lua/ContextDocumentsProxy.cpp
+++ b/Source/Lua/ContextDocumentsProxy.cpp
@@ -51,7 +51,7 @@ int ContextDocumentsProxy__index(lua_State* L)
         if(type == LUA_TSTRING)
             ret = proxy->owner->GetDocument(luaL_checkstring(L,2));
         else
-            ret = proxy->owner->GetDocument((int)luaL_checkinteger(L,2));
+            ret = proxy->owner->GetDocument((int)luaL_checkinteger(L,2)-1);
         LuaType<Document>::push(L,ret,false);
         return 1;
     }

--- a/Source/Lua/ContextDocumentsProxy.cpp
+++ b/Source/Lua/ContextDocumentsProxy.cpp
@@ -38,8 +38,6 @@ template<> void ExtraInit<ContextDocumentsProxy>(lua_State* L, int metatable_ind
     lua_setfield(L,metatable_index,"__index");
     lua_pushcfunction(L,ContextDocumentsProxy__pairs);
     lua_setfield(L,metatable_index,"__pairs");
-    lua_pushcfunction(L,ContextDocumentsProxy__ipairs);
-    lua_setfield(L,metatable_index,"__ipairs");
 }
 
 int ContextDocumentsProxy__index(lua_State* L)
@@ -62,74 +60,64 @@ int ContextDocumentsProxy__index(lua_State* L)
     
 }
 
-//[1] is the object, [2] is the last used key, [3] is the userdata
-int ContextDocumentsProxy__pairs(lua_State* L)
+struct ContextDocumentsProxyPairs
 {
-    Document* doc = nullptr;
-    ContextDocumentsProxy* obj = LuaType<ContextDocumentsProxy>::check(L,1);
-    RMLUI_CHECK_OBJ(obj);
-    int* pindex = (int*)lua_touserdata(L,3);
-    if((*pindex) == -1)
-        *pindex = 0;
-
-    int num_docs = obj->owner->GetNumDocuments();
-    //because there can be missing indexes, make sure to continue until there
-    //is actually a document at the index
-    while((*pindex) < num_docs)
+    static int next(lua_State* L) 
     {
-        doc = obj->owner->GetDocument((*pindex)++);
-        if(doc != nullptr)
-            break;
-    }
-
-    //If we found a document 
-    if(doc != nullptr)
-    {
+        ContextDocumentsProxy* obj = LuaType<ContextDocumentsProxy>::check(L,1);
+        ContextDocumentsProxyPairs* self = static_cast<ContextDocumentsProxyPairs*>(lua_touserdata(L, lua_upvalueindex(1)));
+        Document* doc = nullptr;
+        int num_docs = obj->owner->GetNumDocuments();
+        //because there can be missing indexes, make sure to continue until there
+        //is actually a document at the index
+        while (self->m_cur < num_docs)
+        {
+            doc = obj->owner->GetDocument(self->m_cur++);
+            if (doc != nullptr)
+                break;
+        }
+        if (doc == nullptr)
+        {
+            return 0;
+        }
         lua_pushstring(L,doc->GetId().c_str());
         LuaType<Document>::push(L,doc);
+        return 2;
     }
-    else //if we were at the end and didn't find a document
+    static int destroy(lua_State* L)
     {
-        lua_pushnil(L);
-        lua_pushnil(L);
+        static_cast<ContextDocumentsProxyPairs*>(lua_touserdata(L, 1))->~ContextDocumentsProxyPairs();
+        return 0;
     }
-    return 2;
-}
+    static int constructor(lua_State* L)
+    {
+        void* storage = lua_newuserdata(L, sizeof(ContextDocumentsProxyPairs));
+        if (luaL_newmetatable(L, "RmlUi::Lua::ContextDocumentsProxyPairs"))
+        {
+            static luaL_Reg mt[] =
+            {
+                {"__gc", destroy},
+                {NULL, NULL},
+            };
+            luaL_setfuncs(L, mt, 0);
+        }
+        lua_setmetatable(L, -2);
+        lua_pushcclosure(L, next, 1);
+        new (storage) ContextDocumentsProxyPairs();
+        return 1;
+    }
+    ContextDocumentsProxyPairs()
+        : m_cur(0)
+    { }
+    int m_cur;
+};
 
-//same as __pairs, but putting an integer key instead of a string key
-int ContextDocumentsProxy__ipairs(lua_State* L)
+int ContextDocumentsProxy__pairs(lua_State* L)
 {
-    Document* doc = nullptr;
-    ContextDocumentsProxy* obj = LuaType<ContextDocumentsProxy>::check(L,1);
-    RMLUI_CHECK_OBJ(obj);
-    int* pindex = (int*)lua_touserdata(L,3);
-    if((*pindex) == -1)
-        *pindex = 0;
-
-    int num_docs = obj->owner->GetNumDocuments();
-    //because there can be missing indexes, make sure to continue until there
-    //is actually a document at the index
-    while((*pindex) < num_docs)
-    {
-        doc = obj->owner->GetDocument((*pindex)++);
-        if(doc != nullptr)
-            break;
-    }
-
-    //we found a document
-    if(doc != nullptr)
-    {
-        lua_pushinteger(L,(*pindex)-1);
-        LuaType<Document>::push(L,doc);
-    }
-    else //we got to the end and didn't find another document
-    {
-        lua_pushnil(L);
-        lua_pushnil(L);
-    }
+    ContextDocumentsProxyPairs::constructor(L);
+    lua_pushvalue(L, 1);
     return 2;
 }
-
 
 RegType<ContextDocumentsProxy> ContextDocumentsProxyMethods[] =
 {

--- a/Source/Lua/ContextDocumentsProxy.h
+++ b/Source/Lua/ContextDocumentsProxy.h
@@ -41,7 +41,6 @@ struct ContextDocumentsProxy { Context* owner;  };
 template<> void ExtraInit<ContextDocumentsProxy>(lua_State* L, int metatable_index);
 int ContextDocumentsProxy__index(lua_State* L);
 int ContextDocumentsProxy__pairs(lua_State* L);
-int ContextDocumentsProxy__ipairs(lua_State* L);
 
 extern RegType<ContextDocumentsProxy> ContextDocumentsProxyMethods[];
 extern luaL_Reg ContextDocumentsProxyGetters[];

--- a/Source/Lua/ElementAttributesProxy.cpp
+++ b/Source/Lua/ElementAttributesProxy.cpp
@@ -29,6 +29,7 @@
 #include "ElementAttributesProxy.h"
 #include <RmlUi/Lua/Utilities.h>
 #include <RmlUi/Core/Variant.h>
+#include "Pairs.h"
 
 namespace Rml {
 namespace Lua {
@@ -38,8 +39,6 @@ template<> void ExtraInit<ElementAttributesProxy>(lua_State* L, int metatable_in
     lua_setfield(L,metatable_index,"__index");
     lua_pushcfunction(L,ElementAttributesProxy__pairs);
     lua_setfield(L,metatable_index,"__pairs");
-    lua_pushcfunction(L,ElementAttributesProxy__ipairs);
-    lua_setfield(L,metatable_index,"__ipairs");
 }
 
 int ElementAttributesProxy__index(lua_State* L)
@@ -59,40 +58,11 @@ int ElementAttributesProxy__index(lua_State* L)
         return LuaType<ElementAttributesProxy>::index(L);
 }
 
-//[1] is the object, [2] is the key that was used previously, [3] is the userdata
 int ElementAttributesProxy__pairs(lua_State* L)
 {
     ElementAttributesProxy* obj = LuaType<ElementAttributesProxy>::check(L,1);
     RMLUI_CHECK_OBJ(obj);
-    int& pindex = *(int*)lua_touserdata(L,3);
-	if ((pindex) == -1)
-		pindex = 0;
-	const ElementAttributes& attributes = obj->owner->GetAttributes();
-
-    if(pindex >= 0 && pindex < (int)attributes.size())
-    {
-		auto it = attributes.begin();
-		for (int i = 0; i < pindex; ++i)
-			++it;
-		const String& key = it->first;
-		const Variant* value = &it->second;
-        lua_pushstring(L,key.c_str());
-        PushVariant(L,value);
-    }
-    else
-    {
-        lua_pushnil(L);
-        lua_pushnil(L);
-    }
-    return 2;
-}
-
-//Doesn't index by integer, so don't return anything
-int ElementAttributesProxy__ipairs(lua_State* L)
-{
-    lua_pushnil(L);
-    lua_pushnil(L);
-    return 2;
+    return MakePairs(L, obj->owner->GetAttributes());
 }
 
 RegType<ElementAttributesProxy> ElementAttributesProxyMethods[] =

--- a/Source/Lua/ElementAttributesProxy.h
+++ b/Source/Lua/ElementAttributesProxy.h
@@ -41,7 +41,6 @@ struct ElementAttributesProxy { Element* owner;  };
 template<> void ExtraInit<ElementAttributesProxy>(lua_State* L, int metatable_index);
 int ElementAttributesProxy__index(lua_State* L);
 int ElementAttributesProxy__pairs(lua_State* L);
-int ElementAttributesProxy__ipairs(lua_State* L);
 
 extern RegType<ElementAttributesProxy> ElementAttributesProxyMethods[];
 extern luaL_Reg ElementAttributesProxyGetters[];

--- a/Source/Lua/ElementChildNodesProxy.cpp
+++ b/Source/Lua/ElementChildNodesProxy.cpp
@@ -28,6 +28,7 @@
  
 #include "ElementChildNodesProxy.h"
 #include "Element.h"
+#include "Pairs.h"
 
 namespace Rml {
 namespace Lua {
@@ -38,8 +39,6 @@ template<> void ExtraInit<ElementChildNodesProxy>(lua_State* L, int metatable_in
     lua_setfield(L,metatable_index,"__index");
     lua_pushcfunction(L,ElementChildNodesProxy__pairs);
     lua_setfield(L,metatable_index,"__pairs");
-    lua_pushcfunction(L,ElementChildNodesProxy__ipairs);
-    lua_setfield(L,metatable_index,"__ipairs");
 }
 
 int ElementChildNodesProxy__index(lua_State* L)
@@ -61,32 +60,7 @@ int ElementChildNodesProxy__index(lua_State* L)
 
 int ElementChildNodesProxy__pairs(lua_State* L)
 {
-    //because it is only indexed by integer, just go through ipairs
-    return ElementChildNodesProxy__ipairs(L);
-}
-
-
-//[1] is the object, [2] is the key that was just used, [3] is the userdata
-int ElementChildNodesProxy__ipairs(lua_State* L)
-{
-    ElementChildNodesProxy* obj = LuaType<ElementChildNodesProxy>::check(L,1);
-    RMLUI_CHECK_OBJ(obj);
-    int* pindex = (int*)lua_touserdata(L,3);
-    if((*pindex) == -1) //initial value
-        (*pindex) = 0;
-    int num_children = obj->owner->GetNumChildren();
-    if((*pindex) < num_children)
-    {
-        lua_pushinteger(L,*pindex); //key
-        LuaType<Element>::push(L,obj->owner->GetChild(*pindex)); //value
-        (*pindex) += 1;
-    }
-    else
-    {
-        lua_pushnil(L);
-        lua_pushnil(L);
-    }
-    return 2;
+    return MakeIntPairs(L);
 }
 
 RegType<ElementChildNodesProxy> ElementChildNodesProxyMethods[] = 

--- a/Source/Lua/ElementChildNodesProxy.cpp
+++ b/Source/Lua/ElementChildNodesProxy.cpp
@@ -50,7 +50,7 @@ int ElementChildNodesProxy__index(lua_State* L)
         ElementChildNodesProxy* obj = LuaType<ElementChildNodesProxy>::check(L,1);
         RMLUI_CHECK_OBJ(obj);
         int key = (int)luaL_checkinteger(L,2);
-        Element* child = obj->owner->GetChild(key);
+        Element* child = obj->owner->GetChild(key-1);
         LuaType<Element>::push(L,child,false);
         return 1;
     }

--- a/Source/Lua/ElementChildNodesProxy.h
+++ b/Source/Lua/ElementChildNodesProxy.h
@@ -42,7 +42,6 @@ struct ElementChildNodesProxy { Element* owner;  };
 template<> void ExtraInit<ElementChildNodesProxy>(lua_State* L, int metatable_index);
 int ElementChildNodesProxy__index(lua_State* L);
 int ElementChildNodesProxy__pairs(lua_State* L);
-int ElementChildNodesProxy__ipairs(lua_State* L);
 
 extern RegType<ElementChildNodesProxy> ElementChildNodesProxyMethods[];
 extern luaL_Reg ElementChildNodesProxyGetters[];

--- a/Source/Lua/ElementStyleProxy.cpp
+++ b/Source/Lua/ElementStyleProxy.cpp
@@ -102,7 +102,6 @@ struct ElementStyleProxyPairs
 {
     static int next(lua_State* L) 
     {
-        ElementStyleProxy* obj = LuaType<ElementStyleProxy>::check(L,1);
         ElementStyleProxyPairs* self = static_cast<ElementStyleProxyPairs*>(lua_touserdata(L, lua_upvalueindex(1)));
         if (self->m_view.AtEnd())
         {
@@ -150,8 +149,7 @@ int ElementStyleProxy__pairs(lua_State* L)
     ElementStyleProxy* obj = LuaType<ElementStyleProxy>::check(L,1);
     RMLUI_CHECK_OBJ(obj);
     ElementStyleProxyPairs::constructor(L, obj);
-    lua_pushvalue(L, 1);
-    return 2;
+    return 1;
 }
 
 RegType<ElementStyleProxy> ElementStyleProxyMethods[] = 

--- a/Source/Lua/ElementStyleProxy.cpp
+++ b/Source/Lua/ElementStyleProxy.cpp
@@ -46,9 +46,6 @@ template<> void ExtraInit<ElementStyleProxy>(lua_State* L, int metatable_index)
 
     lua_pushcfunction(L,ElementStyleProxy__pairs);
     lua_setfield(L,metatable_index,"__pairs");
-
-    lua_pushcfunction(L,ElementStyleProxy__ipairs);
-    lua_setfield(L,metatable_index,"__ipairs");
 }
 
 int ElementStyleProxy__index(lua_State* L)
@@ -101,45 +98,59 @@ int ElementStyleProxy__newindex(lua_State* L)
 
 }
 
-//[1] is the object, [2] is the last used key, [3] is the userdata
+struct ElementStyleProxyPairs
+{
+    static int next(lua_State* L) 
+    {
+        ElementStyleProxy* obj = LuaType<ElementStyleProxy>::check(L,1);
+        ElementStyleProxyPairs* self = static_cast<ElementStyleProxyPairs*>(lua_touserdata(L, lua_upvalueindex(1)));
+        if (self->m_view.AtEnd())
+        {
+            return 0;
+        }
+		const String& key = self->m_view.GetName();
+		const Property& property = self->m_view.GetProperty();
+		String val;
+        property.definition->GetValue(val, property);
+        lua_pushlstring(L, key.c_str(), key.size());
+        lua_pushlstring(L, val.c_str(), val.size());
+        ++self->m_view;
+        return 2;
+    }
+    static int destroy(lua_State* L)
+    {
+        static_cast<ElementStyleProxyPairs*>(lua_touserdata(L, 1))->~ElementStyleProxyPairs();
+        return 0;
+    }
+    static int constructor(lua_State* L, ElementStyleProxy* obj)
+    {
+        void* storage = lua_newuserdata(L, sizeof(ElementStyleProxyPairs));
+        if (luaL_newmetatable(L, "RmlUi::Lua::ElementStyleProxyPairs"))
+        {
+            static luaL_Reg mt[] =
+            {
+                {"__gc", destroy},
+                {NULL, NULL},
+            };
+            luaL_setfuncs(L, mt, 0);
+        }
+        lua_setmetatable(L, -2);
+        lua_pushcclosure(L, next, 1);
+        new (storage) ElementStyleProxyPairs(obj);
+        return 1;
+    }
+    ElementStyleProxyPairs(ElementStyleProxy* obj)
+        : m_view(obj->owner->IterateLocalProperties())
+    { }
+    PropertiesIteratorView m_view;
+};
+
 int ElementStyleProxy__pairs(lua_State* L)
 {
     ElementStyleProxy* obj = LuaType<ElementStyleProxy>::check(L,1);
     RMLUI_CHECK_OBJ(obj);
-    int* pindex = (int*)lua_touserdata(L,3);
-	if ((*pindex) == -1)
-		*pindex = 0;
-
-	int i = 0;
-	auto it = obj->owner->IterateLocalProperties();
-	while (i < (*pindex) && !it.AtEnd())
-	{
-		++it;
-		++i;
-	}
-
-    if(!it.AtEnd())
-    {
-		const String& key = it.GetName();
-		const Property& property = it.GetProperty();
-		String val;
-        property.definition->GetValue(val, property);
-        lua_pushstring(L,key.c_str());
-        lua_pushstring(L,val.c_str());
-    }
-    else
-    {
-        lua_pushnil(L);
-        lua_pushnil(L);
-    }
-    return 2;
-}
-
-//only indexed by string
-int ElementStyleProxy__ipairs(lua_State* L)
-{
-    lua_pushnil(L);
-    lua_pushnil(L);
+    ElementStyleProxyPairs::constructor(L, obj);
+    lua_pushvalue(L, 1);
     return 2;
 }
 

--- a/Source/Lua/ElementStyleProxy.h
+++ b/Source/Lua/ElementStyleProxy.h
@@ -42,7 +42,6 @@ template<> void ExtraInit<ElementStyleProxy>(lua_State* L, int metatable_index);
 int ElementStyleProxy__index(lua_State* L);
 int ElementStyleProxy__newindex(lua_State* L);
 int ElementStyleProxy__pairs(lua_State* L);
-int ElementStyleProxy__ipairs(lua_State* L);
 
 extern RegType<ElementStyleProxy> ElementStyleProxyMethods[];
 extern luaL_Reg ElementStyleProxyGetters[];

--- a/Source/Lua/Elements/SelectOptionsProxy.cpp
+++ b/Source/Lua/Elements/SelectOptionsProxy.cpp
@@ -44,7 +44,7 @@ int SelectOptionsProxy__index(lua_State* L)
         SelectOptionsProxy* proxy = LuaType<SelectOptionsProxy>::check(L,1);
         RMLUI_CHECK_OBJ(proxy);
         int index = (int)luaL_checkinteger(L,2);
-        SelectOption* opt = proxy->owner->GetOption(index);
+        SelectOption* opt = proxy->owner->GetOption(index-1);
         RMLUI_CHECK_OBJ(opt);
         lua_newtable(L);
         LuaType<Element>::push(L,opt->GetElement(),false);

--- a/Source/Lua/Elements/SelectOptionsProxy.cpp
+++ b/Source/Lua/Elements/SelectOptionsProxy.cpp
@@ -28,6 +28,7 @@
  
 #include "SelectOptionsProxy.h"
 #include <RmlUi/Core/Element.h>
+#include "../Pairs.h"
 
 
 namespace Rml {
@@ -56,44 +57,10 @@ int SelectOptionsProxy__index(lua_State* L)
         return LuaType<SelectOptionsProxy>::index(L);
 }
 
-//since there are no string keys, just use __ipairs
+
 int SelectOptionsProxy__pairs(lua_State* L)
 {
-    return SelectOptionsProxy__ipairs(L);
-}
-
-//[1] is the object, [2] is the previous key, [3] is the userdata
-int SelectOptionsProxy__ipairs(lua_State* L)
-{
-    SelectOptionsProxy* proxy = LuaType<SelectOptionsProxy>::check(L,1);
-    RMLUI_CHECK_OBJ(proxy);
-    int* pindex = (int*)lua_touserdata(L,3);
-    if((*pindex) == -1)
-        *pindex = 0;
-    SelectOption* opt = nullptr;
-    while((*pindex) < proxy->owner->GetNumOptions())
-    {
-        opt = proxy->owner->GetOption((*pindex)++);
-        if(opt != nullptr) 
-            break;
-    }
-    //we got to the end without finding an option
-    if(opt == nullptr)
-    {
-        lua_pushnil(L);
-        lua_pushnil(L);
-    }
-    else //we found an option
-    {
-        lua_pushinteger(L,(*pindex)-1); //key
-        lua_newtable(L); //value
-        //fill the value
-        LuaType<Element>::push(L,opt->GetElement());
-        lua_setfield(L,-2,"element");
-        lua_pushstring(L,opt->GetValue().c_str());
-        lua_setfield(L,-2,"value");
-    }
-    return 2;
+    return MakeIntPairs(L);
 }
 
 RegType<SelectOptionsProxy> SelectOptionsProxyMethods[] =
@@ -118,8 +85,6 @@ template<> void ExtraInit<SelectOptionsProxy>(lua_State* L, int metatable_index)
     lua_setfield(L,metatable_index,"__index");
     lua_pushcfunction(L,SelectOptionsProxy__pairs);
     lua_setfield(L,metatable_index,"__pairs");
-    lua_pushcfunction(L,SelectOptionsProxy__ipairs);
-    lua_setfield(L,metatable_index,"__ipairs");
 }
 
 RMLUI_LUATYPE_DEFINE(SelectOptionsProxy)

--- a/Source/Lua/Elements/SelectOptionsProxy.h
+++ b/Source/Lua/Elements/SelectOptionsProxy.h
@@ -40,7 +40,6 @@ struct SelectOptionsProxy { ElementFormControlSelect* owner;  };
 
 int SelectOptionsProxy__index(lua_State* L);
 int SelectOptionsProxy__pairs(lua_State* L);
-int SelectOptionsProxy__ipairs(lua_State* L);
 
 extern RegType<SelectOptionsProxy> SelectOptionsProxyMethods[];
 extern luaL_Reg SelectOptionsProxyGetters[];

--- a/Source/Lua/EventParametersProxy.cpp
+++ b/Source/Lua/EventParametersProxy.cpp
@@ -30,6 +30,7 @@
 #include <RmlUi/Lua/Utilities.h>
 #include <RmlUi/Core/Variant.h>
 #include <RmlUi/Core/Dictionary.h>
+#include "Pairs.h"
 
 
 namespace Rml {
@@ -41,8 +42,6 @@ template<> void ExtraInit<EventParametersProxy>(lua_State* L, int metatable_inde
     lua_setfield(L,metatable_index,"__index");
     lua_pushcfunction(L,EventParametersProxy__pairs);
     lua_setfield(L,metatable_index,"__pairs");
-    lua_pushcfunction(L,EventParametersProxy__ipairs);
-    lua_setfield(L,metatable_index,"__ipairs");
 }
 
 int EventParametersProxy__index(lua_State* L)
@@ -63,40 +62,11 @@ int EventParametersProxy__index(lua_State* L)
         return LuaType<EventParametersProxy>::index(L);
 }
 
-
-//[1] is the object, [2] is the last used key, [3] is the userdata
 int EventParametersProxy__pairs(lua_State* L)
 {
     EventParametersProxy* obj = LuaType<EventParametersProxy>::check(L,1);
     RMLUI_CHECK_OBJ(obj);
-    int& pindex = *(int*)lua_touserdata(L,3);
-	if ((pindex) == -1)
-		pindex = 0;
-	const Dictionary& attributes = obj->owner->GetParameters();
-    if(pindex >= 0 && pindex < (int)attributes.size())
-    {
-		auto it = attributes.begin();
-		for (int i = 0; i < pindex; ++i)
-			++it;
-		const String& key = it->first;
-		const Variant* value = &it->second;
-        lua_pushstring(L,key.c_str());
-        PushVariant(L,value);
-    }
-    else
-    {
-        lua_pushnil(L);
-        lua_pushnil(L);
-    }
-    return 2;
-}
-
-//only index by string
-int EventParametersProxy__ipairs(lua_State* L)
-{
-    lua_pushnil(L);
-    lua_pushnil(L);
-    return 2;
+    return MakePairs(L, obj->owner->GetParameters());
 }
 
 RegType<EventParametersProxy> EventParametersProxyMethods[] =

--- a/Source/Lua/EventParametersProxy.h
+++ b/Source/Lua/EventParametersProxy.h
@@ -41,7 +41,6 @@ struct EventParametersProxy { Event* owner;  };
 template<> void ExtraInit<EventParametersProxy>(lua_State* L, int metatable_index);
 int EventParametersProxy__index(lua_State* L);
 int EventParametersProxy__pairs(lua_State* L);
-int EventParametersProxy__ipairs(lua_State* L);
 
 extern RegType<EventParametersProxy> EventParametersProxyMethods[];
 extern luaL_Reg EventParametersProxyGetters[];

--- a/Source/Lua/Pairs.h
+++ b/Source/Lua/Pairs.h
@@ -114,7 +114,12 @@ int MakePairs(lua_State* L, const Container& container) {
 inline int ipairsaux(lua_State* L) {
     lua_Integer i = luaL_checkinteger(L, 2) + 1;
     lua_pushinteger(L, i);
+#if LUA_VERSION_NUM >= 503
     return (lua_geti(L, 1, i) == LUA_TNIL) ? 1 : 2;
+#else
+    lua_pushinteger(L, i);
+    return (lua_gettable(L, 1) == LUA_TNIL) ? 1 : 2;
+#endif
 }
 
 inline int MakeIntPairs(lua_State* L) {

--- a/Source/Lua/Pairs.h
+++ b/Source/Lua/Pairs.h
@@ -118,7 +118,8 @@ inline int ipairsaux(lua_State* L) {
     return (lua_geti(L, 1, i) == LUA_TNIL) ? 1 : 2;
 #else
     lua_pushinteger(L, i);
-    return (lua_gettable(L, 1) == LUA_TNIL) ? 1 : 2;
+    lua_gettable(L, 1);
+    return (lua_isnil(L, -1)) ? 1 : 2;
 #endif
 }
 

--- a/Source/Lua/Pairs.h
+++ b/Source/Lua/Pairs.h
@@ -62,18 +62,13 @@ inline int PairsConvertTolua<Variant>(lua_State* L, const Variant& v) {
 template <typename T>
 struct PairsHelper {
     static int next(lua_State* L) {
-        try {
-            PairsHelper* self = static_cast<PairsHelper*>(lua_touserdata(L, lua_upvalueindex(1)));
-            if (self->m_first == self->m_last) {
-                return 0;
-            }
-            int nreslut = PairsConvertTolua(L, *self->m_first);
-            ++(self->m_first);
-            return nreslut;
-        } catch (const std::exception& e) { 
-            lua_pushstring(L, e.what());
-            return lua_error(L); 
+        PairsHelper* self = static_cast<PairsHelper*>(lua_touserdata(L, lua_upvalueindex(1)));
+        if (self->m_first == self->m_last) {
+            return 0;
         }
+        int nreslut = PairsConvertTolua(L, *self->m_first);
+        ++(self->m_first);
+        return nreslut;
     }
     static int destroy(lua_State* L) {
         static_cast<PairsHelper*>(lua_touserdata(L, 1))->~PairsHelper();

--- a/Source/Lua/Pairs.h
+++ b/Source/Lua/Pairs.h
@@ -1,0 +1,131 @@
+/*
+ * This source file is part of RmlUi, the HTML/CSS Interface Middleware
+ *
+ * For the latest information, see http://github.com/mikke89/RmlUi
+ *
+ * Copyright (c) 2008-2010 CodePoint Ltd, Shift Technology Ltd
+ * Copyright (c) 2019 The RmlUi Team, and contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+ 
+#ifndef RMLUI_LUA_PAIRS_H
+#define RMLUI_LUA_PAIRS_H 
+
+#include <RmlUi/Lua/IncludeLua.h>
+#include <RmlUi/Lua/Utilities.h>
+#include <utility>
+
+namespace Rml {
+namespace Lua {
+    
+template <class T>
+int PairsConvertTolua(lua_State* L, const T& v);
+
+template <class F, class S>
+int PairsConvertTolua(lua_State* L, const std::pair<F, S>& v) {
+    int nresult = 0;
+    nresult += PairsConvertTolua(L, v.first);
+    nresult += PairsConvertTolua(L, v.second);
+    return nresult;
+}
+
+template <>
+inline int PairsConvertTolua<String>(lua_State* L, const String& s) {
+    lua_pushlstring(L, s.c_str(), s.size());
+    return 1;
+}
+
+template <>
+inline int PairsConvertTolua<Variant>(lua_State* L, const Variant& v) {
+    PushVariant(L, &v);
+    return 1;
+}
+
+template <typename T>
+struct PairsHelper {
+    static int next(lua_State* L) {
+        try {
+            PairsHelper* self = static_cast<PairsHelper*>(lua_touserdata(L, lua_upvalueindex(1)));
+            if (self->m_first == self->m_last) {
+                return 0;
+            }
+            int nreslut = PairsConvertTolua(L, *self->m_first);
+            ++(self->m_first);
+            return nreslut;
+        } catch (const std::exception& e) { 
+            lua_pushstring(L, e.what());
+            return lua_error(L); 
+        }
+    }
+    static int destroy(lua_State* L) {
+        static_cast<PairsHelper*>(lua_touserdata(L, 1))->~PairsHelper();
+        return 0;
+    }
+    static int constructor(lua_State* L, const T& first, const T& last) {
+        void* storage = lua_newuserdata(L, sizeof(PairsHelper<T>));
+        if (luaL_newmetatable(L, "RmlUi::Lua::PairsHelper")) {
+            static luaL_Reg mt[] = {
+                {"__gc", destroy},
+                {NULL, NULL},
+            };
+            luaL_setfuncs(L, mt, 0);
+        }
+        lua_setmetatable(L, -2);
+        lua_pushcclosure(L, next, 1);
+        new (storage) PairsHelper<T>(first, last);
+        return 1;
+    }
+    PairsHelper(const T& first, const T& last)
+        : m_first(first)
+        , m_last(last)
+    { }
+    T m_first;
+    T m_last;
+};
+
+template <class Iterator>
+int MakePairs(lua_State* L, const Iterator& first, const Iterator& last) {
+    return PairsHelper<Iterator>::constructor(L, first, last);
+}
+
+template <class Container>
+int MakePairs(lua_State* L, const Container& container) {
+    return MakePairs(L, std::begin(container), std::end(container));
+}
+
+inline int ipairsaux(lua_State* L) {
+    lua_Integer i = luaL_checkinteger(L, 2) + 1;
+    lua_pushinteger(L, i);
+    return (lua_geti(L, 1, i) == LUA_TNIL) ? 1 : 2;
+}
+
+inline int MakeIntPairs(lua_State* L) {
+    luaL_checkany(L, 1);
+    lua_pushcfunction(L, ipairsaux);
+    lua_pushvalue(L, 1);
+    lua_pushinteger(L, 0);
+    return 3;
+}
+
+} // namespace Lua
+} // namespace Rml
+
+#endif

--- a/Source/Lua/RmlUiContextsProxy.cpp
+++ b/Source/Lua/RmlUiContextsProxy.cpp
@@ -29,7 +29,7 @@
 #include "RmlUiContextsProxy.h"
 #include <RmlUi/Core/Context.h>
 #include <RmlUi/Core/Core.h>
-
+#include "Pairs.h"
 
 namespace Rml {
 namespace Lua {
@@ -40,8 +40,6 @@ template<> void ExtraInit<RmlUiContextsProxy>(lua_State* L, int metatable_index)
     lua_setfield(L,metatable_index,"__index");
     lua_pushcfunction(L,RmlUiContextsProxy__pairs);
     lua_setfield(L,metatable_index,"__pairs");
-    lua_pushcfunction(L,RmlUiContextsProxy__ipairs);
-    lua_setfield(L,metatable_index,"__ipairs");
 }
 
 int RmlUiContextsProxy__index(lua_State* L)
@@ -69,57 +67,11 @@ int RmlUiContextsProxy__index(lua_State* L)
 }
 
 
-//[1] is the object, [2] is the last used key, [3] is the userdata
 int RmlUiContextsProxy__pairs(lua_State* L)
 {
-    RmlUiContextsProxy* obj = LuaType<RmlUiContextsProxy>::check(L,1);
-    RMLUI_CHECK_OBJ(obj);
-    int* pindex = (int*)lua_touserdata(L,3);
-    if((*pindex) == -1)
-        *pindex = 0;
-    Context* value = nullptr;
-    if((*pindex)++ < GetNumContexts())
-    {
-        value = GetContext(*pindex);
-    }
-    if(value == nullptr)
-    {
-        lua_pushnil(L);
-        lua_pushnil(L);
-    }
-    else
-    {
-        lua_pushstring(L,value->GetName().c_str());
-        LuaType<Context>::push(L,value);
-    }
-    return 2;
+    return MakeIntPairs(L);
 }
 
-//[1] is the object, [2] is the last used key, [3] is the userdata
-int RmlUiContextsProxy__ipairs(lua_State* L)
-{
-    RmlUiContextsProxy* obj = LuaType<RmlUiContextsProxy>::check(L,1);
-    RMLUI_CHECK_OBJ(obj);
-    int* pindex = (int*)lua_touserdata(L,3);
-    if((*pindex) == -1)
-        *pindex = 0;
-    Context* value = nullptr;
-    if((*pindex)++ < GetNumContexts())
-    {
-        value = GetContext(*pindex);
-    }
-    if(value == nullptr)
-    {
-        lua_pushnil(L);
-        lua_pushnil(L);
-    }
-    else
-    {
-        lua_pushinteger(L,(*pindex)-1);
-        LuaType<Context>::push(L,value);
-    }
-    return 2;
-}
 
 RegType<RmlUiContextsProxy> RmlUiContextsProxyMethods[] =
 {

--- a/Source/Lua/RmlUiContextsProxy.cpp
+++ b/Source/Lua/RmlUiContextsProxy.cpp
@@ -58,7 +58,7 @@ int RmlUiContextsProxy__index(lua_State* L)
         else
         {
             int key = (int)luaL_checkinteger(L,2);
-            LuaType<Context>::push(L,GetContext(key));
+            LuaType<Context>::push(L,GetContext(key-1));
         }
         return 1;
     }

--- a/Source/Lua/RmlUiContextsProxy.h
+++ b/Source/Lua/RmlUiContextsProxy.h
@@ -41,7 +41,6 @@ struct RmlUiContextsProxy { void* nothing;  };
 template<> void ExtraInit<RmlUiContextsProxy>(lua_State* L, int metatable_index);
 int RmlUiContextsProxy__index(lua_State* L);
 int RmlUiContextsProxy__pairs(lua_State* L);
-int RmlUiContextsProxy__ipairs(lua_State* L);
 
 extern RegType<RmlUiContextsProxy> RmlUiContextsProxyMethods[];
 extern luaL_Reg RmlUiContextsProxyGetters[];


### PR DESCRIPTION
This change removes the replacement of **ipairs** and **pairs** in the Lua standard library.

For **ipairs**, the following two pieces of code are equivalent. So we only need to implement `__index` correctly to make **ipairs** work correctly. In fact, `__ipairs` has been removed after Lua5.3. So we no longer need to implement `__ipairs`.

``` lua
for i, v in ipairs(t) do
  -- do something
end
```

``` lua
local i = 1
while true do
  local v = t[i]
  if v == nil then
    break
  end
  -- do something
  i = i + 1
end
```

In addition, this change also resolves #95.