### PR TITLE
Correct chunkname

### DIFF
--- a/Source/Lua/Interpreter.cpp
+++ b/Source/Lua/Interpreter.cpp
@@ -67,7 +67,7 @@ void Interpreter::LoadFile(const String& file)
     file_interface->Read(file_contents, size, handle);
     file_interface->Close(handle);
 
-    if (luaL_loadbuffer(L, file_contents, size, file.c_str()) != 0)
+    if (luaL_loadbuffer(L, file_contents, size, ("@" + file).c_str()) != 0)
         Report(L);
     else //if there were no errors loading, then the compiled function is on the top of the stack
     {

--- a/Source/Lua/LuaDocument.cpp
+++ b/Source/Lua/LuaDocument.cpp
@@ -49,6 +49,9 @@ void LuaDocument::LoadScript(Stream* stream, const String& source_name)
     else
     {
         String buffer;
+        buffer += "--";
+        buffer += this->GetSourceURL();
+        buffer += "\n";
         stream->Read(buffer,stream->Length()); //just do the whole thing
         Interpreter::DoString(buffer, buffer);
     }

--- a/Source/Lua/LuaDocument.cpp
+++ b/Source/Lua/LuaDocument.cpp
@@ -50,7 +50,7 @@ void LuaDocument::LoadScript(Stream* stream, const String& source_name)
     {
         String buffer;
         stream->Read(buffer,stream->Length()); //just do the whole thing
-        Interpreter::DoString(buffer, this->GetSourceURL());
+        Interpreter::DoString(buffer, buffer);
     }
 }
 


### PR DESCRIPTION
The chunkname specification is not part of the Lua standard, but following the specification can be more compatible with debugging and profiling tools.

The chunkname specification is included in the [lua manual](http://www.lua.org/manual/5.4/manual.html#4.7). 

> source: the source of the chunk that created the function. If source starts with a '@', it means that the function was defined in a file where the file name follows the '@'. If source starts with a '=', the remainder of its contents describes the source in a user-dependent manner. Otherwise, the function was defined in a string where source is that string.
