### PR TITLE
Fixes script loading order.

### DIFF
--- a/Include/RmlUi/Core/ElementDocument.h
+++ b/Include/RmlUi/Core/ElementDocument.h
@@ -113,11 +113,16 @@ public:
 	/// @return True if the document is hogging focus.
 	bool IsModal() const;
 
-	/// Load a script into the document. Note that the base implementation does nothing, scripting language addons hook
+	/// Load a inline script into the document. Note that the base implementation does nothing, scripting language addons hook
 	/// this method.
-	/// @param[in] stream Stream of code to process.
-	/// @param[in] source_name Name of the the script the source comes from, useful for debug information.
-	virtual void LoadScript(Stream* stream, const String& source_name);
+	/// @param[in] source The script source.
+	/// @param[in] line Line of the script the source comes from, useful for debug information.
+	virtual void LoadInlineScript(const String& source, int line);
+
+	/// Load a external script into the document. Note that the base implementation does nothing, scripting language addons hook
+	/// this method.
+	/// @param[in] source_name The script file path.
+	virtual void LoadExternalScript(const String& source_name);
 
 	/// Updates the document, including its layout. Users must call this manually before requesting information such as 
 	/// size or position of an element if any element in the document was recently changed, unless Context::Update has

--- a/Include/RmlUi/Core/ElementDocument.h
+++ b/Include/RmlUi/Core/ElementDocument.h
@@ -115,14 +115,15 @@ public:
 
 	/// Load a inline script into the document. Note that the base implementation does nothing, scripting language addons hook
 	/// this method.
-	/// @param[in] source The script source.
-	/// @param[in] line Line of the script the source comes from, useful for debug information.
-	virtual void LoadInlineScript(const String& source, int line);
+	/// @param[in] content The script content.
+	/// @param[in] source_path Path of the script the source comes from, useful for debug information.
+	/// @param[in] source_line Line of the script the source comes from, useful for debug information.
+	virtual void LoadInlineScript(const String& content, const String& source_path, int source_line);
 
 	/// Load a external script into the document. Note that the base implementation does nothing, scripting language addons hook
 	/// this method.
-	/// @param[in] source_name The script file path.
-	virtual void LoadExternalScript(const String& source_name);
+	/// @param[in] source_path The script file path.
+	virtual void LoadExternalScript(const String& source_path);
 
 	/// Updates the document, including its layout. Users must call this manually before requesting information such as 
 	/// size or position of an element if any element in the document was recently changed, unless Context::Update has

--- a/Source/Core/DocumentHeader.cpp
+++ b/Source/Core/DocumentHeader.cpp
@@ -58,7 +58,7 @@ void DocumentHeader::MergeHeader(const DocumentHeader& header)
 	// Combine external data, keeping relative paths
 	MergePaths(template_resources, header.template_resources, header.source);
 	MergePaths(rcss_external, header.rcss_external, header.source);
-	MergeResources(scripts, header.scripts, header.source);
+	MergeResources(scripts, header.scripts);
 }
 
 void DocumentHeader::MergePaths(StringList& target, const StringList& source, const String& source_path)
@@ -69,19 +69,9 @@ void DocumentHeader::MergePaths(StringList& target, const StringList& source, co
 	}
 }
 
-void DocumentHeader::MergeResources(ResourceList& target, const ResourceList& source, const String& base_path)
+void DocumentHeader::MergeResources(ResourceList& target, const ResourceList& source)
 {
-	for (const Resource& script : source)
-	{
-		if (script.is_inline)
-		{
-			target.push_back(script);
-		}
-		else
-		{
-			target.push_back({MergePath(script.content_or_path, base_path)});
-		}
-	}
+	target.insert(target.end(), source.begin(), source.end());
 }
 
 } // namespace Rml

--- a/Source/Core/DocumentHeader.cpp
+++ b/Source/Core/DocumentHeader.cpp
@@ -46,12 +46,12 @@ void DocumentHeader::MergeHeader(const DocumentHeader& header)
 	// Combine internal data	
 	rcss_inline.insert(rcss_inline.end(), header.rcss_inline.begin(), header.rcss_inline.end());	
 	rcss_inline_line_numbers.insert(rcss_inline_line_numbers.end(), header.rcss_inline_line_numbers.begin(), header.rcss_inline_line_numbers.end());
-	scripts_inline.insert(scripts_inline.end(), header.scripts_inline.begin(), header.scripts_inline.end());
+
 	
 	// Combine external data, keeping relative paths
 	MergePaths(template_resources, header.template_resources, header.source);
 	MergePaths(rcss_external, header.rcss_external, header.source);
-	MergePaths(scripts_external, header.scripts_external, header.source);
+	MergeReources(scripts, header.scripts, header.source);
 }
 
 void DocumentHeader::MergePaths(StringList& target, const StringList& source, const String& source_path)
@@ -62,6 +62,23 @@ void DocumentHeader::MergePaths(StringList& target, const StringList& source, co
 		::Rml::GetSystemInterface()->JoinPath(joined_path, StringUtilities::Replace(source_path, '|', ':'), StringUtilities::Replace(source[i], '|', ':'));
 
 		target.push_back(StringUtilities::Replace(joined_path, ':', '|'));
+	}
+}
+
+void DocumentHeader::MergeReources(Vector<Resource>& target, const Vector<Resource>& source, const String& base_path)
+{
+	for (auto const& s : source)
+	{
+		if (s.line)
+		{
+			target.push_back(s);
+		}
+		else
+		{
+			String joined_path;
+			::Rml::GetSystemInterface()->JoinPath(joined_path, StringUtilities::Replace(base_path, '|', ':'), StringUtilities::Replace(s.context, '|', ':'));
+			target.push_back({StringUtilities::Replace(joined_path, ':', '|')});
+		}
 	}
 }
 

--- a/Source/Core/DocumentHeader.cpp
+++ b/Source/Core/DocumentHeader.cpp
@@ -34,13 +34,6 @@
 
 namespace Rml {
 
-static String MergePath(const String& source, const String& base)
-{
-	String joined_path;
-	::Rml::GetSystemInterface()->JoinPath(joined_path, StringUtilities::Replace(base, '|', ':'), StringUtilities::Replace(source, '|', ':'));
-	return StringUtilities::Replace(joined_path, ':', '|');
-}
-
 void DocumentHeader::MergeHeader(const DocumentHeader& header)
 {
 	// Copy the title across if ours is empty
@@ -50,14 +43,9 @@ void DocumentHeader::MergeHeader(const DocumentHeader& header)
 	if (source.empty())
 		source = header.source;
 
-	// Combine internal data	
-	rcss_inline.insert(rcss_inline.end(), header.rcss_inline.begin(), header.rcss_inline.end());	
-	rcss_inline_line_numbers.insert(rcss_inline_line_numbers.end(), header.rcss_inline_line_numbers.begin(), header.rcss_inline_line_numbers.end());
-
-	
 	// Combine external data, keeping relative paths
 	MergePaths(template_resources, header.template_resources, header.source);
-	MergePaths(rcss_external, header.rcss_external, header.source);
+	MergeResources(rcss, header.rcss);
 	MergeResources(scripts, header.scripts);
 }
 
@@ -65,7 +53,10 @@ void DocumentHeader::MergePaths(StringList& target, const StringList& source, co
 {
 	for (size_t i = 0; i < source.size(); i++)
 	{
-		target.push_back(MergePath(source[i], source_path));
+		String joined_path;
+		::Rml::GetSystemInterface()->JoinPath(joined_path, StringUtilities::Replace(source_path, '|', ':'), StringUtilities::Replace(source[i], '|', ':'));
+
+		target.push_back(StringUtilities::Replace(joined_path, ':', '|'));
 	}
 }
 

--- a/Source/Core/DocumentHeader.h
+++ b/Source/Core/DocumentHeader.h
@@ -52,16 +52,22 @@ public:
 	/// A list of template resources that can used while parsing the document
 	StringList template_resources;
 
+	struct Resource {
+		String context;
+		int line = 0;
+	};
 	/// Inline RCSS definitions
 	StringList rcss_inline;
 	LineNumberList rcss_inline_line_numbers;
 	/// External RCSS definitions that should be loaded
 	StringList rcss_external;
 
-	/// Inline script source
-	StringList scripts_inline;
-	/// External scripts that should be loaded
-	StringList scripts_external;
+	struct Script {
+		int line = 0;
+		String context;
+	};
+	/// script source
+	Vector<Resource> scripts;
 
 	/// Merges the specified header with this one
 	/// @param header Header to merge
@@ -69,6 +75,9 @@ public:
 
 	/// Merges paths from one string list to another, preserving the base_path
 	void MergePaths(StringList& target, const StringList& source, const String& base_path);
+
+	/// Merges reources
+	void MergeReources(Vector<Resource>& target, const Vector<Resource>& source, const String& base_path);
 };
 
 } // namespace Rml

--- a/Source/Core/DocumentHeader.h
+++ b/Source/Core/DocumentHeader.h
@@ -53,9 +53,12 @@ public:
 	StringList template_resources;
 
 	struct Resource {
-		String context;
-		int line = 0;
+		String content_or_path; // Content for inline resources, path for external resources.
+		bool is_inline = false;
+		int line = 0;           // Only set for inline resources.
 	};
+	using ResourceList = Vector<Resource>;
+
 	/// Inline RCSS definitions
 	StringList rcss_inline;
 	LineNumberList rcss_inline_line_numbers;
@@ -72,8 +75,8 @@ public:
 	/// Merges paths from one string list to another, preserving the base_path
 	void MergePaths(StringList& target, const StringList& source, const String& base_path);
 
-	/// Merges reources
-	void MergeReources(Vector<Resource>& target, const Vector<Resource>& source, const String& base_path);
+	/// Merges resources
+	void MergeResources(ResourceList& target, const ResourceList& source, const String& base_path);
 };
 
 } // namespace Rml

--- a/Source/Core/DocumentHeader.h
+++ b/Source/Core/DocumentHeader.h
@@ -53,7 +53,8 @@ public:
 	StringList template_resources;
 
 	struct Resource {
-		String content_or_path; // Content for inline resources, path for external resources.
+		String path; // Content path for inline resources, source path for external resources.
+		String content; // Only set for inline resources.
 		bool is_inline = false;
 		int line = 0;           // Only set for inline resources.
 	};
@@ -76,7 +77,7 @@ public:
 	void MergePaths(StringList& target, const StringList& source, const String& base_path);
 
 	/// Merges resources
-	void MergeResources(ResourceList& target, const ResourceList& source, const String& base_path);
+	void MergeResources(ResourceList& target, const ResourceList& source);
 };
 
 } // namespace Rml

--- a/Source/Core/DocumentHeader.h
+++ b/Source/Core/DocumentHeader.h
@@ -62,10 +62,6 @@ public:
 	/// External RCSS definitions that should be loaded
 	StringList rcss_external;
 
-	struct Script {
-		int line = 0;
-		String context;
-	};
 	/// script source
 	Vector<Resource> scripts;
 

--- a/Source/Core/DocumentHeader.h
+++ b/Source/Core/DocumentHeader.h
@@ -60,14 +60,11 @@ public:
 	};
 	using ResourceList = Vector<Resource>;
 
-	/// Inline RCSS definitions
-	StringList rcss_inline;
-	LineNumberList rcss_inline_line_numbers;
-	/// External RCSS definitions that should be loaded
-	StringList rcss_external;
+	/// RCSS definitions
+	ResourceList rcss;
 
 	/// script source
-	Vector<Resource> scripts;
+	ResourceList scripts;
 
 	/// Merges the specified header with this one
 	/// @param header Header to merge

--- a/Source/Core/ElementDocument.cpp
+++ b/Source/Core/ElementDocument.cpp
@@ -131,11 +131,11 @@ void ElementDocument::ProcessHeader(const DocumentHeader* document_header)
 	{
 		if (script.is_inline)
 		{
-			LoadInlineScript(script.content_or_path, script.line);
+			LoadInlineScript(script.content, script.path, script.line);
 		}
 		else
 		{
-			LoadExternalScript(script.content_or_path);
+			LoadExternalScript(script.path);
 		}
 	}
 
@@ -340,16 +340,17 @@ bool ElementDocument::IsModal() const
 }
 
 // Default load inline script implementation
-void ElementDocument::LoadInlineScript(const String& RMLUI_UNUSED_PARAMETER(source), int RMLUI_UNUSED_PARAMETER(line))
+void ElementDocument::LoadInlineScript(const String& RMLUI_UNUSED_PARAMETER(content), const String& RMLUI_UNUSED_PARAMETER(source_path), int RMLUI_UNUSED_PARAMETER(line))
 {
-	RMLUI_UNUSED(source);
+	RMLUI_UNUSED(content);
+	RMLUI_UNUSED(source_path);
 	RMLUI_UNUSED(line);
 }
 
 // Default load external script implementation
-void ElementDocument::LoadExternalScript(const String& RMLUI_UNUSED_PARAMETER(source_name))
+void ElementDocument::LoadExternalScript(const String& RMLUI_UNUSED_PARAMETER(source_path))
 {
-	RMLUI_UNUSED(source_name);
+	RMLUI_UNUSED(source_path);
 }
 
 // Updates the document, including its layout

--- a/Source/Core/ElementDocument.cpp
+++ b/Source/Core/ElementDocument.cpp
@@ -127,16 +127,15 @@ void ElementDocument::ProcessHeader(const DocumentHeader* document_header)
 	}
 
 	// Load scripts.
-	for (auto const& s : header.scripts)
+	for (const DocumentHeader::Resource& script : header.scripts)
 	{
-		if (s.line)
+		if (script.is_inline)
 		{
-			auto stream = MakeUnique<StreamMemory>((const byte*) s.context.c_str(), s.context.size());
-			LoadInlineScript(s.context, s.line);
+			LoadInlineScript(script.content_or_path, script.line);
 		}
 		else
 		{
-			LoadExternalScript(s.context);
+			LoadExternalScript(script.content_or_path);
 		}
 	}
 

--- a/Source/Core/ElementDocument.cpp
+++ b/Source/Core/ElementDocument.cpp
@@ -126,19 +126,18 @@ void ElementDocument::ProcessHeader(const DocumentHeader* document_header)
 		SetStyleSheet(std::move(new_style_sheet));
 	}
 
-	// Load external scripts.
-	for (size_t i = 0; i < header.scripts_external.size(); i++)
+	// Load scripts.
+	for (auto const& s : header.scripts)
 	{
-		auto stream = MakeUnique<StreamFile>();
-		if (stream->Open(header.scripts_external[i]))
-			LoadScript(stream.get(), header.scripts_external[i]);
-	}
-
-	// Load internal scripts.
-	for (size_t i = 0; i < header.scripts_inline.size(); i++)
-	{
-		auto stream = MakeUnique<StreamMemory>((const byte*) header.scripts_inline[i].c_str(), header.scripts_inline[i].size());
-		LoadScript(stream.get(), "");
+		if (s.line)
+		{
+			auto stream = MakeUnique<StreamMemory>((const byte*) s.context.c_str(), s.context.size());
+			LoadInlineScript(s.context, s.line);
+		}
+		else
+		{
+			LoadExternalScript(s.context);
+		}
 	}
 
 	// Hide this document.
@@ -341,10 +340,16 @@ bool ElementDocument::IsModal() const
 	return modal && IsVisible();
 }
 
-// Default load script implementation
-void ElementDocument::LoadScript(Stream* RMLUI_UNUSED_PARAMETER(stream), const String& RMLUI_UNUSED_PARAMETER(source_name))
+// Default load inline script implementation
+void ElementDocument::LoadInlineScript(const String& RMLUI_UNUSED_PARAMETER(source), int RMLUI_UNUSED_PARAMETER(line))
 {
-	RMLUI_UNUSED(stream);
+	RMLUI_UNUSED(source);
+	RMLUI_UNUSED(line);
+}
+
+// Default load external script implementation
+void ElementDocument::LoadExternalScript(const String& RMLUI_UNUSED_PARAMETER(source_name))
+{
 	RMLUI_UNUSED(source_name);
 }
 

--- a/Source/Core/XMLNodeHandlerHead.cpp
+++ b/Source/Core/XMLNodeHandlerHead.cpp
@@ -39,6 +39,13 @@
 
 namespace Rml {
 
+static String Absolutepath(const String& source, const String& base)
+{
+	String joined_path;
+	::Rml::GetSystemInterface()->JoinPath(joined_path, StringUtilities::Replace(base, '|', ':'), StringUtilities::Replace(source, '|', ':'));
+	return StringUtilities::Replace(joined_path, ':', '|');
+}
+
 XMLNodeHandlerHead::XMLNodeHandlerHead()
 {
 }
@@ -95,7 +102,7 @@ Element* XMLNodeHandlerHead::ElementStart(XMLParser* parser, const String& name,
 		String src = Get<String>(attributes, "src", "");
 		if (src.size() > 0)
 		{
-			parser->GetDocumentHeader()->scripts.push_back({src});
+			parser->GetDocumentHeader()->scripts.push_back({Absolutepath(src, parser->GetSourceURL().GetURL())});
 		}
 	}
 
@@ -134,7 +141,14 @@ bool XMLNodeHandlerHead::ElementData(XMLParser* parser, const String& data, XMLD
 
 	// Store an inline script
 	if (tag == "script" && data.size() > 0)
-		parser->GetDocumentHeader()->scripts.push_back({data, true, parser->GetLineNumberOpenTag()});
+	{
+		DocumentHeader::Resource resource;
+		resource.is_inline = true;
+		resource.content = data;
+		resource.path = parser->GetSourceURL().GetURL();
+		resource.line = parser->GetLineNumberOpenTag();
+		parser->GetDocumentHeader()->scripts.push_back(resource);
+	}
 
 	// Store an inline style
 	if (tag == "style" && data.size() > 0)

--- a/Source/Core/XMLNodeHandlerHead.cpp
+++ b/Source/Core/XMLNodeHandlerHead.cpp
@@ -134,7 +134,7 @@ bool XMLNodeHandlerHead::ElementData(XMLParser* parser, const String& data, XMLD
 
 	// Store an inline script
 	if (tag == "script" && data.size() > 0)
-		parser->GetDocumentHeader()->scripts.push_back({data, parser->GetLineNumberOpenTag()});
+		parser->GetDocumentHeader()->scripts.push_back({data, true, parser->GetLineNumberOpenTag()});
 
 	// Store an inline style
 	if (tag == "style" && data.size() > 0)

--- a/Source/Core/XMLNodeHandlerHead.cpp
+++ b/Source/Core/XMLNodeHandlerHead.cpp
@@ -46,6 +46,21 @@ static String Absolutepath(const String& source, const String& base)
 	return StringUtilities::Replace(joined_path, ':', '|');
 }
 
+static DocumentHeader::Resource MakeInlineResource(XMLParser* parser, const String& data)
+{
+	DocumentHeader::Resource resource;
+	resource.is_inline = true;
+	resource.content = data;
+	resource.path = parser->GetSourceURL().GetURL();
+	resource.line = parser->GetLineNumberOpenTag();
+	return resource;
+}
+
+static DocumentHeader::Resource MakeExternalResource(XMLParser* parser, const String& path)
+{
+	return {Absolutepath(path, parser->GetSourceURL().GetURL())};
+}
+
 XMLNodeHandlerHead::XMLNodeHandlerHead()
 {
 }
@@ -75,7 +90,7 @@ Element* XMLNodeHandlerHead::ElementStart(XMLParser* parser, const String& name,
 			if (type == "text/rcss" ||
 				 type == "text/css")
 			{
-				parser->GetDocumentHeader()->rcss_external.push_back(href);
+				parser->GetDocumentHeader()->rcss.push_back(MakeExternalResource(parser, href));
 			}
 
 			// If its an template, add to the template fields
@@ -102,7 +117,7 @@ Element* XMLNodeHandlerHead::ElementStart(XMLParser* parser, const String& name,
 		String src = Get<String>(attributes, "src", "");
 		if (src.size() > 0)
 		{
-			parser->GetDocumentHeader()->scripts.push_back({Absolutepath(src, parser->GetSourceURL().GetURL())});
+			parser->GetDocumentHeader()->scripts.push_back(MakeExternalResource(parser, src));
 		}
 	}
 
@@ -142,19 +157,13 @@ bool XMLNodeHandlerHead::ElementData(XMLParser* parser, const String& data, XMLD
 	// Store an inline script
 	if (tag == "script" && data.size() > 0)
 	{
-		DocumentHeader::Resource resource;
-		resource.is_inline = true;
-		resource.content = data;
-		resource.path = parser->GetSourceURL().GetURL();
-		resource.line = parser->GetLineNumberOpenTag();
-		parser->GetDocumentHeader()->scripts.push_back(resource);
+		parser->GetDocumentHeader()->scripts.push_back(MakeInlineResource(parser, data));
 	}
 
 	// Store an inline style
 	if (tag == "style" && data.size() > 0)
 	{
-		parser->GetDocumentHeader()->rcss_inline.push_back(data);
-		parser->GetDocumentHeader()->rcss_inline_line_numbers.push_back(parser->GetLineNumberOpenTag());
+		parser->GetDocumentHeader()->rcss.push_back(MakeInlineResource(parser, data));
 	}
 
 	return true;

--- a/Source/Core/XMLNodeHandlerHead.cpp
+++ b/Source/Core/XMLNodeHandlerHead.cpp
@@ -95,7 +95,7 @@ Element* XMLNodeHandlerHead::ElementStart(XMLParser* parser, const String& name,
 		String src = Get<String>(attributes, "src", "");
 		if (src.size() > 0)
 		{
-			parser->GetDocumentHeader()->scripts_external.push_back(src);
+			parser->GetDocumentHeader()->scripts.push_back({src});
 		}
 	}
 
@@ -134,7 +134,7 @@ bool XMLNodeHandlerHead::ElementData(XMLParser* parser, const String& data, XMLD
 
 	// Store an inline script
 	if (tag == "script" && data.size() > 0)
-		parser->GetDocumentHeader()->scripts_inline.push_back(data);
+		parser->GetDocumentHeader()->scripts.push_back({data, parser->GetLineNumberOpenTag()});
 
 	// Store an inline style
 	if (tag == "style" && data.size() > 0)

--- a/Source/Core/XMLNodeHandlerHead.cpp
+++ b/Source/Core/XMLNodeHandlerHead.cpp
@@ -58,7 +58,10 @@ static DocumentHeader::Resource MakeInlineResource(XMLParser* parser, const Stri
 
 static DocumentHeader::Resource MakeExternalResource(XMLParser* parser, const String& path)
 {
-	return {Absolutepath(path, parser->GetSourceURL().GetURL())};
+	DocumentHeader::Resource resource;
+	resource.is_inline = false;
+	resource.path = Absolutepath(path, parser->GetSourceURL().GetURL());
+	return resource;
 }
 
 XMLNodeHandlerHead::XMLNodeHandlerHead()

--- a/Source/Lua/LuaDocument.cpp
+++ b/Source/Lua/LuaDocument.cpp
@@ -39,22 +39,21 @@ LuaDocument::LuaDocument(const String& tag) : ElementDocument(tag)
 {
 }
 
-void LuaDocument::LoadScript(Stream* stream, const String& source_name)
+void LuaDocument::LoadInlineScript(const String& source, int line)
 {
-    //if it is loaded from a file
-    if(!source_name.empty())
-    {
-        Interpreter::LoadFile(source_name);
-    }
-    else
-    {
-        String buffer;
-        buffer += "--";
-        buffer += this->GetSourceURL();
-        buffer += "\n";
-        stream->Read(buffer,stream->Length()); //just do the whole thing
-        Interpreter::DoString(buffer, buffer);
-    }
+    String buffer;
+    buffer += "--";
+    buffer += this->GetSourceURL();
+    buffer += ":";
+    buffer += std::to_string(line);
+    buffer += "\n";
+    buffer += source;
+    Interpreter::DoString(buffer, buffer);
+}
+
+void LuaDocument::LoadExternalScript(const String& source_name)
+{
+    Interpreter::LoadFile(source_name);
 }
 
 } // namespace Lua

--- a/Source/Lua/LuaDocument.cpp
+++ b/Source/Lua/LuaDocument.cpp
@@ -39,21 +39,21 @@ LuaDocument::LuaDocument(const String& tag) : ElementDocument(tag)
 {
 }
 
-void LuaDocument::LoadInlineScript(const String& source, int line)
+void LuaDocument::LoadInlineScript(const String& context, const String& source_path, int source_line)
 {
     String buffer;
     buffer += "--";
-    buffer += this->GetSourceURL();
+    buffer += source_path;
     buffer += ":";
-    buffer += Rml::ToString(line);
+    buffer += Rml::ToString(source_line);
     buffer += "\n";
-    buffer += source;
+    buffer += context;
     Interpreter::DoString(buffer, buffer);
 }
 
-void LuaDocument::LoadExternalScript(const String& source_name)
+void LuaDocument::LoadExternalScript(const String& source_path)
 {
-    Interpreter::LoadFile(source_name);
+    Interpreter::LoadFile(source_path);
 }
 
 } // namespace Lua

--- a/Source/Lua/LuaDocument.cpp
+++ b/Source/Lua/LuaDocument.cpp
@@ -45,7 +45,7 @@ void LuaDocument::LoadInlineScript(const String& source, int line)
     buffer += "--";
     buffer += this->GetSourceURL();
     buffer += ":";
-    buffer += std::to_string(line);
+    buffer += Rml::ToString(line);
     buffer += "\n";
     buffer += source;
     Interpreter::DoString(buffer, buffer);

--- a/Source/Lua/LuaDocument.h
+++ b/Source/Lua/LuaDocument.h
@@ -29,7 +29,7 @@
 #ifndef RMLUI_LUA_LUADOCUMENT_H
 #define RMLUI_LUA_LUADOCUMENT_H
 /*
-    This class is an ElementDocument that overrides the LoadScript function
+    This class is an ElementDocument that overrides the LoadInlineScript and LoadExternalScript function
 */
 #include <RmlUi/Core/ElementDocument.h>
 
@@ -40,7 +40,8 @@ class LuaDocument : public ::Rml::ElementDocument
 {
 public:
     LuaDocument(const String& tag);
-    void LoadScript(Stream* stream, const String& source_name) override;
+    void LoadInlineScript(const String& source, int line) override;
+    void LoadExternalScript(const String& source_name) override;
 };
 
 } // namespace Lua

--- a/Source/Lua/LuaDocument.h
+++ b/Source/Lua/LuaDocument.h
@@ -40,8 +40,8 @@ class LuaDocument : public ::Rml::ElementDocument
 {
 public:
     LuaDocument(const String& tag);
-    void LoadInlineScript(const String& source, int line) override;
-    void LoadExternalScript(const String& source_name) override;
+    void LoadInlineScript(const String& content, const String& source_path, int source_line) override;
+    void LoadExternalScript(const String& source_path) override;
 };
 
 } // namespace Lua


### PR DESCRIPTION
This change fixes the loading order of inline script and external script.
```
test.rml:
<script> print(1) </script>
<script src="test.lua"></script>
<script> print(3) </script>

test.lua:
print(2)
```

Before output:
2
1
3

After output:
1
2
3

I noticed that RCSS has the same problem, but I am not sure if RCSS needs to be modified.


In addition, I added line number information to the inline script, which will make the debug information more friendly.