### PR TITLE
Polish the lua data model.

### DIFF
--- a/Samples/luainvaders/data/options.rml
+++ b/Samples/luainvaders/data/options.rml
@@ -31,6 +31,10 @@ if Options.datamodel == nil then
 	Options.datamodel = rmlui.contexts["main"]:OpenDataModel("options", {
 		graphics = 'ok',
 		options_changed = false,
+		audios = {
+			{id="reverb", label="Reverb", checked=true},
+			{id="3d", label="3D Spatialisation"},
+		}
 	})
 end
 
@@ -119,8 +123,9 @@ end
 				<p data-if="graphics == 'bad'">Are you sure about this? Bad graphics are just plain <em>bad.</em></p>
 				<p>
 					Audio:<br />
-					<input id="reverb" type="checkbox" name="reverb" checked /> Reverb<br />
-					<input id="3d" type="checkbox" name="3d" /> 3D Spatialisation
+					<span data-for="audio : audios">
+						<input data-attr-id="audio.id" type="checkbox" data-attr-name="audio.id" data-attrif-checked="audio.checked" /> {{audio.label}}<br />
+					</span>
 				</p>
 			</div>
 			<input type="submit" name="button" value="accept" data-attrif-disabled="!options_changed">Accept</input>

--- a/Samples/luainvaders/data/options.rml
+++ b/Samples/luainvaders/data/options.rml
@@ -76,8 +76,8 @@ function Options.LoadOptions(document)
     
     AsInput(document:GetElementById(options['graphics'])).checked = true
     --because everything is loaded as a string, we have to fool around with the boolean variables
-    AsInput(document:GetElementById('reverb')).checked = (options['reverb'] == 'true')
-    AsInput(document:GetElementById('3d')).checked = (options['3d'] == 'true')
+	Options.datamodel.audios[1].checked = (options['reverb'] == 'true')
+	Options.datamodel.audios[2].checked = (options['3d'] == 'true')
 	Options.datamodel.options_changed = false
 end
 

--- a/Source/Lua/LuaDataModel.cpp
+++ b/Source/Lua/LuaDataModel.cpp
@@ -63,7 +63,7 @@ namespace luabind {
 		}
 	}
 #endif
-	typedef std::function<void(void)> call_t;
+	using call_t = Rml::Function<void(void)>;
 	inline int errhandler(lua_State* L) {
 		const char* msg = lua_tostring(L, 1);
 		if (msg == NULL) {
@@ -118,10 +118,10 @@ struct LuaDataModel {
 class LuaTableDef : public VariableDefinition {
 public:
 	LuaTableDef(const struct LuaDataModel* model);
-	virtual bool Get(void* ptr, Variant& variant);
-	virtual bool Set(void* ptr, const Variant& variant);
-	virtual int Size(void* ptr);
-	virtual DataVariable Child(void* ptr, const DataAddressEntry& address);
+	bool Get(void* ptr, Variant& variant) override;
+	bool Set(void* ptr, const Variant& variant) override;
+	int Size(void* ptr) override;
+	DataVariable Child(void* ptr, const DataAddressEntry& address) override;
 protected:
 	const struct LuaDataModel* model;
 };
@@ -129,7 +129,7 @@ protected:
 class LuaScalarDef final : public LuaTableDef {
 public:
 	LuaScalarDef(const struct LuaDataModel* model);
-	virtual DataVariable Child(void* ptr, const DataAddressEntry& address);
+	DataVariable Child(void* ptr, const DataAddressEntry& address) override;
 };
 
 LuaTableDef::LuaTableDef(const struct LuaDataModel *model)


### PR DESCRIPTION
This pr continues the work of #146, adding arrays, structures and event callbacks. In addition, it is allowed to continue to register variables and callbacks after constructing the data-model, for example
```lua
local options = rmlui.contexts["main"]:OpenDataModel("options", {
    options_changed = false
})
options.graphics = 'ok' -- register new var `graphics `
```
