### PR TITLE
Attribute value supports rml escape

### DIFF
--- a/Include/RmlUi/Core/StringUtilities.h
+++ b/Include/RmlUi/Core/StringUtilities.h
@@ -78,6 +78,9 @@ namespace StringUtilities
 	/// Encode RML characters, eg. '<' to '&lt;'
 	RMLUICORE_API String EncodeRml(const String& string);
 
+	/// Decode RML characters, eg. '&lt;' to '<'
+	RMLUICORE_API String DecodeRml(const String& string);
+
 	// Replaces all occurences of 'search' in 'subject' with 'replace'.
 	RMLUICORE_API String Replace(String subject, const String& search, const String& replace);
 	// Replaces all occurences of 'search' in 'subject' with 'replace'.

--- a/Source/Core/BaseXMLParser.cpp
+++ b/Source/Core/BaseXMLParser.cpp
@@ -382,7 +382,7 @@ bool BaseXMLParser::ReadAttributes(XMLAttributes& attributes, bool& parse_raw_xm
 		if (attributes_for_inner_xml_data.count(attribute) == 1)
 			parse_raw_xml_content = true;
 
- 		attributes[attribute] = value;
+ 		attributes[attribute] = StringUtilities::DecodeRml(value);
 
 		// Check for the end of the tag.
 		if (PeekString("/", false) || PeekString(">", false))

--- a/Source/Core/StringUtilities.cpp
+++ b/Source/Core/StringUtilities.cpp
@@ -122,6 +122,45 @@ RMLUICORE_API String StringUtilities::EncodeRml(const String& string)
 	return result;
 }
 
+String StringUtilities::DecodeRml(const String& s)
+{
+	String result;
+	result.reserve(s.size());
+	for (size_t i = 0; i < s.size();)
+	{
+		if (s[i] == '&')
+		{
+			if (s[i+1] == 'l' && s[i+2] == 't' && s[i+3] == ';')
+			{
+				result += "<";
+				i += 4;
+				continue;
+			}
+			else if (s[i+1] == 'g' && s[i+2] == 't' && s[i+3] == ';')
+			{
+				result += ">";
+				i += 4;
+				continue;
+			}
+			else if (s[i+1] == 'a' && s[i+2] == 'm' && s[i+3] == 'p' && s[i+4] == ';')
+			{
+				result += "&";
+				i += 5;
+				continue;
+			}
+			else if (s[i+1] == 'q' && s[i+2] == 'u' && s[i+3] == 'o' && s[i+4] == 't' && s[i+5] == ';')
+			{
+				result += "\"";
+				i += 6;
+				continue;
+			}
+		}
+		result += s[i];
+		i += 1;
+	}
+	return result;
+}
+
 String StringUtilities::Replace(String subject, const String& search, const String& replace)
 {
 	size_t pos = 0;


### PR DESCRIPTION
This change allows escaping of element attributes. e.g.

```html
<div data-style-decorator="'image(&quot;image.png&quot;)'" />
```
