### PR TITLE
Find element parent by selector

### DIFF
--- a/Include/RmlUi/Core/Element.h
+++ b/Include/RmlUi/Core/Element.h
@@ -419,9 +419,11 @@ public:
 	/// Gets this element's parent node.
 	/// @return This element's parent.
 	Element* GetParentNode() const;
-	/// Recursively search for a parent of this node matching the given selector.
-	/// @return The parent if found, or nullptr if no parent could be matched
-	Element* FindParent(const String& selector) const;
+	/// Recursively search for a ancestor of this node matching the given selector.
+	/// @param[in] selectors The selector or comma-separated selectors to match against.
+	/// @return The ancestor if found, or nullptr if no ancestor could be matched.
+	/// @performance Prefer GetElementById/TagName/ClassName whenever possible.
+	Element* Closest(const String& selectors) const;
 
 	/// Gets the element immediately following this one in the tree.
 	/// @return This element's next sibling element, or nullptr if there is no sibling element.

--- a/Include/RmlUi/Core/Element.h
+++ b/Include/RmlUi/Core/Element.h
@@ -419,6 +419,9 @@ public:
 	/// Gets this element's parent node.
 	/// @return This element's parent.
 	Element* GetParentNode() const;
+	/// Recursively search for a parent of this node matching the given selector.
+	/// @return The parent if found, or nullptr if no parent could be matched
+	Element* FindParent(const String& selector) const;
 
 	/// Gets the element immediately following this one in the tree.
 	/// @return This element's next sibling element, or nullptr if there is no sibling element.

--- a/Source/Core/Element.cpp
+++ b/Source/Core/Element.cpp
@@ -1023,7 +1023,7 @@ Element* Element::FindParent(const String& selector) const
 	StyleSheetNode root_node;
 	StyleSheetNodeListRaw leaf_nodes = StyleSheetParser::ConstructNodes(root_node, selector);
 
-	 if (leaf_nodes.size() != 1)
+	if (leaf_nodes.size() != 1)
 	{
 		Log::Message(Log::LT_WARNING, "Query selector '%s' does not contain exactly one selector. In element %s", selector.c_str(), GetAddress().c_str());
 		return nullptr;

--- a/Source/Core/Element.cpp
+++ b/Source/Core/Element.cpp
@@ -1017,6 +1017,35 @@ Element* Element::GetParentNode() const
 	return parent;
 }
 
+// Recursively search for a parent of this node matching the given selector.
+Element* Element::FindParent(const String& selector) const
+{
+	StyleSheetNode root_node;
+	StyleSheetNodeListRaw leaf_nodes = StyleSheetParser::ConstructNodes(root_node, selector);
+
+	 if (leaf_nodes.size() != 1)
+	{
+		Log::Message(Log::LT_WARNING, "Query selector '%s' does not contain exactly one selector. In element %s", selector.c_str(), GetAddress().c_str());
+		return nullptr;
+	}
+
+	Element* parent = GetParentNode();
+
+	while(parent)
+	{
+		if(leaf_nodes[0]->IsApplicable(parent, false))
+		{
+			return parent;
+		} 
+		else
+		{
+			parent = parent->GetParentNode();
+		}
+	}
+
+	return nullptr;
+}
+
 // Gets the element immediately following this one in the tree.
 Element* Element::GetNextSibling() const
 {

--- a/Source/Core/Element.cpp
+++ b/Source/Core/Element.cpp
@@ -1017,15 +1017,15 @@ Element* Element::GetParentNode() const
 	return parent;
 }
 
-// Recursively search for a parent of this node matching the given selector.
-Element* Element::FindParent(const String& selector) const
+// Recursively search for a ancestor of this node matching the given selector.
+Element* Element::Closest(const String& selectors) const
 {
 	StyleSheetNode root_node;
-	StyleSheetNodeListRaw leaf_nodes = StyleSheetParser::ConstructNodes(root_node, selector);
+	StyleSheetNodeListRaw leaf_nodes = StyleSheetParser::ConstructNodes(root_node, selectors);
 
-	if (leaf_nodes.size() != 1)
+	if (leaf_nodes.empty())
 	{
-		Log::Message(Log::LT_WARNING, "Query selector '%s' does not contain exactly one selector. In element %s", selector.c_str(), GetAddress().c_str());
+		Log::Message(Log::LT_WARNING, "Query selector '%s' is empty. In element %s", selectors.c_str(), GetAddress().c_str());
 		return nullptr;
 	}
 
@@ -1033,14 +1033,15 @@ Element* Element::FindParent(const String& selector) const
 
 	while(parent)
 	{
-		if(leaf_nodes[0]->IsApplicable(parent, false))
+		for (const StyleSheetNode* node : leaf_nodes)
 		{
-			return parent;
-		} 
-		else
-		{
-			parent = parent->GetParentNode();
+			if (node->IsApplicable(parent, false))
+			{
+				return parent;
+			}
 		}
+		
+		parent = parent->GetParentNode();
 	}
 
 	return nullptr;


### PR DESCRIPTION
Currently there are selection methods to find children by selector but not recursive parents, so I added one.

Since the methods for query selector parsing are implementation-private, I couldnt actually do this in my own project, so why not create a PR. (exposing those functions could be another nice addition)