### PR TITLE
Added support of (smart) pointers as members and added support for "T& getter()" getters

### DIFF
--- a/Include/RmlUi/Core/DataModelHandle.h
+++ b/Include/RmlUi/Core/DataModelHandle.h
@@ -110,6 +110,23 @@ public:
 		return type_register->RegisterArray<Container>();
 	}
 
+	// Register a pointer type.
+	// @note The type applies to every data model associated with the current Context.
+	// @note If 'PointerType' represents a non-scalar type, that type must already have been registered with the appropriate 'Register...()' functions.
+	template<typename PointerType>
+	bool RegisterPointer() {
+		return type_register->RegisterPointer<PointerType>();
+	}
+
+	// Register an array type.
+	// @note The type applies to every data model associated with the current Context.
+	// @note If 'PointerType::element_type' represents a non-scalar type, that type must already have been registered with the appropriate 'Register...()' functions.
+	// @note PointerType requires the following functions to be implemented: PointerType::element_type* get(). This is satisfied by several "pointer containers" such as std::shared_ptr.
+	template<typename PointerType>
+	bool RegisterComplexPointer() {
+		return type_register->RegisterComplexPointer<PointerType>();
+	}
+
 	// Register a transform function.
 	// A transform function modifies a variant with optional arguments. It can be called in data expressions using the pipe '|' operator.
 	// @note The transform function applies to every data model associated with the current Context.

--- a/Include/RmlUi/Core/DataTypeRegister.h
+++ b/Include/RmlUi/Core/DataTypeRegister.h
@@ -187,12 +187,15 @@ private:
 };
 
 template<typename Object>
-template<typename MemberType>
+template <typename MemberType>
 inline StructHandle<Object>& StructHandle<Object>::RegisterMember(const String& name, MemberType Object::* member_ptr) {
-	VariableDefinition* member_type = type_register->GetOrAddScalar<MemberType>();
-	struct_definition->AddMember(name, MakeUnique<StructMemberObject<Object, MemberType>>(member_type, member_ptr));
-	return *this;
+    using MemberTypeValue = typename std::remove_pointer<MemberType>::type;
+    using MemberTypeValue2 = typename Rml::remove_smart_pointer<MemberTypeValue>::type;
+    VariableDefinition* member_type = type_register->GetOrAddScalar<MemberTypeValue2>();
+    struct_definition->AddMember(name, MakeUnique<StructMemberObject<Object, MemberType>>(member_type, member_ptr));
+    return *this;
 }
+
 template<typename Object>
 inline StructHandle<Object>& StructHandle<Object>::RegisterMemberFunc(const String& name, MemberGetFunc<Object> get_func, MemberSetFunc<Object> set_func) {
 	VariableDefinition* definition = type_register->RegisterMemberFunc<Object>(get_func, set_func);

--- a/Include/RmlUi/Core/DataVariable.h
+++ b/Include/RmlUi/Core/DataVariable.h
@@ -199,6 +199,35 @@ private:
 	MemberType Object::* member_ptr;
 };
 
+template <typename Object, typename MemberType>
+class StructMemberObject<Object, MemberType*> final : public StructMember {
+public:
+    StructMemberObject(VariableDefinition* definition, MemberType* Object::* member_ptr) : StructMember(definition), member_ptr(member_ptr) {}
+    
+    void* GetPointer(void* base_ptr) override {
+        auto ptr = (const void*)(static_cast<Object*>(base_ptr)->*member_ptr);
+        return const_cast<void*>(ptr);
+    }
+
+private:
+    MemberType* Object::* member_ptr;
+};
+
+template <typename Object, typename MemberType>
+class StructMemberObject<Object, SharedPtr<MemberType>> final : public StructMember {
+public:
+    StructMemberObject(VariableDefinition* definition, SharedPtr<MemberType> Object::* member_ptr) : StructMember(definition), member_ptr(member_ptr) {}
+
+    void* GetPointer(void* base_ptr) override {
+        SharedPtr<MemberType> shptr = (static_cast<Object*>(base_ptr)->*member_ptr);
+        auto ptr = (const void*) shptr.get();
+        return const_cast<void*>(ptr);
+    }
+
+private:
+    SharedPtr<MemberType> Object::* member_ptr;
+};
+
 class StructMemberFunc final : public StructMember {
 public:
 	StructMemberFunc(VariableDefinition* definition) : StructMember(definition) {}

--- a/Include/RmlUi/Core/DataVariable.h
+++ b/Include/RmlUi/Core/DataVariable.h
@@ -232,6 +232,7 @@ public:
 		return int(static_cast<Container*>(ptr)->size());
 	}
 
+	using value_type = typename Container::value_type;
 protected:
 	DataVariable Child(void* void_ptr, const DataAddressEntry& address) override
 	{
@@ -251,7 +252,7 @@ protected:
 		auto it = ptr->begin();
 		std::advance(it, index);
 
-		void* next_ptr = &(*it);
+		void* next_ptr = Extractor<value_type, void*, value_type>::ConvertPointer(*it);
 		return DataVariable(underlying_definition, next_ptr);
 	}
 
@@ -312,6 +313,11 @@ struct Extractor {
         auto v = (const void*)&(res);
         return const_cast<void*>(v);
     }
+    static void* ConvertPointer(Object& base_obj)
+    {
+        auto v = (const void*)&(base_obj);
+        return const_cast<void*>(v);
+    }
 };
 
 template <typename Object, typename GetterType, typename ReturnType>
@@ -323,6 +329,11 @@ struct Extractor<Object, GetterType, ReturnType*> {
         auto ptr = (const void*)(res);
         return const_cast<void*>(ptr);
     }
+	static void* ConvertPointer(Object& base_obj)
+	{
+		auto v = (const void*)(base_obj);
+		return const_cast<void*>(v);
+	}
 };
 
 template <typename Object, typename GetterType>

--- a/Include/RmlUi/Core/DataVariable.h
+++ b/Include/RmlUi/Core/DataVariable.h
@@ -47,6 +47,38 @@ enum class DataVariableType { Scalar, Array, Struct, Function, MemberFunction };
 *   Together they can be used to get and set variables between the user side and data model side.
 */
 
+template <typename Object, typename GetterType, typename ReturnType>
+struct Extractor {
+	static void* ExtractPointer(void* base_ptr, GetterType member_ptr)
+	{
+		auto tmp = static_cast<Object*>(base_ptr);
+		auto &res = (tmp->*member_ptr)();
+		auto v = (const void*)&(res);
+		return const_cast<void*>(v);
+	}
+	static void* ConvertPointer(Object& base_obj)
+	{
+		auto v = (const void*)&(base_obj);
+		return const_cast<void*>(v);
+	}
+};
+
+template <typename Object, typename GetterType, typename ReturnType>
+struct Extractor<Object, GetterType, ReturnType*> {
+	static void* ExtractPointer(void* base_ptr, GetterType member_ptr)
+	{
+		auto tmp = static_cast<Object*>(base_ptr);
+		auto res = (tmp->*member_ptr)();
+		auto ptr = (const void*)(res);
+		return const_cast<void*>(ptr);
+	}
+	static void* ConvertPointer(Object& base_obj)
+	{
+		auto v = (const void*)(base_obj);
+		return const_cast<void*>(v);
+	}
+};
+
 class RMLUICORE_API DataVariable {
 public:
 	DataVariable() {}
@@ -302,38 +334,6 @@ public:
 
 private:
 	MemberType* Object::* member_ptr;
-};
-
-template <typename Object, typename GetterType, typename ReturnType>
-struct Extractor {
-    static void* ExtractPointer(void* base_ptr, GetterType member_ptr)
-    {
-        auto tmp = static_cast<Object*>(base_ptr);
-        auto &res = (tmp->*member_ptr)();
-        auto v = (const void*)&(res);
-        return const_cast<void*>(v);
-    }
-    static void* ConvertPointer(Object& base_obj)
-    {
-        auto v = (const void*)&(base_obj);
-        return const_cast<void*>(v);
-    }
-};
-
-template <typename Object, typename GetterType, typename ReturnType>
-struct Extractor<Object, GetterType, ReturnType*> {
-    static void* ExtractPointer(void* base_ptr, GetterType member_ptr)
-    {
-        auto tmp = static_cast<Object*>(base_ptr);
-        auto res = (tmp->*member_ptr)();
-        auto ptr = (const void*)(res);
-        return const_cast<void*>(ptr);
-    }
-	static void* ConvertPointer(Object& base_obj)
-	{
-		auto v = (const void*)(base_obj);
-		return const_cast<void*>(v);
-	}
 };
 
 template <typename Object, typename GetterType>

--- a/Include/RmlUi/Core/DataVariable.h
+++ b/Include/RmlUi/Core/DataVariable.h
@@ -120,7 +120,7 @@ public:
 		variant = *static_cast<T*>(ptr);
 		return true;
 	}
-	bool Set(void* ptr, const Variant& variant) override
+	bool Set(void* RMLUI_UNUSED_PARAMETER(ptr), const Variant& RMLUI_UNUSED_PARAMETER(variant)) override
 	{
         Log::Message(Log::LT_WARNING, "Only getter exposed for this variable.");
         return false;
@@ -256,7 +256,7 @@ struct Extractor {
 
 template <typename Object, typename GetterType>
 struct Extractor<SharedPtr<Object>, GetterType, Object*> {
-    static void* ExtractPointer(void* base_ptr, GetterType member_ptr)
+    static void* ExtractPointer(void* base_ptr, GetterType RMLUI_UNUSED_PARAMETER(member_ptr))
     {
         SharedPtr<Object>* obj = static_cast<SharedPtr<Object>*>(base_ptr);
         Object* val = obj->get();

--- a/Include/RmlUi/Core/Traits.h
+++ b/Include/RmlUi/Core/Traits.h
@@ -96,8 +96,21 @@ public:
 		return GetId< typename std::remove_cv< typename std::remove_reference< T >::type >::type >();
 	}
 };
-
-} // namespace Rml
+    
+    template< class T > struct remove_smart_pointer                    {typedef T type;};
+    template< class T > struct remove_smart_pointer<SharedPtr<T>> {typedef T type;};
+    template< class T > struct remove_smart_pointer<SharedPtr<const T>> {typedef T type;};
+    template< class T > struct remove_smart_pointer<SharedPtr<T>&> {typedef T type;};
+    template< class T > struct remove_smart_pointer<SharedPtr<const T>&> {typedef T type;};
+    
+    template<typename MemberType>
+    struct remove_raw_smart_pointer
+    {
+        using _type1 = typename std::remove_const<MemberType>::type;
+        using _type2 = typename Rml::remove_smart_pointer<_type1>::type;
+        using type = typename std::remove_pointer<_type2>::type;
+    };
+}; // namespace Rml
 
 
 

--- a/Include/RmlUi/Core/Traits.h
+++ b/Include/RmlUi/Core/Traits.h
@@ -110,7 +110,7 @@ public:
         using _type2 = typename Rml::remove_smart_pointer<_type1>::type;
         using type = typename std::remove_pointer<_type2>::type;
     };
-}; // namespace Rml
+} // namespace Rml
 
 
 

--- a/Source/Core/DataModel.cpp
+++ b/Source/Core/DataModel.cpp
@@ -292,6 +292,7 @@ DataVariable DataModel::GetVariable(const DataAddress& address) const
 		for (int i = 1; i < (int)address.size() && variable; i++)
 		{
 			variable = variable.Child(address[i]);
+            variable.Access(variable);
 			if (!variable)
 				return DataVariable();
 		}

--- a/Source/Core/DataVariable.cpp
+++ b/Source/Core/DataVariable.cpp
@@ -30,6 +30,15 @@
 
 namespace Rml {
 
+void DataVariable::Access(DataVariable& out) {
+	if(this->definition == nullptr)
+		return;
+	auto ndef = this->definition;
+	void* nptr = nullptr;
+    this->definition->Access(ptr, ndef, nptr);
+    out = DataVariable(ndef, nptr);
+}
+
 bool DataVariable::Get(Variant& variant) {
     return definition->Get(ptr, variant);
 }
@@ -50,7 +59,9 @@ DataVariableType DataVariable::Type() {
     return definition->Type();
 }
 
-
+void VariableDefinition::Access(void* ptr, VariableDefinition*& output_def, void*& output_ptr){
+	output_ptr = ptr;
+}
 bool VariableDefinition::Get(void* /*ptr*/, Variant& /*variant*/) {
     Log::Message(Log::LT_WARNING, "Values can only be retrieved from scalar data types.");
     return false;

--- a/Source/Core/DataVariable.cpp
+++ b/Source/Core/DataVariable.cpp
@@ -59,7 +59,7 @@ DataVariableType DataVariable::Type() {
     return definition->Type();
 }
 
-void VariableDefinition::Access(void* ptr, VariableDefinition*& output_def, void*& output_ptr){
+void VariableDefinition::Access(void* ptr, VariableDefinition*& /*output_def*/, void*& output_ptr){
 	output_ptr = ptr;
 }
 bool VariableDefinition::Get(void* /*ptr*/, Variant& /*variant*/) {


### PR DESCRIPTION
Added support of (smart) pointers as members and added "T& getter()" getters.

Newly supported member types:
- T*
- SharedPtr<T>


Getters supported (not limited to, might be more I didn't think of/test):
- T& getter();
- T* getter();
- const T* getter();
- T* getter() const;
- const T* getter() const;
- SharedPtr<T> getter();
- <scalar> getter() const;