### PR TITLE
Add missing SetAttributes call when cloning Element

### DIFF
--- a/Source/Core/Element.cpp
+++ b/Source/Core/Element.cpp
@@ -257,6 +257,9 @@ ElementPtr Element::Clone() const
 
 	if (clone != nullptr)
 	{
+		// Set the attributes manually in case the instancer does not set them.
+		clone->SetAttributes(attributes);
+
 		String inner_rml;
 		GetInnerRML(inner_rml);
 


### PR DESCRIPTION
When calling Element::Clone the default element instancer omits the top-level element's attributes, so I added a manual call to copy the attributes to the clone to make sure they exist.