### PR TITLE
Fix typo in conditional potentially causing incorrect results

### DIFF
--- a/Source/Core/LayoutBlockBox.cpp
+++ b/Source/Core/LayoutBlockBox.cpp
@@ -306,7 +306,7 @@ LayoutBlockBox::CloseResult LayoutBlockBox::Close()
 
 			if (found_baseline)
 			{
-				if (baseline < 0 && (overflow_x_property != Style::Overflow::Visible || overflow_x_property != Style::Overflow::Visible))
+				if (baseline < 0 && (overflow_x_property != Style::Overflow::Visible || overflow_y_property != Style::Overflow::Visible))
 				{
 					baseline = 0;
 				}


### PR DESCRIPTION
The OR expression originally had the same expression on both the LHS and RHS.
Looks like a typo, since `overflow_y_property` exists and it looks like the program might want to check both there. 