### PR TITLE
Rml::UnregisterPlugin and Rml::Debugger::Shutdown

### DIFF
--- a/Include/RmlUi/Core/Core.h
+++ b/Include/RmlUi/Core/Core.h
@@ -134,6 +134,9 @@ RMLUICORE_API bool LoadFontFace(const byte* data, int data_size, const String& f
 /// Registers a generic RmlUi plugin.
 RMLUICORE_API void RegisterPlugin(Plugin* plugin);
 
+/// Unregisters a generic RmlUi plugin.
+RMLUICORE_API void UnregisterPlugin(Plugin* plugin);
+
 /// Registers a new event type. If the type already exists, it will replace custom event types, but not internal types.
 /// @param[in] type The new event type.
 /// @param[in] interruptible Whether the event can be interrupted during dispatch.

--- a/Include/RmlUi/Debugger/Debugger.h
+++ b/Include/RmlUi/Debugger/Debugger.h
@@ -42,6 +42,10 @@ namespace Debugger {
 /// @return True if the debugger was successfully initialised
 RMLUIDEBUGGER_API bool Initialise(Context* context);
 
+/// Shuts down the debugger.
+/// @return True if the debugger was successfully shut down
+RMLUIDEBUGGER_API bool Shutdown();
+
 /// Sets the context to be debugged.
 /// @param[in] context The context to be debugged.
 /// @return True if the debugger is initialised and the context was switched, false otherwise.

--- a/Source/Core/Core.cpp
+++ b/Source/Core/Core.cpp
@@ -342,6 +342,15 @@ void RegisterPlugin(Plugin* plugin)
 	PluginRegistry::RegisterPlugin(plugin);
 }
 
+// Unregisters a generic rmlui plugin
+void UnregisterPlugin(Plugin* plugin)
+{
+	PluginRegistry::UnregisterPlugin(plugin);
+
+	if(initialised)
+		plugin->OnShutdown();
+}
+
 EventId RegisterEventType(const String& type, bool interruptible, bool bubbles, DefaultActionPhase default_action_phase)
 {
 	return EventSpecificationInterface::InsertOrReplaceCustom(type, interruptible, bubbles, default_action_phase);

--- a/Source/Core/PluginRegistry.cpp
+++ b/Source/Core/PluginRegistry.cpp
@@ -28,6 +28,7 @@
 
 #include "PluginRegistry.h"
 #include "../../Include/RmlUi/Core/Plugin.h"
+#include <algorithm>
 
 namespace Rml {
 
@@ -50,6 +51,18 @@ void PluginRegistry::RegisterPlugin(Plugin* plugin)
 		document_plugins.push_back(plugin);
 	if (event_classes & Plugin::EVT_ELEMENT)
 		element_plugins.push_back(plugin);
+}
+
+void PluginRegistry::UnregisterPlugin(Plugin* plugin)
+{
+	int event_classes = plugin->GetEventClasses();
+
+	if(event_classes & Plugin::EVT_BASIC)
+		basic_plugins.erase(std::remove(basic_plugins.begin(), basic_plugins.end(), plugin), basic_plugins.end());
+	if(event_classes & Plugin::EVT_DOCUMENT)
+		document_plugins.erase(std::remove(document_plugins.begin(), document_plugins.end(), plugin), document_plugins.end());
+	if(event_classes & Plugin::EVT_ELEMENT)
+		element_plugins.erase(std::remove(element_plugins.begin(), element_plugins.end(), plugin), element_plugins.end());
 }
 
 // Calls OnInitialise() on all plugins.

--- a/Source/Core/PluginRegistry.h
+++ b/Source/Core/PluginRegistry.h
@@ -46,6 +46,7 @@ class PluginRegistry
 {
 public:
 	static void RegisterPlugin(Plugin* plugin);
+	static void UnregisterPlugin(Plugin* plugin);
 
 	/// Calls OnInitialise() on all plugins.
 	static void NotifyInitialise();

--- a/Source/Debugger/Debugger.cpp
+++ b/Source/Debugger/Debugger.cpp
@@ -57,6 +57,20 @@ bool Initialise(Context* context)
 	return true;
 }
 
+// Shuts down the debugger.
+bool Shutdown()
+{
+	DebuggerPlugin* plugin = DebuggerPlugin::GetInstance();
+	if(plugin == nullptr) {
+		Log::Message(Log::LT_WARNING, "Unable to shutdown debugger plugin, it was not initialised!");
+		return false;
+	}
+
+	UnregisterPlugin(plugin);
+
+	return true;
+}
+
 // Sets the context to be debugged.
 bool SetContext(Context* context)
 {


### PR DESCRIPTION
I've had to add a way to unregister a plugin, otherwise the stale plugin pointer would be used in various places. Hope that's not too much a deviation from what we talked about in https://github.com/mikke89/RmlUi/issues/200. I've been able to use this locally and it worked very well. It may even come in handy to be able to arbitrarily unregister specific plugins in the future...