### PR TITLE
Fixed a rounding error in the border radius color lerp

### DIFF
--- a/Source/Core/GeometryBackgroundBorder.cpp
+++ b/Source/Core/GeometryBackgroundBorder.cpp
@@ -260,13 +260,13 @@ void GeometryBackgroundBorder::DrawArc(Vector2f pos_center, Vector2f r, float a0
 		const float a = Math::Lerp(t, a0, a1);
 		const Colourb color
 		{
-			static_cast<unsigned char>(std::lroundf(Math::Lerp(t, 
+			static_cast<unsigned char>(Math::RoundToInteger(Math::Lerp(t, 
 				static_cast<float>(color0[0]), static_cast<float>(color1[0])))),
-			static_cast<unsigned char>(std::lroundf(Math::Lerp(t, 
+			static_cast<unsigned char>(Math::RoundToInteger(Math::Lerp(t, 
 				static_cast<float>(color0[1]), static_cast<float>(color1[1])))),
-			static_cast<unsigned char>(std::lroundf(Math::Lerp(t, 
+			static_cast<unsigned char>(Math::RoundToInteger(Math::Lerp(t, 
 				static_cast<float>(color0[2]), static_cast<float>(color1[2])))),
-			static_cast<unsigned char>(std::lroundf(Math::Lerp(t, 
+			static_cast<unsigned char>(Math::RoundToInteger(Math::Lerp(t, 
 				static_cast<float>(color0[3]), static_cast<float>(color1[3]))))
 		};
 
@@ -348,13 +348,13 @@ void GeometryBackgroundBorder::DrawArcArc(Vector2f pos_center, float R, Vector2f
 		const float a = Math::Lerp(t, a0, a1);
 		const Colourb color
 		{
-			static_cast<unsigned char>(std::lroundf(Math::Lerp(t, 
+			static_cast<unsigned char>(Math::RoundToInteger(Math::Lerp(t, 
 				static_cast<float>(color0[0]), static_cast<float>(color1[0])))),
-			static_cast<unsigned char>(std::lroundf(Math::Lerp(t, 
+			static_cast<unsigned char>(Math::RoundToInteger(Math::Lerp(t, 
 				static_cast<float>(color0[1]), static_cast<float>(color1[1])))),
-			static_cast<unsigned char>(std::lroundf(Math::Lerp(t, 
+			static_cast<unsigned char>(Math::RoundToInteger(Math::Lerp(t, 
 				static_cast<float>(color0[2]), static_cast<float>(color1[2])))),
-			static_cast<unsigned char>(std::lroundf(Math::Lerp(t, 
+			static_cast<unsigned char>(Math::RoundToInteger(Math::Lerp(t, 
 				static_cast<float>(color0[3]), static_cast<float>(color1[3]))))
 		};
 

--- a/Source/Core/GeometryBackgroundBorder.cpp
+++ b/Source/Core/GeometryBackgroundBorder.cpp
@@ -258,7 +258,17 @@ void GeometryBackgroundBorder::DrawArc(Vector2f pos_center, Vector2f r, float a0
 		const float t = float(i) / float(num_points - 1);
 
 		const float a = Math::Lerp(t, a0, a1);
-		const Colourb color = Math::Lerp(t, color0, color1);
+		const Colourb color
+		{
+			static_cast<unsigned char>(std::lroundf(Math::Lerp(t, 
+				static_cast<float>(color0[0]), static_cast<float>(color1[0])))),
+			static_cast<unsigned char>(std::lroundf(Math::Lerp(t, 
+				static_cast<float>(color0[1]), static_cast<float>(color1[1])))),
+			static_cast<unsigned char>(std::lroundf(Math::Lerp(t, 
+				static_cast<float>(color0[2]), static_cast<float>(color1[2])))),
+			static_cast<unsigned char>(std::lroundf(Math::Lerp(t, 
+				static_cast<float>(color0[3]), static_cast<float>(color1[3]))))
+		};
 
 		const Vector2f unit_vector(Math::Cos(a), Math::Sin(a));
 
@@ -336,7 +346,17 @@ void GeometryBackgroundBorder::DrawArcArc(Vector2f pos_center, float R, Vector2f
 		const float t = float(i) / float(num_points - 1);
 
 		const float a = Math::Lerp(t, a0, a1);
-		const Colourb color = Math::Lerp(t, color0, color1);
+		const Colourb color
+		{
+			static_cast<unsigned char>(std::lroundf(Math::Lerp(t, 
+				static_cast<float>(color0[0]), static_cast<float>(color1[0])))),
+			static_cast<unsigned char>(std::lroundf(Math::Lerp(t, 
+				static_cast<float>(color0[1]), static_cast<float>(color1[1])))),
+			static_cast<unsigned char>(std::lroundf(Math::Lerp(t, 
+				static_cast<float>(color0[2]), static_cast<float>(color1[2])))),
+			static_cast<unsigned char>(std::lroundf(Math::Lerp(t, 
+				static_cast<float>(color0[3]), static_cast<float>(color1[3]))))
+		};
 
 		const Vector2f unit_vector(Math::Cos(a), Math::Sin(a));
 

--- a/Source/Core/GeometryBackgroundBorder.h
+++ b/Source/Core/GeometryBackgroundBorder.h
@@ -31,6 +31,7 @@
 
 #include "../../Include/RmlUi/Core/Types.h"
 #include "../../Include/RmlUi/Core/Vertex.h"
+#include <math.h>
 
 namespace Rml {
 

--- a/Source/Core/GeometryBackgroundBorder.h
+++ b/Source/Core/GeometryBackgroundBorder.h
@@ -31,7 +31,6 @@
 
 #include "../../Include/RmlUi/Core/Types.h"
 #include "../../Include/RmlUi/Core/Vertex.h"
-#include <math.h>
 
 namespace Rml {
 


### PR DESCRIPTION
The lerp on the colors in the border radius code sometimes had an error that happened because the result was truncated instead of rounded.

It could be seen when blending two colors that were the same. The points along the arc would have different colors, like this:
```
DEBUG: color is 255, 224, 102
DEBUG: color is 255, 223, 101
DEBUG: color is 255, 223, 101
DEBUG: color is 254, 223, 101
DEBUG: color is 254, 223, 101
DEBUG: color is 255, 224, 102
DEBUG: color is 255, 224, 102
```

This is what this behavior would look like:
![qwerty](https://user-images.githubusercontent.com/78047391/125102601-b3230680-e098-11eb-9cf0-4bdcdd80fc91.png)

I didn't modify the lerp function itself. I only changed the way it is called in this specific case. There may be other places where a similar fix is needed.
