### PR TITLE
Overcome a limitation of binding data variables to checkboxes

### DIFF
--- a/Source/Core/DataControllerDefault.h
+++ b/Source/Core/DataControllerDefault.h
@@ -42,33 +42,37 @@ class DataModel;
 class DataExpression;
 using DataExpressionPtr = UniquePtr<DataExpression>;
 
-
-class DataControllerValue : public DataController, private EventListener {
+class DataControllerAttributeBased : public DataController, private EventListener {
 public:
-    DataControllerValue(Element* element);
-    ~DataControllerValue();
+    DataControllerAttributeBased(Element* element, String attribute);
+    ~DataControllerAttributeBased();
 
     bool Initialize(DataModel& model, Element* element, const String& expression, const String& modifier) override;
 
-protected:
+private:
     // Responds to 'Change' events.
     void ProcessEvent(Event& event) override;
     
     // Delete this.
     void Release() override;
 
-    // Set the new value on the variable, returns true if it should be dirtied.
-    virtual bool SetValue(const Variant& new_value, DataVariable variable);
-
     DataAddress address;
+    String attribute;
 };
 
 
-class DataControllerChecked final : public DataControllerValue {
+class DataControllerAttributeBasedInstancer final : public DataControllerInstancer {
 public:
-    DataControllerChecked(Element* element);
+    DataControllerAttributeBasedInstancer(String attribute)
+        : attribute(std::move(attribute))
+    {}
 
-    bool SetValue(const Variant& new_value, DataVariable variable) override;
+    DataControllerPtr InstanceController(Element* element) override {
+        return DataControllerPtr(new DataControllerAttributeBased(element, attribute));
+    }
+
+private:
+    String attribute;
 };
 
 

--- a/Source/Core/DataControllerDefault.h
+++ b/Source/Core/DataControllerDefault.h
@@ -42,10 +42,10 @@ class DataModel;
 class DataExpression;
 using DataExpressionPtr = UniquePtr<DataExpression>;
 
-class DataControllerAttributeBased : public DataController, private EventListener {
+class DataControllerValue : public DataController, private EventListener {
 public:
-    DataControllerAttributeBased(Element* element, String attribute);
-    ~DataControllerAttributeBased();
+    DataControllerValue(Element* element);
+    ~DataControllerValue();
 
     bool Initialize(DataModel& model, Element* element, const String& expression, const String& modifier) override;
 
@@ -57,22 +57,6 @@ private:
     void Release() override;
 
     DataAddress address;
-    String attribute;
-};
-
-
-class DataControllerAttributeBasedInstancer final : public DataControllerInstancer {
-public:
-    DataControllerAttributeBasedInstancer(String attribute)
-        : attribute(std::move(attribute))
-    {}
-
-    DataControllerPtr InstanceController(Element* element) override {
-        return DataControllerPtr(new DataControllerAttributeBased(element, attribute));
-    }
-
-private:
-    String attribute;
 };
 
 

--- a/Source/Core/Elements/InputTypeCheckbox.cpp
+++ b/Source/Core/Elements/InputTypeCheckbox.cpp
@@ -39,6 +39,12 @@ InputTypeCheckbox::~InputTypeCheckbox()
 {
 }
 
+String InputTypeCheckbox::GetValue() const
+{
+	auto value = InputType::GetValue();
+	return value.empty() ? "on" : value;
+}
+
 // Returns if this value should be submitted with the form.
 bool InputTypeCheckbox::IsSubmitted()
 {
@@ -52,11 +58,9 @@ bool InputTypeCheckbox::OnAttributeChange(const ElementAttributes& changed_attri
 	{
 		const bool checked = element->HasAttribute("checked");
 		element->SetPseudoClass("checked", checked);
-
-		const auto value = GetValue();
 		element->DispatchEvent(EventId::Change, {
-			{ "checked", Variant(checked) },
-			{ "value", Variant(checked ? (value.empty() ? "on" : value) : "") }
+			{ "data-binding-override-value", Variant(checked) },
+			{ "value", Variant(checked ? GetValue() : "") }
 		});
 	}
 

--- a/Source/Core/Elements/InputTypeCheckbox.cpp
+++ b/Source/Core/Elements/InputTypeCheckbox.cpp
@@ -48,15 +48,16 @@ bool InputTypeCheckbox::IsSubmitted()
 // Checks for necessary functional changes in the control as a result of changed attributes.
 bool InputTypeCheckbox::OnAttributeChange(const ElementAttributes& changed_attributes)
 {
-	// Check if maxlength has been defined.
-	if (changed_attributes.find("checked") != changed_attributes.end())
+	if (changed_attributes.count("checked"))
 	{
-		bool checked = element->HasAttribute("checked");
+		const bool checked = element->HasAttribute("checked");
 		element->SetPseudoClass("checked", checked);
 
-		Dictionary parameters;
-		parameters["value"] = String(checked ? GetValue() : "");
-		element->DispatchEvent(EventId::Change, parameters);
+		const auto value = GetValue();
+		element->DispatchEvent(EventId::Change, {
+			{ "checked", Variant(checked) },
+			{ "value", Variant(checked ? (value.empty() ? "on" : value) : "") }
+		});
 	}
 
 	return true;
@@ -65,8 +66,7 @@ bool InputTypeCheckbox::OnAttributeChange(const ElementAttributes& changed_attri
 // Checks for necessary functional changes in the control as a result of the event.
 void InputTypeCheckbox::ProcessDefaultAction(Event& event)
 {
-	if (event == EventId::Click &&
-		!element->IsDisabled())
+	if (event == EventId::Click && !element->IsDisabled())
 	{
 		if (element->HasAttribute("checked"))
 			element->RemoveAttribute("checked");

--- a/Source/Core/Elements/InputTypeCheckbox.h
+++ b/Source/Core/Elements/InputTypeCheckbox.h
@@ -45,6 +45,10 @@ public:
 	InputTypeCheckbox(ElementFormControlInput* element);
 	virtual ~InputTypeCheckbox();
 
+	/// Returns a string representation of the current value of the form control.
+	/// @return The value of the form control.
+	String GetValue() const override;
+
 	/// Returns if this value should be submitted with the form.
 	/// @return True if the form control is to be submitted, false otherwise.
 	bool IsSubmitted() override;

--- a/Source/Core/Elements/InputTypeRadio.cpp
+++ b/Source/Core/Elements/InputTypeRadio.cpp
@@ -43,6 +43,12 @@ InputTypeRadio::~InputTypeRadio()
 {
 }
 
+String InputTypeRadio::GetValue() const
+{
+	auto value = InputType::GetValue();
+	return value.empty() ? "on" : value;
+}
+
 // Returns if this value should be submitted with the form.
 bool InputTypeRadio::IsSubmitted()
 {
@@ -62,8 +68,7 @@ bool InputTypeRadio::OnAttributeChange(const ElementAttributes& changed_attribut
 
 		const auto perceived_value = Variant(checked ? GetValue() : "");
 		element->DispatchEvent(EventId::Change, {
-			{ "checked", perceived_value },
-			{ "should_affect_data_binding", Variant(checked) },
+			{ "data-binding-override-value", checked ? Variant(perceived_value) : Variant() },
 			{ "value", perceived_value }
 		});
 	}

--- a/Source/Core/Elements/InputTypeRadio.cpp
+++ b/Source/Core/Elements/InputTypeRadio.cpp
@@ -52,8 +52,7 @@ bool InputTypeRadio::IsSubmitted()
 // Checks for necessary functional changes in the control as a result of changed attributes.
 bool InputTypeRadio::OnAttributeChange(const ElementAttributes& changed_attributes)
 {
-	// Check if maxlength has been defined.
-	if (changed_attributes.find("checked") != changed_attributes.end())
+	if (changed_attributes.count("checked"))
 	{
 		bool checked = element->HasAttribute("checked");
 		element->SetPseudoClass("checked", checked);
@@ -61,9 +60,12 @@ bool InputTypeRadio::OnAttributeChange(const ElementAttributes& changed_attribut
 		if (checked)
 			PopRadioSet();
 
-		Dictionary parameters;
-		parameters["value"] = String(checked ? GetValue() : "");
-		element->DispatchEvent(EventId::Change, parameters);
+		const auto perceived_value = Variant(checked ? GetValue() : "");
+		element->DispatchEvent(EventId::Change, {
+			{ "checked", perceived_value },
+			{ "should_affect_data_binding", Variant(checked) },
+			{ "value", perceived_value }
+		});
 	}
 
 	return true;
@@ -79,8 +81,7 @@ void InputTypeRadio::OnChildAdd()
 // Checks for necessary functional changes in the control as a result of the event.
 void InputTypeRadio::ProcessDefaultAction(Event& event)
 {
-	if (event == EventId::Click &&
-		!element->IsDisabled())
+	if (event == EventId::Click && !element->IsDisabled())
 		element->SetAttribute("checked", "");
 }
 

--- a/Source/Core/Elements/InputTypeRadio.h
+++ b/Source/Core/Elements/InputTypeRadio.h
@@ -45,6 +45,10 @@ public:
 	InputTypeRadio(ElementFormControlInput* element);
 	virtual ~InputTypeRadio();
 
+	/// Returns a string representation of the current value of the form control.
+	/// @return The value of the form control.
+	String GetValue() const override;
+
 	/// Returns if this value should be submitted with the form.
 	/// @return True if the form control is to be submitted, false otherwise.
 	bool IsSubmitted() override;

--- a/Source/Core/Factory.cpp
+++ b/Source/Core/Factory.cpp
@@ -186,9 +186,8 @@ struct DefaultInstancers {
 	DataViewInstancerDefault<DataViewFor> structural_data_view_for;
 
 	// Data binding controllers
-	DataControllerAttributeBasedInstancer data_controller_checked { "checked" };
 	DataControllerInstancerDefault<DataControllerEvent> data_controller_event;
-	DataControllerAttributeBasedInstancer data_controller_value { "value" };
+	DataControllerInstancerDefault<DataControllerValue> data_controller_value;
 };
 
 static UniquePtr<DefaultInstancers> default_instancers;
@@ -279,7 +278,7 @@ bool Factory::Initialise()
 	RegisterDataViewInstancer(&default_instancers->structural_data_view_for, "for",     true );
 
 	// Data binding controllers
-	RegisterDataControllerInstancer(&default_instancers->data_controller_checked, "checked");
+	RegisterDataControllerInstancer(&default_instancers->data_controller_value, "checked");
 	RegisterDataControllerInstancer(&default_instancers->data_controller_event, "event");
 	RegisterDataControllerInstancer(&default_instancers->data_controller_value, "value");
 

--- a/Source/Core/Factory.cpp
+++ b/Source/Core/Factory.cpp
@@ -186,9 +186,9 @@ struct DefaultInstancers {
 	DataViewInstancerDefault<DataViewFor> structural_data_view_for;
 
 	// Data binding controllers
-	DataControllerInstancerDefault<DataControllerValue> data_controller_value;
+	DataControllerAttributeBasedInstancer data_controller_checked { "checked" };
 	DataControllerInstancerDefault<DataControllerEvent> data_controller_event;
-	DataControllerInstancerDefault<DataControllerChecked> data_controller_checked;
+	DataControllerAttributeBasedInstancer data_controller_value { "value" };
 };
 
 static UniquePtr<DefaultInstancers> default_instancers;
@@ -279,9 +279,9 @@ bool Factory::Initialise()
 	RegisterDataViewInstancer(&default_instancers->structural_data_view_for, "for",     true );
 
 	// Data binding controllers
-	RegisterDataControllerInstancer(&default_instancers->data_controller_value, "value");
-	RegisterDataControllerInstancer(&default_instancers->data_controller_event, "event");
 	RegisterDataControllerInstancer(&default_instancers->data_controller_checked, "checked");
+	RegisterDataControllerInstancer(&default_instancers->data_controller_event, "event");
+	RegisterDataControllerInstancer(&default_instancers->data_controller_value, "value");
 
 	// XML node handlers
 	XMLParser::RegisterNodeHandler("", MakeShared<XMLNodeHandlerDefault>());


### PR DESCRIPTION
When binding data variables to checkboxes I encountered that the presence of a non-empty `value` attribute is required in order for them to properly function. I consider this a limitation, so I devised a solution to overcome it. I believe that the resulting changes make the underlying philosophy more streamlined.

In my opinion, channeling the changes of the `checked` attribute of checkboxes into imaginary changes in `value` and then blending them together with radio buttons confuse things quite a bit, hence my attempt at cleaning it up.

Any comments or thoughts are much appreciated!