### PR TITLE
Fix ElementHandle resizing incorrectly when the size_target has "box-sizing: border-box"

### DIFF
--- a/Source/Core/ElementHandle.cpp
+++ b/Source/Core/ElementHandle.cpp
@@ -94,7 +94,10 @@ void ElementHandle::ProcessDefaultAction(Event& event)
 				move_original_position.y = move_target->GetOffsetTop();
 			}
 			if (size_target)
-				size_original_size = size_target->GetBox().GetSize(Box::CONTENT);
+				size_original_size = size_target->GetBox().GetSize(
+					(size_target->GetComputedValues().box_sizing == Style::BoxSizing::BorderBox)
+					? Box::BORDER
+					: Box::CONTENT);
 		}
 		else if (event == EventId::Drag)
 		{


### PR DESCRIPTION
This is an example of the issue. When the drag starts it jumps so that the cursor is below the blue box instead of in the middle where it started.

![drag-jump](https://user-images.githubusercontent.com/9959776/126918221-c87eb317-607a-464d-8f94-31c5c12b6d0c.gif)
