### PR TITLE
Upgraded font-weight

### DIFF
--- a/Include/RmlUi/Core/ComputedValues.h
+++ b/Include/RmlUi/Core/ComputedValues.h
@@ -114,7 +114,7 @@ public:
 enum class Visibility : uint8_t { Visible, Hidden };
 
 enum class FontStyle : uint8_t { Normal, Italic };
-enum class FontWeight : uint8_t { Normal, Bold };
+enum class FontWeight : uint16_t { Auto = 0, Normal = 400, Bold = 700 }; // Any definite value in the range [1,1000] is valid.
 
 enum class TextAlign : uint8_t { Left, Right, Center, Justify };
 enum class TextDecoration : uint8_t { None, Underline, Overline, LineThrough };

--- a/Include/RmlUi/Core/Core.h
+++ b/Include/RmlUi/Core/Core.h
@@ -119,18 +119,22 @@ RMLUICORE_API int GetNumContexts();
 /// Adds a new font face to the font engine. The face's family, style and weight will be determined from the face itself.
 /// @param[in] file_name The file to load the face from.
 /// @param[in] fallback_face True to use this font face for unknown characters in other font faces.
+/// @param[in] weight The weight to load when the font face contains multiple weights, otherwise the weight to register the font as. By default it
+/// loads all found font weights.
 /// @return True if the face was loaded successfully, false otherwise.
-RMLUICORE_API bool LoadFontFace(const String& file_name, bool fallback_face = false);
+RMLUICORE_API bool LoadFontFace(const String& file_name, bool fallback_face = false, Style::FontWeight weight = Style::FontWeight::Auto);
 /// Adds a new font face from memory to the font engine. The face's family, style and weight is given by the parameters.
 /// @param[in] data A pointer to the data.
 /// @param[in] data_size Size of the data in bytes.
 /// @param[in] family The family to register the font as.
 /// @param[in] style The style to register the font as.
-/// @param[in] weight The weight to register the font as.
+/// @param[in] weight The weight to load when the font face contains multiple weights, otherwise the weight to register the font as. By default it
+/// loads all found font weights.
 /// @param[in] fallback_face True to use this font face for unknown characters in other font faces.
 /// @return True if the face was loaded successfully, false otherwise.
 /// @lifetime The pointed to 'data' must remain available until after the call to Rml::Shutdown.
-RMLUICORE_API bool LoadFontFace(const byte* data, int data_size, const String& font_family, Style::FontStyle style, Style::FontWeight weight, bool fallback_face = false);
+RMLUICORE_API bool LoadFontFace(const byte* data, int data_size, const String& font_family, Style::FontStyle style,
+	Style::FontWeight weight = Style::FontWeight::Auto, bool fallback_face = false);
 
 /// Registers a generic RmlUi plugin.
 RMLUICORE_API void RegisterPlugin(Plugin* plugin);

--- a/Include/RmlUi/Core/FontEngineInterface.h
+++ b/Include/RmlUi/Core/FontEngineInterface.h
@@ -52,15 +52,16 @@ public:
 	/// Called by RmlUi when it wants to load a font face from file.
 	/// @param[in] file_name The file to load the face from.
 	/// @param[in] fallback_face True to use this font face for unknown characters in other font faces.
+	/// @param[in] weight The weight to load when the font face contains multiple weights, otherwise the weight to register the font as.
 	/// @return True if the face was loaded successfully, false otherwise.
-	virtual bool LoadFontFace(const String& file_name, bool fallback_face);
+	virtual bool LoadFontFace(const String& file_name, bool fallback_face, Style::FontWeight weight);
 
 	/// Called by RmlUi when it wants to load a font face from memory, registered using the provided family, style, and weight.
 	/// @param[in] data A pointer to the data.
 	/// @param[in] data_size Size of the data in bytes.
 	/// @param[in] family The family to register the font as.
 	/// @param[in] style The style to register the font as.
-	/// @param[in] weight The weight to register the font as.
+	/// @param[in] weight The weight to load when the font face contains multiple weights, otherwise the weight to register the font as.
 	/// @param[in] fallback_face True to use this font face for unknown characters in other font faces.
 	/// @return True if the face was loaded successfully, false otherwise.
 	/// Note: The debugger plugin will load its embedded font faces through this method using the family name 'rmlui-debugger-font'.

--- a/Include/RmlUi/Core/Math.h
+++ b/Include/RmlUi/Core/Math.h
@@ -107,6 +107,10 @@ RMLUICORE_API bool AreEqual(float value_0, float value_1);
 /// @param[in] value The number of get the absolute value of.
 /// @return The absolute value of the number.
 RMLUICORE_API float AbsoluteValue(float value);
+/// Calculates the absolute value of a number.
+/// @param[in] value The number of get the absolute value of.
+/// @return The absolute value of the number.
+RMLUICORE_API int AbsoluteValue(int value);
 
 /// Calculates the cosine of an angle.
 /// @param[in] angle The angle to calculate the cosine of, in radians.

--- a/Samples/basic/bitmapfont/src/FontEngineInterfaceBitmap.cpp
+++ b/Samples/basic/bitmapfont/src/FontEngineInterfaceBitmap.cpp
@@ -40,7 +40,7 @@ FontEngineInterfaceBitmap::~FontEngineInterfaceBitmap()
 	FontProviderBitmap::Shutdown();
 }
 
-bool FontEngineInterfaceBitmap::LoadFontFace(const String& file_name, bool /*fallback_face*/)
+bool FontEngineInterfaceBitmap::LoadFontFace(const String& file_name, bool /*fallback_face*/, FontWeight /*weight*/)
 {
 	return FontProviderBitmap::LoadFontFace(file_name);
 }

--- a/Samples/basic/bitmapfont/src/FontEngineInterfaceBitmap.h
+++ b/Samples/basic/bitmapfont/src/FontEngineInterfaceBitmap.h
@@ -57,7 +57,7 @@ public:
 	virtual ~FontEngineInterfaceBitmap();
 
 	/// Called by RmlUi when it wants to load a font face from file.
-	bool LoadFontFace(const String& file_name, bool fallback_face) override;
+	bool LoadFontFace(const String& file_name, bool fallback_face, FontWeight weight) override;
 
 	/// Called by RmlUi when it wants to load a font face from memory, registered using the provided family, style, and weight.
 	/// @param[in] data A pointer to the data.

--- a/Source/Core/Core.cpp
+++ b/Source/Core/Core.cpp
@@ -331,9 +331,9 @@ int GetNumContexts()
 	return (int) contexts.size();
 }
 
-bool LoadFontFace(const String& file_name, bool fallback_face)
+bool LoadFontFace(const String& file_name, bool fallback_face, Style::FontWeight weight)
 {
-	return font_interface->LoadFontFace(file_name, fallback_face);
+	return font_interface->LoadFontFace(file_name, fallback_face, weight);
 }
 
 bool LoadFontFace(const byte* data, int data_size, const String& font_family, Style::FontStyle style, Style::FontWeight weight, bool fallback_face)

--- a/Source/Core/FontEngineDefault/FontEngineInterfaceDefault.cpp
+++ b/Source/Core/FontEngineDefault/FontEngineInterfaceDefault.cpp
@@ -42,9 +42,9 @@ FontEngineInterfaceDefault::~FontEngineInterfaceDefault()
 	FontProvider::Shutdown();
 }
 
-bool FontEngineInterfaceDefault::LoadFontFace(const String& file_name, bool fallback_face)
+bool FontEngineInterfaceDefault::LoadFontFace(const String& file_name, bool fallback_face, Style::FontWeight weight)
 {
-	return FontProvider::LoadFontFace(file_name, fallback_face);
+	return FontProvider::LoadFontFace(file_name, fallback_face, weight);
 }
 
 bool FontEngineInterfaceDefault::LoadFontFace(const byte* data, int data_size, const String& font_family, Style::FontStyle style, Style::FontWeight weight, bool fallback_face)

--- a/Source/Core/FontEngineDefault/FontEngineInterfaceDefault.h
+++ b/Source/Core/FontEngineDefault/FontEngineInterfaceDefault.h
@@ -39,7 +39,7 @@ public:
 	virtual ~FontEngineInterfaceDefault();
 
 	/// Adds a new font face to the database. The face's family, style and weight will be determined from the face itself.
-	bool LoadFontFace(const String& file_name, bool fallback_face) override;
+	bool LoadFontFace(const String& file_name, bool fallback_face, Style::FontWeight weight) override;
 
 	/// Adds a new font face to the database using the provided family, style and weight.
 	bool LoadFontFace(const byte* data, int data_size, const String& font_family, Style::FontStyle style, Style::FontWeight weight, bool fallback_face) override;

--- a/Source/Core/FontEngineDefault/FontFace.cpp
+++ b/Source/Core/FontEngineDefault/FontFace.cpp
@@ -33,24 +33,17 @@
 
 namespace Rml {
 
-FontFace::FontFace(FontFaceHandleFreetype _face, Style::FontStyle _style, Style::FontWeight _weight, UniquePtr<byte[]> _face_memory)
+FontFace::FontFace(FontFaceHandleFreetype _face, Style::FontStyle _style, Style::FontWeight _weight)
 {
 	style = _style;
 	weight = _weight;
 	face = _face;
-
-	face_memory = std::move(_face_memory);
 }
 
 FontFace::~FontFace()
 {
 	if (face) 
-	{
 		FreeType::ReleaseFace(face);
-		face_memory.reset();
-		face = 0;
-	}
-	handles.clear();
 }
 
 // Returns the style of the font face.

--- a/Source/Core/FontEngineDefault/FontFace.h
+++ b/Source/Core/FontEngineDefault/FontFace.h
@@ -43,7 +43,7 @@ class FontFaceHandleDefault;
 class FontFace
 {
 public:
-	FontFace(FontFaceHandleFreetype face, Style::FontStyle style, Style::FontWeight weight, UniquePtr<byte[]> face_memory);
+	FontFace(FontFaceHandleFreetype face, Style::FontStyle style, Style::FontWeight weight);
 	~FontFace();
 
 	Style::FontStyle GetStyle() const;
@@ -58,9 +58,6 @@ public:
 private:
 	Style::FontStyle style;
 	Style::FontWeight weight;
-
-	// Only filled if we own the memory used by the FreeType face handle.
-	UniquePtr<byte[]> face_memory;
 
 	// Key is font size
 	using HandleMap = UnorderedMap< int, UniquePtr<FontFaceHandleDefault> >;

--- a/Source/Core/FontEngineDefault/FontFamily.h
+++ b/Source/Core/FontEngineDefault/FontFamily.h
@@ -44,6 +44,7 @@ class FontFamily
 {
 public:
 	FontFamily(const String& name);
+	~FontFamily();
 
 	/// Returns a handle to the most appropriate font in the family, at the correct size.
 	/// @param[in] style The style of the desired handle.
@@ -64,7 +65,13 @@ public:
 protected:
 	String name;
 
-	using FontFaceList = Vector< UniquePtr<FontFace> >;
+	struct FontFaceEntry {
+		UniquePtr<FontFace> face;
+		// Only filled if we own the memory used by the face's FreeType handle. May be shared with other faces in this family.
+		UniquePtr<byte[]> face_memory;
+	};
+
+	using FontFaceList = Vector<FontFaceEntry>;
 	FontFaceList font_faces;
 };
 

--- a/Source/Core/FontEngineDefault/FontProvider.cpp
+++ b/Source/Core/FontEngineDefault/FontProvider.cpp
@@ -34,6 +34,7 @@
 #include "../../../Include/RmlUi/Core/Core.h"
 #include "../../../Include/RmlUi/Core/FileInterface.h"
 #include "../../../Include/RmlUi/Core/Log.h"
+#include "../../../Include/RmlUi/Core/Math.h"
 #include "../../../Include/RmlUi/Core/StringUtilities.h"
 #include <algorithm>
 
@@ -103,7 +104,7 @@ FontFaceHandleDefault* FontProvider::GetFallbackFontFace(int index, int font_siz
 }
 
 
-bool FontProvider::LoadFontFace(const String& file_name, bool fallback_face)
+bool FontProvider::LoadFontFace(const String& file_name, bool fallback_face, Style::FontWeight weight)
 {
 	FileInterface* file_interface = GetFileInterface();
 	FileHandle handle = file_interface->Open(file_name);
@@ -121,13 +122,14 @@ bool FontProvider::LoadFontFace(const String& file_name, bool fallback_face)
 	file_interface->Read(buffer, length, handle);
 	file_interface->Close(handle);
 
-	bool result = Get().LoadFontFace(buffer, (int)length, fallback_face, std::move(buffer_ptr), file_name);
+	bool result = Get().LoadFontFace(buffer, (int)length, fallback_face, std::move(buffer_ptr), file_name, {}, Style::FontStyle::Normal, weight);
 
 	return result;
 }
 
 
-bool FontProvider::LoadFontFace(const byte* data, int data_size, const String& font_family, Style::FontStyle style, Style::FontWeight weight, bool fallback_face)
+bool FontProvider::LoadFontFace(const byte* data, int data_size, const String& font_family, Style::FontStyle style, Style::FontWeight weight,
+	bool fallback_face)
 {
 	const String source = "memory";
 	
@@ -136,36 +138,99 @@ bool FontProvider::LoadFontFace(const byte* data, int data_size, const String& f
 	return result;
 }
 
+
 bool FontProvider::LoadFontFace(const byte* data, int data_size, bool fallback_face, UniquePtr<byte[]> face_memory, const String& source,
 	String font_family, Style::FontStyle style, Style::FontWeight weight)
 {
-	FontFaceHandleFreetype ft_face = FreeType::LoadFace(data, data_size, source);
-	
-	if (!ft_face)
+	using Style::FontWeight;
+
+	Vector<FaceVariation> face_variations;
+	if (!FreeType::GetFaceVariations(data, data_size, face_variations))
 	{
-		Log::Message(Log::LT_ERROR, "Failed to load font face %s from '%s'.", font_family.c_str(), source.c_str());
+		Log::Message(Log::LT_ERROR, "Failed to load font face from '%s': Invalid or unsupported font face file format.", source.c_str());
 		return false;
 	}
 
-	if (font_family.empty())
+	Vector<FaceVariation> load_variations;
+	if (face_variations.empty())
 	{
-		FreeType::GetFaceStyle(ft_face, font_family, style, weight);
+		load_variations.push_back(FaceVariation{Style::FontWeight::Auto, 0, 0});
+	}
+	else
+	{
+		// Iterate through all the face variations and pick the ones to load. The list is already sorted by (weight, width). When weight is set to
+		// 'auto' we load all the weights of the face. However, we only want to load one width for each weight.
+		for (auto it = face_variations.begin(); it != face_variations.end();)
+		{
+			if (weight != FontWeight::Auto && it->weight != weight)
+			{
+				++it;
+				continue;
+			}
+
+			// We don't currently have any way for users to select widths, so we search for a regular (medium) value here.
+			constexpr int search_width = 100;
+			const FontWeight current_weight = it->weight;
+
+			int best_width_distance = Math::AbsoluteValue((int)it->width - search_width);
+			auto it_best_width = it;
+			
+			// Search forward to find the best 'width' with the same weight.
+			for (++it; it != face_variations.end(); ++it)
+			{
+				if (it->weight != current_weight)
+					break;
+
+				const int width_distance = Math::AbsoluteValue((int)it->width - search_width);
+				if (width_distance < best_width_distance)
+				{
+					best_width_distance = width_distance;
+					it_best_width = it;
+				}
+			}
+
+			load_variations.push_back(*it_best_width);
+		}
 	}
 
-	const String font_face_description = FontFaceDescription(font_family, style, weight);
-
-	if (!AddFace(ft_face, font_family, style, weight, fallback_face, std::move(face_memory)))
+	if (load_variations.empty())
 	{
-		Log::Message(Log::LT_ERROR, "Failed to load font face %s from '%s'.", font_face_description.c_str(), source.c_str());
+		Log::Message(Log::LT_ERROR, "Failed to load font face from '%s': Could not locate face with weight %d.", source.c_str(), (int)weight);
 		return false;
 	}
 
-	Log::Message(Log::LT_INFO, "Loaded font face %s from '%s'.", font_face_description.c_str(), source.c_str());
+	for (const FaceVariation& variation : load_variations)
+	{
+		FontFaceHandleFreetype ft_face = FreeType::LoadFace(data, data_size, source, variation.named_instance_index);
+		if (!ft_face)
+			return false;
+
+		if (font_family.empty())
+			FreeType::GetFaceStyle(ft_face, &font_family, &style, nullptr);
+		if (weight == FontWeight::Auto)
+			FreeType::GetFaceStyle(ft_face, nullptr, nullptr, &weight);
+
+		const FontWeight variation_weight = (variation.weight == FontWeight::Auto ? weight : variation.weight);
+		const String font_face_description = FontFaceDescription(font_family, style, variation_weight);
+
+		if (!AddFace(ft_face, font_family, style, variation_weight, fallback_face, std::move(face_memory)))
+		{
+			Log::Message(Log::LT_ERROR, "Failed to load font face %s from '%s'.", font_face_description.c_str(), source.c_str());
+			return false;
+		}
+
+		Log::Message(Log::LT_INFO, "Loaded font face %s from '%s'.", font_face_description.c_str(), source.c_str());
+	}
+
 	return true;
 }
 
-bool FontProvider::AddFace(FontFaceHandleFreetype face, const String& family, Style::FontStyle style, Style::FontWeight weight, bool fallback_face, UniquePtr<byte[]> face_memory)
+bool FontProvider::AddFace(FontFaceHandleFreetype face, const String& family, Style::FontStyle style, Style::FontWeight weight, bool fallback_face,
+	UniquePtr<byte[]> face_memory)
 {
+	if (family.empty() || weight == Style::FontWeight::Auto)
+		return false;
+
 	String family_lower = StringUtilities::ToLower(family);
 	FontFamily* font_family = nullptr;
 	auto it = font_families.find(family_lower);

--- a/Source/Core/FontEngineDefault/FontProvider.h
+++ b/Source/Core/FontEngineDefault/FontProvider.h
@@ -61,7 +61,7 @@ public:
 	static FontFaceHandleDefault* GetFontFaceHandle(const String& family, Style::FontStyle style, Style::FontWeight weight, int size);
 
 	/// Adds a new font face to the database. The face's family, style and weight will be determined from the face itself.
-	static bool LoadFontFace(const String& file_name, bool fallback_face);
+	static bool LoadFontFace(const String& file_name, bool fallback_face, Style::FontWeight weight = Style::FontWeight::Auto);
 
 	/// Adds a new font face from memory.
 	static bool LoadFontFace(const byte* data, int data_size, const String& font_family, Style::FontStyle style, Style::FontWeight weight, bool fallback_face);
@@ -79,9 +79,10 @@ private:
 	static FontProvider& Get();
 
 	bool LoadFontFace(const byte* data, int data_size, bool fallback_face, UniquePtr<byte[]> face_memory, const String& source,
-		String font_family = {}, Style::FontStyle style = Style::FontStyle::Normal, Style::FontWeight weight = Style::FontWeight::Normal);
+		String font_family, Style::FontStyle style, Style::FontWeight weight);
 
-	bool AddFace(FontFaceHandleFreetype face, const String& family, Style::FontStyle style, Style::FontWeight weight, bool fallback_face, UniquePtr<byte[]> face_memory);
+	bool AddFace(FontFaceHandleFreetype face, const String& family, Style::FontStyle style, Style::FontWeight weight, bool fallback_face,
+		UniquePtr<byte[]> face_memory);
 
 	using FontFaceList = Vector<FontFace*>;
 	using FontFamilyMap = UnorderedMap< String, UniquePtr<FontFamily>>;

--- a/Source/Core/FontEngineDefault/FontTypes.h
+++ b/Source/Core/FontEngineDefault/FontTypes.h
@@ -15,7 +15,7 @@
  *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -29,16 +29,15 @@
 #ifndef RMLUI_CORE_FONTENGINEDEFAULT_FONTTYPES_H
 #define RMLUI_CORE_FONTENGINEDEFAULT_FONTTYPES_H
 
-#include "../../../Include/RmlUi/Core/Types.h"
 #include "../../../Include/RmlUi/Core/ComputedValues.h"
 #include "../../../Include/RmlUi/Core/FontGlyph.h"
+#include "../../../Include/RmlUi/Core/Types.h"
 
 namespace Rml {
 
 using FontFaceHandleFreetype = uintptr_t;
 
-struct FontMetrics 
-{
+struct FontMetrics {
 	int size;
 	int x_height;
 	int line_height;
@@ -47,6 +46,19 @@ struct FontMetrics
 	float underline_position;
 	float underline_thickness;
 };
+
+struct FaceVariation {
+	Style::FontWeight weight;
+	uint16_t width;
+	int named_instance_index;
+};
+
+inline bool operator<(const FaceVariation& a, const FaceVariation& b)
+{
+	if (a.weight == b.weight)
+		return a.width < b.width;
+	return a.weight < b.weight;
+}
 
 } // namespace Rml
 #endif

--- a/Source/Core/FontEngineDefault/FreeTypeInterface.h
+++ b/Source/Core/FontEngineDefault/FreeTypeInterface.h
@@ -40,14 +40,17 @@ bool Initialise();
 // Shutdown FreeType library.
 void Shutdown();
 
+// Returns a sorted list of available font variations for the font face located in memory.
+bool GetFaceVariations(const byte* data, int data_length, Vector<FaceVariation>& out_face_variations);
+
 // Loads a FreeType face from memory, 'source' is only used for logging.
-FontFaceHandleFreetype LoadFace(const byte* data, int data_length, const String& source);
+FontFaceHandleFreetype LoadFace(const byte* data, int data_length, const String& source, int named_instance_index = 0);
 
 // Releases the FreeType face.
 bool ReleaseFace(FontFaceHandleFreetype face);
 
-// Retrieves the font family, style and weight of the given font face.
-void GetFaceStyle(FontFaceHandleFreetype face, String& font_family, Style::FontStyle& style, Style::FontWeight& weight);
+// Retrieves the font family, style and weight of the given font face. Use nullptr to ignore a property.
+void GetFaceStyle(FontFaceHandleFreetype face, String* font_family, Style::FontStyle* style, Style::FontWeight* weight);
 
 // Initializes a face for a given font size. Glyphs are filled with the ASCII subset, and the font face metrics are set.
 bool InitialiseFaceHandle(FontFaceHandleFreetype face, int font_size, FontGlyphMap& glyphs, FontMetrics& metrics, bool load_default_glyphs);

--- a/Source/Core/FontEngineInterface.cpp
+++ b/Source/Core/FontEngineInterface.cpp
@@ -34,7 +34,7 @@ FontEngineInterface::FontEngineInterface() {}
 
 FontEngineInterface::~FontEngineInterface() {}
 
-bool FontEngineInterface::LoadFontFace(const String& /*file_name*/, bool /*fallback_face*/)
+bool FontEngineInterface::LoadFontFace(const String& /*file_name*/, bool /*fallback_face*/, Style::FontWeight /*weight*/)
 {
 	return false;
 }

--- a/Source/Core/LayoutInlineBoxText.cpp
+++ b/Source/Core/LayoutInlineBoxText.cpp
@@ -48,6 +48,8 @@ String FontFaceDescription(const String& font_family, Style::FontStyle style, St
 		font_attributes += "italic, ";
 	if (weight == Style::FontWeight::Bold)
 		font_attributes += "bold, ";
+	else if (weight != Style::FontWeight::Auto && weight != Style::FontWeight::Normal)
+		font_attributes += "weight=" + ToString((int)weight) + ", ";
 
 	if (font_attributes.empty())
 		font_attributes = "regular";

--- a/Source/Core/Math.cpp
+++ b/Source/Core/Math.cpp
@@ -59,6 +59,11 @@ RMLUICORE_API float AbsoluteValue(float value)
 	return fabsf(value);
 }
 
+RMLUICORE_API int AbsoluteValue(int value)
+{
+	return abs(value);
+}
+
 // Calculates the cosine of an angle.
 RMLUICORE_API float Cos(float angle)
 {

--- a/Source/Core/StyleSheetSpecification.cpp
+++ b/Source/Core/StyleSheetSpecification.cpp
@@ -379,7 +379,7 @@ void StyleSheetSpecification::RegisterDefaultProperties()
 
 	RegisterProperty(PropertyId::FontFamily, "font-family", "", true, true).AddParser("string");
 	RegisterProperty(PropertyId::FontStyle, "font-style", "normal", true, true).AddParser("keyword", "normal, italic");
-	RegisterProperty(PropertyId::FontWeight, "font-weight", "normal", true, true).AddParser("keyword", "normal, bold");
+	RegisterProperty(PropertyId::FontWeight, "font-weight", "normal", true, true).AddParser("keyword", "normal=400, bold=700").AddParser("number");
 	RegisterProperty(PropertyId::FontSize, "font-size", "12px", true, true).AddParser("length").AddParser("length_percent").SetRelativeTarget(RelativeTarget::ParentFontSize);
 	RegisterShorthand(ShorthandId::Font, "font", "font-style, font-weight, font-size, font-family", ShorthandType::FallThrough);
 


### PR DESCRIPTION
This PR upgrades support for font-weight in .rcss files:

font-weight: (uint:0-0xFFFF)
and
font-weight: thin|light|normal|medium|bold|black



The PR supports 2 ways to load weights for fonts:

Rml::LoadFontFace("assets/OpenSans.ttf", false, 300); // Only load weight 300 from this font file.
or
Rml::LoadFontFace("assets/OpenSans.ttf", false); // Load all weights from this font file. (The third arg defaults to 0).



The PR also tries to match faces by the nearest weight, after trying to match by a direct weight.

![font-weights](https://user-images.githubusercontent.com/2442591/162085855-87037416-18df-4cdc-a7f6-10cbc9b18dd8.png)
