### PR TITLE
Fixes #322 by cleaning up event listeners before the plugin is deleted.

### DIFF
--- a/Source/Debugger/DebuggerPlugin.cpp
+++ b/Source/Debugger/DebuggerPlugin.cpp
@@ -373,6 +373,13 @@ bool DebuggerPlugin::LoadLogElement()
 
 void DebuggerPlugin::ReleaseElements()
 {
+	// Erase event listeners to prevent crashes.
+	if (debug_context && info_element)
+	{
+		debug_context->RemoveEventListener("click", info_element, true);
+		debug_context->RemoveEventListener("mouseover", info_element, true);
+	}
+
 	if (host_context)
 	{
 		if (menu_element)
@@ -395,6 +402,10 @@ void DebuggerPlugin::ReleaseElements()
 			application_interface = nullptr;
 			log_interface.reset();
 		}
+
+		// Update to release documents before the plugin gets deleted.
+		// Helps avoid cleanup crashes.
+		host_context->Update();
 	}
 
 	if (debug_context)
@@ -404,6 +415,10 @@ void DebuggerPlugin::ReleaseElements()
 			debug_context->UnloadDocument(hook_element);
 			hook_element = nullptr;
 		}
+
+		// Update to release documents before the plugin gets deleted.
+		// Helps avoid cleanup crashes.
+		debug_context->Update();
 	}
 }
 

--- a/Source/Debugger/ElementInfo.cpp
+++ b/Source/Debugger/ElementInfo.cpp
@@ -59,6 +59,9 @@ ElementInfo::ElementInfo(const String& tag) : ElementDocument(tag)
 
 ElementInfo::~ElementInfo()
 {
+	RemoveEventListener(EventId::Click, this);
+	RemoveEventListener(EventId::Mouseover, this);
+	RemoveEventListener(EventId::Mouseout, this);
 }
 
 // Initialises the info element.

--- a/Source/Debugger/ElementLog.cpp
+++ b/Source/Debugger/ElementLog.cpp
@@ -80,6 +80,18 @@ ElementLog::ElementLog(const String& tag) : ElementDocument(tag)
 
 ElementLog::~ElementLog()
 {
+	RemoveEventListener(EventId::Click, this);
+
+	if (beacon && beacon->GetFirstChild())
+	{
+		beacon->GetFirstChild()->RemoveEventListener(EventId::Click, this);
+		beacon->GetParentNode()->RemoveChild(beacon);
+	}
+
+	if (message_content)
+	{
+		message_content->RemoveEventListener(EventId::Resize, this);
+	}
 }
 
 // Initialises the log element.


### PR DESCRIPTION
This would fix #322.  Forgot that I had to add that in the description.