### PR TITLE
Lua plugin: Add __eq metamethod for C++ objects to get equality check working

### DIFF
--- a/Include/RmlUi/Lua/LuaType.h
+++ b/Include/RmlUi/Lua/LuaType.h
@@ -142,6 +142,8 @@ public:
     /** The __tostring metamethod.
     @return 1, because it pushes a string representation of the userdata on to the stack  */
     static inline int tostring_T(lua_State* L);
+    /** The __eq metamethod. Facilitates equality tests with C++-side pointers  */
+    static inline int eq_T(lua_State* L);
     /** The __index metamethod. Called whenever the user attempts to access a variable that is
     not in the immediate table. This handles the method calls and calls tofunctions in __getters    */
     static inline int index(lua_State* L);

--- a/Include/RmlUi/Lua/LuaType.inl
+++ b/Include/RmlUi/Lua/LuaType.inl
@@ -62,6 +62,9 @@ void LuaType<T>::Register(lua_State* L)
     lua_pushcfunction(L, tostring_T);
     lua_setfield(L, metatable, "__tostring");
 
+    lua_pushcfunction(L, eq_T);
+    lua_setfield(L, metatable, "__eq");
+
     ExtraInit<T>(L,metatable); //optionally implemented by individual types
 
     lua_newtable(L); //for method table -> [3] = this table
@@ -198,6 +201,17 @@ int LuaType<T>::tostring_T(lua_State* L)
     void* obj = static_cast<void*>(*ptrHold);
     snprintf(buff, max_pointer_string_size, "%p", obj);
     lua_pushfstring(L, "%s (%s)", GetTClassName<T>(), buff);
+    return 1;
+}
+
+template<typename T>
+int LuaType<T>::eq_T(lua_State* L)
+{
+    T* o1 = check(L,1);
+    RMLUI_CHECK_OBJ(o1);
+    T* o2 = check(L,2);
+    RMLUI_CHECK_OBJ(o2);
+    lua_pushboolean(L, o1 == o2);
     return 1;
 }
 


### PR DESCRIPTION
The PR fixes lua sided equality checks for objects returned from the C++ side.

Before this change an element returned by a selector query function in Lua would always compare false against the same element retrieved in a different call, even though the pointer was identical.
