### PR TITLE
Improve .gitignore and LoadDocument and LoadFont documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,11 +13,16 @@
 # Distribution target
 /Distribution/
 
-# Ignore MacOSX directory info
+# macOS directory info file
 .DS_Store
 
-# VS user project files
-.vs/
+# Hidden folders
+.*/
+
+# Not ignore .github/
+!.github/
+
+# Visual Studio project files
 *.suo
 *.user
 *.opensdf

--- a/Include/RmlUi/Core/Context.h
+++ b/Include/RmlUi/Core/Context.h
@@ -92,7 +92,8 @@ public:
 	/// @return The new document, or nullptr if no document could be created.
 	ElementDocument* CreateDocument(const String& instancer_name = "body");
 	/// Load a document into the context.
-	/// @param[in] document_path The path to the document to load.
+	/// @param[in] document_path The path to the document to load. The path is passed directly to the file interface which is used to load the file.
+	/// The default file interface accepts both absolute paths and paths relative to the working directory.
 	/// @return The loaded document, or nullptr if no document was loaded.
 	ElementDocument* LoadDocument(const String& document_path);
 	/// Load a document into the context.

--- a/Include/RmlUi/Core/Core.h
+++ b/Include/RmlUi/Core/Core.h
@@ -117,12 +117,13 @@ RMLUICORE_API Context* GetContext(int index);
 RMLUICORE_API int GetNumContexts();
 
 /// Adds a new font face to the font engine. The face's family, style and weight will be determined from the face itself.
-/// @param[in] file_name The file to load the face from.
+/// @param[in] file_path The path to the file to load the face from. The path is passed directly to the file interface which is used to load the file.
+/// The default file interface accepts both absolute paths and paths relative to the working directory.
 /// @param[in] fallback_face True to use this font face for unknown characters in other font faces.
 /// @param[in] weight The weight to load when the font face contains multiple weights, otherwise the weight to register the font as. By default it
 /// loads all found font weights.
 /// @return True if the face was loaded successfully, false otherwise.
-RMLUICORE_API bool LoadFontFace(const String& file_name, bool fallback_face = false, Style::FontWeight weight = Style::FontWeight::Auto);
+RMLUICORE_API bool LoadFontFace(const String& file_path, bool fallback_face = false, Style::FontWeight weight = Style::FontWeight::Auto);
 /// Adds a new font face from memory to the font engine. The face's family, style and weight is given by the parameters.
 /// @param[in] data A pointer to the data.
 /// @param[in] data_size Size of the data in bytes.

--- a/Source/Core/Core.cpp
+++ b/Source/Core/Core.cpp
@@ -332,9 +332,9 @@ int GetNumContexts()
 	return (int) contexts.size();
 }
 
-bool LoadFontFace(const String& file_name, bool fallback_face, Style::FontWeight weight)
+bool LoadFontFace(const String& file_path, bool fallback_face, Style::FontWeight weight)
 {
-	return font_interface->LoadFontFace(file_name, fallback_face, weight);
+	return font_interface->LoadFontFace(file_path, fallback_face, weight);
 }
 
 bool LoadFontFace(const byte* data, int data_size, const String& font_family, Style::FontStyle style, Style::FontWeight weight, bool fallback_face)

--- a/Source/Core/FontEngineInterface.cpp
+++ b/Source/Core/FontEngineInterface.cpp
@@ -34,7 +34,7 @@ FontEngineInterface::FontEngineInterface() {}
 
 FontEngineInterface::~FontEngineInterface() {}
 
-bool FontEngineInterface::LoadFontFace(const String& /*file_name*/, bool /*fallback_face*/, Style::FontWeight /*weight*/)
+bool FontEngineInterface::LoadFontFace(const String& /*file_path*/, bool /*fallback_face*/, Style::FontWeight /*weight*/)
 {
 	return false;
 }


### PR DESCRIPTION
Improves the .gitignore file to ignore all IDE and code editor setting folders regardless of their names and improves the documentation and function interface of `LoadDocument()` and `LoadFontFace()` in their file path variants regarding on how relative paths are treated.

The Doxygen comments have been written using the official Markdown compatibility spec of Doxygen, which some IDEs might have issues displaying it the right way due to not implementing Doxygen comments properly. However, by Doxygen standards they are just fine.

- The docstrings being displayed in Doxygen:
![imagen](https://user-images.githubusercontent.com/48522412/179748561-2c7607fa-6bc4-4b87-81a9-3f57460aaf5a.png)
![imagen](https://user-images.githubusercontent.com/48522412/179748597-0e405d21-d92b-44eb-bd0b-64a52db91d2a.png)

- The docstrings being displayed in Visual Studio Code:
![imagen](https://user-images.githubusercontent.com/48522412/179748954-6368e857-f7df-4285-926d-008ba03f22f4.png)
![imagen](https://user-images.githubusercontent.com/48522412/179748927-579009a9-36c5-4a42-b0b0-76777a35bde1.png)

