### PR TITLE
Fix robin_hood.h

### DIFF
--- a/Include/RmlUi/Core/Containers/robin_hood.h
+++ b/Include/RmlUi/Core/Containers/robin_hood.h
@@ -195,7 +195,7 @@ static Counts& counts() {
 // workaround missing "is_trivially_copyable" in g++ < 5.0
 // See https://stackoverflow.com/a/31798726/48181
 #if defined(__GNUC__) && __GNUC__ < 5
-#    define ROBIN_HOOD_IS_TRIVIALLY_COPYABLE(...) __has_trivial_copy(__VA_ARGS__)
+#    define ROBIN_HOOD_IS_TRIVIALLY_COPYABLE(...) __is_trivially_constructible(__VA_ARGS__)
 #else
 #    define ROBIN_HOOD_IS_TRIVIALLY_COPYABLE(...) std::is_trivially_copyable<__VA_ARGS__>::value
 #endif


### PR DESCRIPTION
Updates ROBIN_HOOD_IS_TRIVIALLY_COPYABLE definition due to compiler
warning as error policy that makes Emscripten CI builds fail

Haven't checked if this actually fails on runtime or not.