### PR TITLE
Extend Element::ScrollIntoView parameters.

### DIFF
--- a/Include/RmlUi/Core/Element.h
+++ b/Include/RmlUi/Core/Element.h
@@ -15,7 +15,7 @@
  *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -65,6 +65,35 @@ class StyleSheetContainer;
 class TransformState;
 struct ElementMeta;
 struct StackingOrderedChild;
+
+/**
+	Describes behavior of Element::ScrollIntoView.
+ */
+
+struct ScrollIntoViewOptions
+{
+	enum Alignment
+	{
+		/// Align to the left or top edge of the parent element.
+		START,
+		/// Align to the center of the parent element.
+		CENTER,
+		/// Align to the right or bottom edge of the parent element.
+		END,
+		/// Align with minimal scroll change.
+		NEAREST
+	};
+
+	/// Initializes default behavior. Vertical scroll alignment is START, horizontal scroll alignment is NEAREST.
+	ScrollIntoViewOptions();
+	/// Initializes behavior with the same alignment for vertical and horizontal scroll.
+	explicit ScrollIntoViewOptions(Alignment alignment);
+	/// Initializes behavior with the specified alignments for vertical and horizontal scroll.
+	ScrollIntoViewOptions(Alignment vertical, Alignment horizontal);
+
+	Alignment vertical;
+	Alignment horizontal;
+};
 
 /**
 	A generic element in the DOM tree.
@@ -203,13 +232,13 @@ public:
 	/// @param[in] name The name of the local property definition to remove.
 	void RemoveProperty(const String& name);
 	void RemoveProperty(PropertyId id);
-	/// Returns one of this element's properties. If the property is not defined for this element and not inherited 
+	/// Returns one of this element's properties. If the property is not defined for this element and not inherited
 	/// from an ancestor, the default value will be returned.
 	/// @param[in] name The name of the property to fetch the value for.
 	/// @return The value of this property for this element, or nullptr if no property exists with the given name.
-	const Property* GetProperty(const String& name);		
-	const Property* GetProperty(PropertyId id);		
-	/// Returns the values of one of this element's properties.		
+	const Property* GetProperty(const String& name);
+	const Property* GetProperty(PropertyId id);
+	/// Returns the values of one of this element's properties.
 	/// @param[in] name The name of the property to get.
 	/// @return The value of this property.
 	template < typename T >
@@ -262,7 +291,7 @@ public:
 	/// If no animation exists for the given property name, the call will be ignored.
 	/// @return True if a new animation key was added.
 	bool AddAnimationKey(const String& property_name, const Property& target_value, float duration, Tween tween = Tween{});
-	
+
 	/// Iterator for the local (non-inherited) properties defined on this element.
 	/// @warning Modifying the element's properties or classes invalidates the iterator.
 	/// @return Iterator to the first property defined on this element.
@@ -500,6 +529,9 @@ public:
 	bool DispatchEvent(EventId id, const Dictionary& parameters);
 
 	/// Scrolls the parent element's contents so that this element is visible.
+	/// @param[in] options Scroll parameters that control desired element alignment relative to the parent.
+	void ScrollIntoView(const ScrollIntoViewOptions& options);
+	/// Scrolls the parent element's contents so that this element is visible.
 	/// @param[in] align_with_top If true, the element will align itself to the top of the parent element's window. If false, the element will be aligned to the bottom of the parent element's window.
 	void ScrollIntoView(bool align_with_top = true);
 
@@ -568,7 +600,7 @@ public:
 	/// Returns the data model of this element.
 	DataModel* GetDataModel() const;
 	//@}
-	
+
 	/// Gets the render interface owned by this element's context.
 	/// @return The element's context's render interface.
 	RenderInterface* GetRenderInterface();
@@ -653,7 +685,7 @@ protected:
 
 private:
 	void SetParent(Element* parent);
-	
+
 	void SetDataModel(DataModel* new_data_model);
 
 	void DirtyAbsoluteOffset();
@@ -767,7 +799,7 @@ private:
 	float z_index;
 
 	ElementList stacking_context;
-	
+
 	UniquePtr< TransformState > transform_state;
 
 	ElementAnimationList animations;

--- a/Tests/Source/UnitTests/Element.cpp
+++ b/Tests/Source/UnitTests/Element.cpp
@@ -70,6 +70,79 @@ static const String document_clone_rml = R"(
 </rml>
 )";
 
+static const String document_scroll_rml = R"(
+<rml>
+<head>
+	<title>Test</title>
+	<style>
+		body {
+			left: 0;
+			top: 0;
+			width: 100px;
+			height: 100px;
+			padding: 0;
+			margin: 0;
+			overflow: scroll;
+		}
+		div {
+			display: block;
+			width: 200px;
+			height: 50px;
+			padding: 0;
+			margin: 0;
+		}
+		span {
+			display: inline-block;
+			width: 50px;
+			height: 50px;
+			padding: 0;
+			margin: 0;
+		}
+		scrollbarvertical,
+		scrollbarhorizontal {
+			width: 0;
+			height: 0;
+		}
+	</style>
+</head>
+
+<body id="scrollable">
+<div id="row0">
+	<span id="cell00"></span>
+	<span id="cell01"></span>
+	<span id="cell02"></span>
+	<span id="cell03"></span>
+</div>
+<div id="row1">
+	<span id="cell10"></span>
+	<span id="cell11"></span>
+	<span id="cell12"></span>
+	<span id="cell13"></span>
+</div>
+<div id="row2">
+	<span id="cell20"></span>
+	<span id="cell21"></span>
+	<span id="cell22"></span>
+	<span id="cell23"></span>
+</div>
+<div id="row3">
+	<span id="cell30"></span>
+	<span id="cell31"></span>
+	<span id="cell32"></span>
+	<span id="cell33"></span>
+</div>
+</body>
+</rml>
+)";
+
+void Run(Context* context)
+{
+	context->Update();
+	context->Render();
+
+	TestsShell::RenderLoop();
+}
+
 TEST_CASE("Element")
 {
 	Context* context = TestsShell::GetContext();
@@ -209,6 +282,106 @@ TEST_CASE("Element")
 		CHECK(element_ptr->GetInnerRML() == "");
 		element_ptr->SetInnerRML("text");
 		CHECK(element_ptr->GetInnerRML() == "text");
+	}
+
+	document->Close();
+	TestsShell::ShutdownShell();
+}
+
+TEST_CASE("ElementScroll")
+{
+	Context* context = TestsShell::GetContext();
+	REQUIRE(context);
+
+	ElementDocument* document = context->LoadDocumentFromMemory(document_scroll_rml);
+	REQUIRE(document);
+	document->Show();
+
+	Run(context);
+
+	Element* scrollable = document->GetElementById("scrollable");
+	REQUIRE(scrollable);
+	Element* cells[4][4]{};
+	for (int i = 0; i < 4; ++i)
+	{
+		for (int j = 0; j < 4; ++j)
+		{
+			cells[i][j] = document->GetElementById(CreateString(8, "cell%d%d", i, j));
+			REQUIRE(cells[i][j]);
+		}
+	}
+
+	REQUIRE(cells[0][0]->GetAbsoluteOffset(Rml::Box::Area::BORDER) == Vector2f(0, 0));
+	REQUIRE(cells[2][2]->GetAbsoluteOffset(Rml::Box::Area::BORDER) == Vector2f(100, 100));
+	REQUIRE(cells[3][3]->GetAbsoluteOffset(Rml::Box::Area::BORDER) == Vector2f(150, 150));
+	REQUIRE(scrollable->GetScrollLeft() == 0);
+	REQUIRE(scrollable->GetScrollTop() == 0);
+
+	SUBCASE("LegacyScroll")
+	{
+		cells[2][2]->ScrollIntoView(true);
+
+		Run(context);
+
+		REQUIRE(cells[0][0]->GetAbsoluteOffset(Rml::Box::Area::BORDER) == Vector2f(-100, -100));
+		REQUIRE(cells[2][2]->GetAbsoluteOffset(Rml::Box::Area::BORDER) == Vector2f(0, 0));
+		REQUIRE(cells[3][3]->GetAbsoluteOffset(Rml::Box::Area::BORDER) == Vector2f(50, 50));
+		REQUIRE(scrollable->GetScrollLeft() == 100);
+		REQUIRE(scrollable->GetScrollTop() == 100);
+
+		cells[2][2]->ScrollIntoView(false);
+
+		Run(context);
+
+		REQUIRE(cells[0][0]->GetAbsoluteOffset(Rml::Box::Area::BORDER) == Vector2f(-100, -50));
+		REQUIRE(cells[2][2]->GetAbsoluteOffset(Rml::Box::Area::BORDER) == Vector2f(0, 50));
+		REQUIRE(cells[3][3]->GetAbsoluteOffset(Rml::Box::Area::BORDER) == Vector2f(50, 100));
+		REQUIRE(scrollable->GetScrollLeft() == 100);
+		REQUIRE(scrollable->GetScrollTop() == 50);
+	}
+
+	SUBCASE("AdvancedScroll")
+	{
+		cells[2][2]->ScrollIntoView(ScrollIntoViewOptions(ScrollIntoViewOptions::CENTER));
+
+		Run(context);
+
+		REQUIRE(cells[0][0]->GetAbsoluteOffset(Rml::Box::Area::BORDER) == Vector2f(-75, -75));
+		REQUIRE(cells[2][2]->GetAbsoluteOffset(Rml::Box::Area::BORDER) == Vector2f(25, 25));
+		REQUIRE(cells[3][3]->GetAbsoluteOffset(Rml::Box::Area::BORDER) == Vector2f(75, 75));
+
+		SUBCASE("NearestAlready")
+		{
+			cells[2][2]->ScrollIntoView(ScrollIntoViewOptions(ScrollIntoViewOptions::NEAREST));
+
+			Run(context);
+
+			REQUIRE(cells[0][0]->GetAbsoluteOffset(Rml::Box::Area::BORDER) == Vector2f(-75, -75));
+			REQUIRE(cells[2][2]->GetAbsoluteOffset(Rml::Box::Area::BORDER) == Vector2f(25, 25));
+			REQUIRE(cells[3][3]->GetAbsoluteOffset(Rml::Box::Area::BORDER) == Vector2f(75, 75));
+		}
+
+		SUBCASE("NearestBefore")
+		{
+			cells[1][1]->ScrollIntoView(ScrollIntoViewOptions(ScrollIntoViewOptions::NEAREST));
+
+			Run(context);
+
+			REQUIRE(cells[0][0]->GetAbsoluteOffset(Rml::Box::Area::BORDER) == Vector2f(-50, -50));
+			REQUIRE(cells[1][1]->GetAbsoluteOffset(Rml::Box::Area::BORDER) == Vector2f(0, 0));
+			REQUIRE(cells[2][2]->GetAbsoluteOffset(Rml::Box::Area::BORDER) == Vector2f(50, 50));
+		}
+
+		SUBCASE("NearestAfter")
+		{
+			cells[3][3]->ScrollIntoView(ScrollIntoViewOptions(ScrollIntoViewOptions::NEAREST));
+
+			Run(context);
+
+			REQUIRE(cells[1][1]->GetAbsoluteOffset(Rml::Box::Area::BORDER) == Vector2f(-50, -50));
+			REQUIRE(cells[2][2]->GetAbsoluteOffset(Rml::Box::Area::BORDER) == Vector2f(0, 0));
+			REQUIRE(cells[3][3]->GetAbsoluteOffset(Rml::Box::Area::BORDER) == Vector2f(50, 50));
+		}
 	}
 
 	document->Close();


### PR DESCRIPTION
I reasonably tested it both in UTs and in my project, I don't really feel like doing more work.

PS: I also have small personal vendetta against trailing spaces and my tools are configured to remove them automatically. I can revert these changes if I must.