### PR TITLE
Fix data-text expression not persisting through element removal

### DIFF
--- a/Source/Core/DataViewDefault.cpp
+++ b/Source/Core/DataViewDefault.cpp
@@ -314,18 +314,15 @@ bool DataViewVisible::Update(DataModel& model)
 DataViewText::DataViewText(Element* element) : DataView(element, 0)
 {}
 
-bool DataViewText::Initialize(DataModel& model, Element* element, const String& RMLUI_UNUSED_PARAMETER(expression), const String& RMLUI_UNUSED_PARAMETER(modifier))
+bool DataViewText::Initialize(DataModel& model, Element* element, const String& expression, const String& RMLUI_UNUSED_PARAMETER(modifier))
 {
-	RMLUI_UNUSED(expression);
 	RMLUI_UNUSED(modifier);
 
 	ElementText* element_text = rmlui_dynamic_cast<ElementText*>(element);
 	if (!element_text)
 		return false;
 
-	const String& in_text = element_text->GetText();
-	
-	text.reserve(in_text.size());
+	text.reserve(expression.size());
 
 	DataExpressionInterface expression_interface(&model, element);
 
@@ -336,13 +333,13 @@ bool DataViewText::Initialize(DataModel& model, Element* element, const String& 
 	bool in_brackets = false;
 	bool in_string = false;
 
-	for(char c : in_text) {
+	for(char c : expression) {
 		was_in_brackets = in_brackets;
 
 		const char* error_str = XMLParseTools::ParseDataBrackets(in_brackets, in_string, c, previous);
 		if (error_str)
 		{
-			Log::Message(Log::LT_WARNING, "Failed to parse data view text '%s'. %s", in_text.c_str(), error_str);
+			Log::Message(Log::LT_WARNING, "Failed to parse data view text '%s'. %s", expression.c_str(), error_str);
 			return false;
 		}
 
@@ -354,7 +351,7 @@ bool DataViewText::Initialize(DataModel& model, Element* element, const String& 
 		{
 			DataEntry entry;
 			entry.index = text.size();
-			entry.data_expression = MakeUnique<DataExpression>(String(in_text.begin() + begin_brackets + 1, in_text.begin() + cur - 1));
+			entry.data_expression = MakeUnique<DataExpression>(String(expression.begin() + begin_brackets + 1, expression.begin() + cur - 1));
 			entry.value = "#rmlui#"; // A random value that the user string will not be initialized with.
 
 			if (entry.data_expression->Parse(expression_interface, false))

--- a/Source/Core/DataViewDefault.cpp
+++ b/Source/Core/DataViewDefault.cpp
@@ -312,7 +312,9 @@ bool DataViewVisible::Update(DataModel& model)
 
 
 DataViewText::DataViewText(Element* element) : DataView(element, 0)
-{}
+{
+	int i = 0;
+}
 
 bool DataViewText::Initialize(DataModel& model, Element* element, const String& RMLUI_UNUSED_PARAMETER(expression), const String& RMLUI_UNUSED_PARAMETER(modifier))
 {
@@ -379,6 +381,9 @@ bool DataViewText::Initialize(DataModel& model, Element* element, const String& 
 
 	if (data_entries.empty())
 		return false;
+
+	// Save sucessfully parsed expression in attribute for restoring after element removal
+	element->SetAttribute("data-text", in_text);
 
 	return true;
 }
@@ -450,6 +455,14 @@ StringList DataViewText::GetVariableNameList() const
 
 void DataViewText::Release()
 {
+	ElementText* element_text = rmlui_dynamic_cast<ElementText*>(GetElement());
+	if (element_text) 
+	{
+		if(auto attr = element_text->GetAttribute("data-text")) 
+		{
+			element_text->SetText(attr->Get<std::string>());
+		}
+	}
 	delete this;
 }
 

--- a/Source/Core/DataViewDefault.cpp
+++ b/Source/Core/DataViewDefault.cpp
@@ -313,7 +313,6 @@ bool DataViewVisible::Update(DataModel& model)
 
 DataViewText::DataViewText(Element* element) : DataView(element, 0)
 {
-	int i = 0;
 }
 
 bool DataViewText::Initialize(DataModel& model, Element* element, const String& RMLUI_UNUSED_PARAMETER(expression), const String& RMLUI_UNUSED_PARAMETER(modifier))

--- a/Source/Core/DataViewDefault.cpp
+++ b/Source/Core/DataViewDefault.cpp
@@ -314,15 +314,18 @@ bool DataViewVisible::Update(DataModel& model)
 DataViewText::DataViewText(Element* element) : DataView(element, 0)
 {}
 
-bool DataViewText::Initialize(DataModel& model, Element* element, const String& expression, const String& RMLUI_UNUSED_PARAMETER(modifier))
+bool DataViewText::Initialize(DataModel& model, Element* element, const String& RMLUI_UNUSED_PARAMETER(expression), const String& RMLUI_UNUSED_PARAMETER(modifier))
 {
+	RMLUI_UNUSED(expression);
 	RMLUI_UNUSED(modifier);
 
 	ElementText* element_text = rmlui_dynamic_cast<ElementText*>(element);
 	if (!element_text)
 		return false;
 
-	text.reserve(expression.size());
+	const String& in_text = element_text->GetText();
+	
+	text.reserve(in_text.size());
 
 	DataExpressionInterface expression_interface(&model, element);
 
@@ -333,13 +336,13 @@ bool DataViewText::Initialize(DataModel& model, Element* element, const String& 
 	bool in_brackets = false;
 	bool in_string = false;
 
-	for(char c : expression) {
+	for(char c : in_text) {
 		was_in_brackets = in_brackets;
 
 		const char* error_str = XMLParseTools::ParseDataBrackets(in_brackets, in_string, c, previous);
 		if (error_str)
 		{
-			Log::Message(Log::LT_WARNING, "Failed to parse data view text '%s'. %s", expression.c_str(), error_str);
+			Log::Message(Log::LT_WARNING, "Failed to parse data view text '%s'. %s", in_text.c_str(), error_str);
 			return false;
 		}
 
@@ -351,7 +354,7 @@ bool DataViewText::Initialize(DataModel& model, Element* element, const String& 
 		{
 			DataEntry entry;
 			entry.index = text.size();
-			entry.data_expression = MakeUnique<DataExpression>(String(expression.begin() + begin_brackets + 1, expression.begin() + cur - 1));
+			entry.data_expression = MakeUnique<DataExpression>(String(in_text.begin() + begin_brackets + 1, in_text.begin() + cur - 1));
 			entry.value = "#rmlui#"; // A random value that the user string will not be initialized with.
 
 			if (entry.data_expression->Parse(expression_interface, false))

--- a/Source/Core/DataViewDefault.cpp
+++ b/Source/Core/DataViewDefault.cpp
@@ -454,12 +454,15 @@ StringList DataViewText::GetVariableNameList() const
 
 void DataViewText::Release()
 {
-	ElementText* element_text = rmlui_dynamic_cast<ElementText*>(GetElement());
-	if (element_text) 
+	if(IsValid()) 
 	{
-		if(auto attr = element_text->GetAttribute("data-text")) 
+		ElementText* element_text = rmlui_dynamic_cast<ElementText*>(GetElement());
+		if (element_text) 
 		{
-			element_text->SetText(attr->Get<std::string>());
+			if(auto attr = element_text->GetAttribute("data-text")) 
+			{
+				element_text->SetText(attr->Get<std::string>());
+			}
 		}
 	}
 	delete this;

--- a/Source/Core/Factory.cpp
+++ b/Source/Core/Factory.cpp
@@ -436,7 +436,7 @@ bool Factory::InstanceElementText(Element* parent, const String& in_text)
 
 		// If we have curly brackets in the text, we tag the element so that the appropriate data view (DataViewText) is constructed.
 		if (has_data_expression)
-			attributes.emplace("data-text", in_text);
+			attributes.emplace("data-text", Variant());
 
 		ElementPtr element = Factory::InstanceElement(parent, "#text", "#text", attributes);
 		if (!element)

--- a/Source/Core/Factory.cpp
+++ b/Source/Core/Factory.cpp
@@ -436,7 +436,7 @@ bool Factory::InstanceElementText(Element* parent, const String& in_text)
 
 		// If we have curly brackets in the text, we tag the element so that the appropriate data view (DataViewText) is constructed.
 		if (has_data_expression)
-			attributes.emplace("data-text", Variant());
+			attributes.emplace("data-text", in_text);
 
 		ElementPtr element = Factory::InstanceElement(parent, "#text", "#text", attributes);
 		if (!element)

--- a/Tests/Source/UnitTests/DataBinding.cpp
+++ b/Tests/Source/UnitTests/DataBinding.cpp
@@ -450,3 +450,34 @@ TEST_CASE("databinding.inside_string")
 
 	TestsShell::ShutdownShell();
 }
+
+TEST_CASE("databinding.remove_element_and_restore_data_expression")
+{
+	Context* context = TestsShell::GetContext();
+	REQUIRE(context);
+
+	REQUIRE(InitializeDataBindings(context));
+
+	ElementDocument* document = context->LoadDocumentFromMemory(inside_string_rml);
+	REQUIRE(document);
+	document->Show();
+
+	context->Update();
+	context->Render();
+
+	TestsShell::RenderLoop();
+
+	auto pointer = document->QuerySelector("p:nth-child(1)");
+	auto parent = pointer->GetParentNode();
+	auto element = parent->RemoveChild(pointer);
+	REQUIRE(element);
+
+	TestsShell::RenderLoop();
+
+	pointer = parent->InsertBefore(std::move(element), parent->GetFirstChild());
+	REQUIRE(pointer);
+
+	document->Close();
+
+	TestsShell::ShutdownShell();
+}


### PR DESCRIPTION
Fixes #365 by storing the initial and subsequently successfully parsed data-text expressions in the data-text attribute.
When deleting the view, it restores the content of the element text to the last saved expression.

