### PR TITLE
Fix Access Violation in data model member access with nullptr struct binding

### DIFF
--- a/Source/Core/DataVariable.cpp
+++ b/Source/Core/DataVariable.cpp
@@ -141,16 +141,22 @@ BasePointerDefinition::BasePointerDefinition(VariableDefinition* underlying_defi
 
 bool BasePointerDefinition::Get(void* ptr, Variant& variant)
 {
+    if(!ptr) 
+        return false;
     return underlying_definition->Get(DereferencePointer(ptr), variant);
 }
 
 bool BasePointerDefinition::Set(void* ptr, const Variant& variant)
 {
+    if(!ptr) 
+        return false;
     return underlying_definition->Set(DereferencePointer(ptr), variant);
 }
 
 int BasePointerDefinition::Size(void* ptr)
 {
+    if(!ptr) 
+        return 0;
     return underlying_definition->Size(DereferencePointer(ptr));
 }
 

--- a/Source/Core/DataVariable.cpp
+++ b/Source/Core/DataVariable.cpp
@@ -162,6 +162,8 @@ int BasePointerDefinition::Size(void* ptr)
 
 DataVariable BasePointerDefinition::Child(void* ptr, const DataAddressEntry& address)
 {
+    if(!ptr)
+        return DataVariable();
     return underlying_definition->Child(DereferencePointer(ptr), address);
 }
 


### PR DESCRIPTION
Binding a struct pointer member and accessing a member of said struct while the bound pointer is null leads to an access violation in the member fetching process.

This PR checks the struct base pointer for null before trying to dereference and go deeper down the address lookup.