### PR TITLE
misc cmake update

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[CMakeLists.txt]
+indent_style = tab
+indent_size = 4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -372,7 +372,10 @@ if(BUILD_LUA_BINDINGS)
 endif()
 
 # rlottie
-if( ENABLE_LOTTIE_PLUGIN )
+if( ENABLE_LOTTIE_PLUGIN AND TARGET rlottie::rlottie )
+	list(APPEND CORE_LINK_LIBS rlottie::rlottie)
+	list(APPEND CORE_INCLUDE_DIRS rlottie::rlottie)
+elseif( ENABLE_LOTTIE_PLUGIN )
 	# Try to find the rlottie library.
 	if(NOT DEFINED rlottie_DIR)
 		set(rlottie_DIR $ENV{RLOTTIE_DIR})
@@ -1000,6 +1003,7 @@ endif()
 include(CMakePackageConfigHelpers OPTIONAL RESULT_VARIABLE PkgHelpers_AVAILABLE)
 
 # guard against older versions of cmake which do not provide it
+if(${CMAKE_PROJECT_NAME} STREQUAL ${PROJECT_NAME})
 if(PkgHelpers_AVAILABLE)
 	set (INCLUDE_INSTALL_DIR "include")
 	set (LIB_INSTALL_DIR "lib")
@@ -1038,5 +1042,6 @@ else()
 	message("If you wish to use find_package(RmlUi) in your own project to find RmlUi library"
 		" please update cmake to version which provides CMakePackageConfighelpers module"
 		" or write generators for RmlUiConfig.cmake by yourself.")
+endif()
 endif()
 


### PR DESCRIPTION
this pr makes some changes:

- add  RMLUI_FREETYPE_EXTERNAL option
- add RMLUI_RLOTTIE_EXTERNAL option
- enable CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS and CMAKE_POSITION_INDEPENDENT_CODE

RMLUI_FREETYPE_EXTERNAL  makes rmlui use existed freetype target. such as:

```cmake
add_subdirectory(freetype)
add_subdirectory(rlottie)
set(RMLUI_FREETYPE_EXTERNAL ON CACHE BOOL "use existed freetype target")
set(RMLUI_RLOTTIE_EXTERNALON ON CACHE BOOL "use existed rlottie target")
add_subdirectory(RmlUi)
```

the reason use freetype_interface instead of freetype is freetype has not set -fpie, so it make a link error.