### PR TITLE
CSS content property and unicode escape sequences

### DIFF
--- a/Include/RmlUi/Core/ComputedValues.h
+++ b/Include/RmlUi/Core/ComputedValues.h
@@ -287,6 +287,7 @@ namespace Style {
 		LengthPercentage  row_gap()                    const { return LengthPercentage(rare.row_gap_type, rare.row_gap); }
 		LengthPercentage  column_gap()                 const { return LengthPercentage(rare.column_gap_type, rare.column_gap); }
 		float             scrollbar_margin()           const { return rare.scrollbar_margin; }
+		const String*     content()                    const;
 		
 		// -- Assignment --
 		// Common

--- a/Include/RmlUi/Core/Element.h
+++ b/Include/RmlUi/Core/Element.h
@@ -707,9 +707,12 @@ private:
 
 	/// Removes all transitions that are no longer part of the element's 'transition' property.
 	void HandleTransitionProperty();
-
+	
 	/// Starts new animations and removes animations no longer part of the element's 'animation' property.
 	void HandleAnimationProperty();
+	
+	/// Updates the elements inner content according to the element's 'content' property.
+	void HandleContentProperty();
 
 	/// Advances the animations (including transitions) forward in time.
 	void AdvanceAnimations();
@@ -732,6 +735,7 @@ private:
 	bool dirty_transition : 1;
 	bool dirty_transform : 1;
 	bool dirty_perspective : 1;
+	bool dirty_content : 1;
 
 	OwnedElementList children;
 	int num_non_dom_children;

--- a/Include/RmlUi/Core/ID.h
+++ b/Include/RmlUi/Core/ID.h
@@ -170,6 +170,7 @@ enum class PropertyId : uint8_t
 	FlexShrink,
 	FlexWrap,
 	JustifyContent,
+	Content,
 
 	NumDefinedIds,
 	FirstCustomId = NumDefinedIds,

--- a/Source/Core/ComputedValues.cpp
+++ b/Source/Core/ComputedValues.cpp
@@ -52,6 +52,16 @@ const TransitionList* Style::ComputedValues::transition() const
 	return nullptr;
 }
 
+const String* ComputedValues::content() const
+{
+	if (auto p = element->GetLocalProperty(PropertyId::Content))
+	{
+		if (p->unit == Property::STRING)
+			return &(p->value.GetReference<String>());
+	}
+	return nullptr;
+}
+
 String Style::ComputedValues::font_family() const
 {
 	if (auto p = element->GetProperty(PropertyId::FontFamily))

--- a/Source/Core/ElementStyle.cpp
+++ b/Source/Core/ElementStyle.cpp
@@ -855,6 +855,7 @@ PropertyIdSet ElementStyle::ComputeValues(Style::ComputedValues& values, const S
 			break;
 
 		// Fetched from element's properties.
+		case PropertyId::Content:
 		case PropertyId::Cursor:
 		case PropertyId::Transform:
 		case PropertyId::Transition:

--- a/Source/Core/PropertyParserString.cpp
+++ b/Source/Core/PropertyParserString.cpp
@@ -15,7 +15,7 @@
  *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- *
+ * 
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -26,70 +26,46 @@
  *
  */
 
-#include "PropertyParserString.h"
 #include <sstream>
+
+#include "PropertyParserString.h"
 
 namespace Rml {
 
-PropertyParserString::PropertyParserString() {}
-
-PropertyParserString::~PropertyParserString() {}
-
-std::string unicode_to_utf8(int charcode)
+PropertyParserString::PropertyParserString()
 {
-	std::string result;
-	if (charcode < 128)
-	{
-		result.push_back(charcode);
-	}
-	else
-	{
-		int first_bits = 6;
-		const int other_bits = 6;
-		int first_val = 0xC0;
-		int t = 0;
-		while (charcode >= (1 << first_bits))
-		{
-			{
-				t = 128 | (charcode & ((1 << other_bits) - 1));
-				charcode >>= other_bits;
-				first_val |= 1 << (first_bits);
-				first_bits--;
-			}
-			result.insert(0, 1, t);
-		}
-		t = first_val | charcode;
-		result.insert(0, 1, t);
-	}
-	return result;
+}
+
+PropertyParserString::~PropertyParserString()
+{
 }
 
 // Called to parse a RCSS string declaration.
 bool PropertyParserString::ParseValue(Property& property, const String& value, const ParameterMap& RMLUI_UNUSED_PARAMETER(parameters)) const
 {
 	RMLUI_UNUSED(parameters);
-
+	
 	// parse escaped unicode literals according to https://www.w3.org/TR/CSS2/syndata.html#characters
-
+	
 	std::string str = value;
 	std::string::size_type startIdx = 0;
 	do
 	{
 		startIdx = str.find("\\", startIdx);
-		if (startIdx == std::string::npos)
+		if (startIdx == std::string::npos) 
 			break;
-
+		
 		std::string::size_type endIdx = str.find_first_not_of("0123456789abcdefABCDEF", startIdx + 1);
-		if (endIdx == std::string::npos)
+		if (endIdx == std::string::npos) 
 			endIdx = str.length();
-
+		
 		std::string tmpStr = str.substr(startIdx + 1, endIdx - (startIdx + 1));
 		std::istringstream iss(tmpStr);
-
+		
 		uint32_t cp;
 		if (iss >> std::hex >> cp)
 		{
-			std::string utf8 = unicode_to_utf8(cp);
+			std::string utf8 = StringUtilities::ToUTF8(static_cast<Character>(cp));
 			str.replace(startIdx, 1 + tmpStr.length(), utf8);
 			startIdx += utf8.length();
 		}
@@ -97,10 +73,10 @@ bool PropertyParserString::ParseValue(Property& property, const String& value, c
 			startIdx += 1;
 	}
 	while (true);
-
+	
 	property.value = Variant(str);
 	property.unit = Property::STRING;
-
+	
 	return true;
 }
 

--- a/Source/Core/PropertyParserString.cpp
+++ b/Source/Core/PropertyParserString.cpp
@@ -26,6 +26,8 @@
  *
  */
 
+#include <sstream>
+
 #include "PropertyParserString.h"
 
 namespace Rml {
@@ -38,12 +40,77 @@ PropertyParserString::~PropertyParserString()
 {
 }
 
+std::string to_utf8(uint32_t cp)
+{
+	// from https://stackoverflow.com/a/28553727/4882174
+    std::string result;
+
+    int count;
+    if (cp <= 0x007F)
+        count = 1;
+    else if (cp <= 0x07FF)
+        count = 2;
+    else if (cp <= 0xFFFF)
+        count = 3;
+    else if (cp <= 0x10FFFF)
+        count = 4;
+    else
+        return result; // or throw an exception
+
+    result.resize(count);
+
+    if (count > 1)
+    {
+        for (int i = count - 1; i > 0; --i)
+        {
+            result[i] = (char) (0x80 | (cp & 0x3F));
+            cp >>= 6;
+        }
+
+        for (int i = 0; i < count; ++i)
+            cp |= (1 << (7-i));
+    }
+
+    result[0] = (char) cp;
+
+    return result;
+}
+
 // Called to parse a RCSS string declaration.
 bool PropertyParserString::ParseValue(Property& property, const String& value, const ParameterMap& RMLUI_UNUSED_PARAMETER(parameters)) const
 {
 	RMLUI_UNUSED(parameters);
+	
+	// parse escaped unicode literals according to https://www.w3.org/TR/CSS2/syndata.html#characters
 
-	property.value = Variant(value);
+	std::string str = value;
+	std::string::size_type startIdx = 0;
+	do
+	{
+		startIdx = str.find("\\", startIdx);
+		if (startIdx == std::string::npos) 
+			break;
+
+		std::string::size_type endIdx = str.find_first_not_of("0123456789abcdefABCDEF", startIdx + 1);
+		if (endIdx == std::string::npos) 
+			endIdx = str.length();
+
+		std::string tmpStr = str.substr(startIdx + 1, endIdx - (startIdx + 1));
+		std::istringstream iss(tmpStr);
+
+		uint32_t cp;
+		if (iss >> std::hex >> cp)
+		{
+			std::string utf8 = to_utf8(cp);
+			str.replace(startIdx, 1 + tmpStr.length(), utf8);
+			startIdx += utf8.length();
+		}
+		else
+			startIdx += 1;
+	}
+	while (true);
+
+	property.value = Variant(str);
 	property.unit = Property::STRING;
 
 	return true;

--- a/Source/Core/PropertyParserString.cpp
+++ b/Source/Core/PropertyParserString.cpp
@@ -39,41 +39,41 @@ PropertyParserString::PropertyParserString()
 PropertyParserString::~PropertyParserString()
 {
 }
-
+	
 std::string to_utf8(uint32_t cp)
 {
 	// from https://stackoverflow.com/a/28553727/4882174
-    std::string result;
-
-    int count;
-    if (cp <= 0x007F)
-        count = 1;
-    else if (cp <= 0x07FF)
-        count = 2;
-    else if (cp <= 0xFFFF)
-        count = 3;
-    else if (cp <= 0x10FFFF)
-        count = 4;
-    else
-        return result; // or throw an exception
-
-    result.resize(count);
-
-    if (count > 1)
-    {
-        for (int i = count - 1; i > 0; --i)
-        {
-            result[i] = (char) (0x80 | (cp & 0x3F));
-            cp >>= 6;
-        }
-
-        for (int i = 0; i < count; ++i)
-            cp |= (1 << (7-i));
-    }
-
-    result[0] = (char) cp;
-
-    return result;
+	std::string result;
+	
+	int count;
+	if (cp <= 0x007F)
+		count = 1;
+	else if (cp <= 0x07FF)
+		count = 2;
+	else if (cp <= 0xFFFF)
+		count = 3;
+	else if (cp <= 0x10FFFF)
+		count = 4;
+	else
+		return result; // or throw an exception
+	
+	result.resize(count);
+	
+	if (count > 1)
+	{
+		for (int i = count - 1; i > 0; --i)
+		{
+			result[i] = (char) (0x80 | (cp & 0x3F));
+			cp >>= 6;
+		}
+		
+		for (int i = 0; i < count; ++i)
+			cp |= (1 << (7 - i));
+	}
+	
+	result[0] = (char) cp;
+	
+	return result;
 }
 
 // Called to parse a RCSS string declaration.

--- a/Source/Core/StyleSheetSpecification.cpp
+++ b/Source/Core/StyleSheetSpecification.cpp
@@ -430,6 +430,8 @@ void StyleSheetSpecification::RegisterDefaultProperties()
 	RegisterProperty(PropertyId::FlexShrink, "flex-shrink", "1", false, true).AddParser("number");
 	RegisterProperty(PropertyId::FlexWrap, "flex-wrap", "nowrap", false, true).AddParser("keyword", "nowrap, wrap, wrap-reverse");
 	RegisterProperty(PropertyId::JustifyContent, "justify-content", "flex-start", false, true).AddParser("keyword", "flex-start, flex-end, center, space-between, space-around");
+	
+	RegisterProperty(PropertyId::Content, "content", "", false, true).AddParser("string");
 
 	RegisterShorthand(ShorthandId::Flex, "flex", "flex-grow, flex-shrink, flex-basis", ShorthandType::Flex);
 	RegisterShorthand(ShorthandId::FlexFlow, "flex-flow", "flex-direction, flex-wrap", ShorthandType::FallThrough);

--- a/Tests/Source/UnitTests/ElementStyle.cpp
+++ b/Tests/Source/UnitTests/ElementStyle.cpp
@@ -82,11 +82,15 @@ static const String document_content_rml = R"(
 		div {
 			content: "Content from RCSS";
 		}
+		p {
+			content: "\2193"; /* unicode arrow pointing down (↓) */
+		}
 	</style>
 </head>
 
 <body>
 <div id="div" />
+<p id="p" />
 </body>
 </rml>
 )";
@@ -121,16 +125,19 @@ TEST_CASE("elementstyle.content")
 	REQUIRE(document);
 	document->Show();
 	
-	auto element = document->GetElementById("div");
-	CHECK(element->GetProperty(PropertyId::Content)->ToString() == "Content from RCSS");
-	element->SetProperty(PropertyId::Content, Property("Different content", Property::STRING));
+	auto p = document->GetElementById("p");
+	CHECK(p->GetProperty(PropertyId::Content)->ToString() == "↓");
+	
+	auto div = document->GetElementById("div");
+	CHECK(div->GetProperty(PropertyId::Content)->ToString() == "Content from RCSS");
+	div->SetProperty(PropertyId::Content, Property("Different content", Property::STRING));
 	
 	context->Update();
 	context->Render();
 	
 	TestsShell::RenderLoop();
 	
-	CHECK(element->GetProperty(PropertyId::Content)->ToString() == "Different content");
+	CHECK(div->GetProperty(PropertyId::Content)->ToString() == "Different content");
 		
 	document->Close();
 	

--- a/Tests/Source/UnitTests/ElementStyle.cpp
+++ b/Tests/Source/UnitTests/ElementStyle.cpp
@@ -69,7 +69,6 @@ static const String document_content_rml = R"(
 <rml>
 <head>
 	<title>Test</title>
-	<link type="text/rcss" href="/assets/rml.rcss"/>
 	<style>
 		body
 		{

--- a/Tests/Source/UnitTests/ElementStyle.cpp
+++ b/Tests/Source/UnitTests/ElementStyle.cpp
@@ -84,12 +84,16 @@ static const String document_content_rml = R"(
 		p {
 			content: "\2193"; /* unicode arrow pointing down (↓) */
 		}
+		span {
+			content: "A \ B"; /* sanity check against unescape logic */
+		}
 	</style>
 </head>
 
 <body>
 <div id="div" />
 <p id="p" />
+<span id="span" />
 </body>
 </rml>
 )";
@@ -126,6 +130,9 @@ TEST_CASE("elementstyle.content")
 	
 	auto p = document->GetElementById("p");
 	CHECK(p->GetProperty(PropertyId::Content)->ToString() == "↓");
+
+	auto span = document->GetElementById("span");
+	CHECK(span->GetProperty(PropertyId::Content)->ToString() == "A \\ B");
 	
 	auto div = document->GetElementById("div");
 	CHECK(div->GetProperty(PropertyId::Content)->ToString() == "Content from RCSS");

--- a/Tests/Source/UnitTests/ElementStyle.cpp
+++ b/Tests/Source/UnitTests/ElementStyle.cpp
@@ -65,6 +65,32 @@ static const String document_decorator_rml = R"(
 </rml>
 )";
 
+static const String document_content_rml = R"(
+<rml>
+<head>
+	<title>Test</title>
+	<link type="text/rcss" href="/assets/rml.rcss"/>
+	<style>
+		body
+		{
+			font-family: LatoLatin;
+			font-weight: normal;
+			font-style: normal;
+			font-size: 15dp;
+			color: white;
+		}
+		div {
+			content: "Content from RCSS";
+		}
+	</style>
+</head>
+
+<body>
+<div id="div" />
+</body>
+</rml>
+)";
+
 
 TEST_CASE("elementstyle.inline_decorator_images")
 {
@@ -72,7 +98,7 @@ TEST_CASE("elementstyle.inline_decorator_images")
 	REQUIRE(context);
 
 	// There should be no warnings loading this document. There should be three images visible.
-	ElementDocument* document = context->LoadDocumentFromMemory(document_decorator_rml, "assets/");
+	ElementDocument* document = context->LoadDocumentFromMemory(document_decorator_rml);
 	REQUIRE(document);
 	document->Show();
 
@@ -83,5 +109,30 @@ TEST_CASE("elementstyle.inline_decorator_images")
 
 	document->Close();
 
+	TestsShell::ShutdownShell();
+}
+
+TEST_CASE("elementstyle.content")
+{
+	Context* context = TestsShell::GetContext();
+	REQUIRE(context);
+	
+	ElementDocument* document = context->LoadDocumentFromMemory(document_content_rml, "assets/");
+	REQUIRE(document);
+	document->Show();
+	
+	auto element = document->GetElementById("div");
+	CHECK(element->GetProperty(PropertyId::Content)->ToString() == "Content from RCSS");
+	element->SetProperty(PropertyId::Content, Property("Different content", Property::STRING));
+	
+	context->Update();
+	context->Render();
+	
+	TestsShell::RenderLoop();
+	
+	CHECK(element->GetProperty(PropertyId::Content)->ToString() == "Different content");
+		
+	document->Close();
+	
 	TestsShell::ShutdownShell();
 }


### PR DESCRIPTION
This PR adds the content property in a very simple first version. Only text literals are supported, and will be instantiated as inner RML. Additionally, unicode unescaping according to the CSS spec is added as well.

I wanted this feature in order to be able to use icon web-fonts out of the box using their stylesheet with as little modification as possible (i think we currently don't support ::before, do we?)

After implementing the backslash escaping, i noticed however that currently backslashes are handled like windows path delimiters, which would of course clash with the escaping syntax. Thus the current escaping tests fail.

So maybe we need to introduce a spec-diverging escape sequence like \u or something. But that would still cause unwanted behavior in the rare cases where Windows folders would start with a u.