### PR TITLE
Sorted StyleSheetNodes

### DIFF
--- a/Include/RmlUi/Config/Config.h
+++ b/Include/RmlUi/Config/Config.h
@@ -50,9 +50,9 @@
 #include <array>
 #include <unordered_map>
 #include <memory>
-
-#ifdef RMLUI_NO_THIRDPARTY_CONTAINERS
 #include <set>
+	
+#ifdef RMLUI_NO_THIRDPARTY_CONTAINERS
 #include <unordered_set>
 #else
 #include "../Core/Containers/chobo/flat_map.hpp"
@@ -96,6 +96,8 @@ using SmallUnorderedMap = UnorderedMap< Key, Value >;
 template <typename T>
 using UnorderedSet = std::unordered_set< T >;
 template <typename T>
+using OrderedSet = std::set< T >;
+template <typename T>
 using SmallUnorderedSet = std::unordered_set< T >;
 template <typename T>
 using SmallOrderedSet = std::set< T >;
@@ -106,6 +108,8 @@ template <typename Key, typename Value>
 using SmallUnorderedMap = chobo::flat_map< Key, Value >;
 template <typename T>
 using UnorderedSet = robin_hood::unordered_flat_set< T >;
+template <typename T>
+using OrderedSet = std::set< T >;
 template <typename T>
 using SmallUnorderedSet = chobo::flat_set< T >;
 template <typename T>

--- a/Source/Core/StyleSheetNode.cpp
+++ b/Source/Core/StyleSheetNode.cpp
@@ -59,7 +59,7 @@ StyleSheetNode::StyleSheetNode(StyleSheetNode* parent, CompoundSelector&& select
 
 StyleSheetNode* StyleSheetNode::GetOrCreateChildNode(const CompoundSelector& other)
 {
-	static auto scratch = MakeUnique<StyleSheetNode>(this, CompoundSelector{});
+	static auto scratch = MakeUnique<StyleSheetNode>(nullptr, CompoundSelector{});
 	
 	scratch->selector = other;
 	
@@ -79,7 +79,7 @@ StyleSheetNode* StyleSheetNode::GetOrCreateChildNode(const CompoundSelector& oth
 
 StyleSheetNode* StyleSheetNode::GetOrCreateChildNode(CompoundSelector&& other)
 {
-	static auto scratch = MakeUnique<StyleSheetNode>(this, CompoundSelector{});
+	static auto scratch = MakeUnique<StyleSheetNode>(nullptr, CompoundSelector{});
 	
 	scratch->selector = std::move(other);
 	

--- a/Source/Core/StyleSheetNode.h
+++ b/Source/Core/StyleSheetNode.h
@@ -37,7 +37,7 @@ namespace Rml {
 
 struct StyleSheetIndex;
 class StyleSheetNode;
-using StyleSheetNodeList = Vector<UniquePtr<StyleSheetNode>>;
+using StyleSheetNodeList = OrderedSet<UniquePtr<StyleSheetNode>>;
 
 /**
     A style sheet is composed of a tree of nodes.
@@ -78,7 +78,9 @@ public:
 
 	/// Returns the specificity of this node.
 	int GetSpecificity() const;
-
+	
+	bool operator<(StyleSheetNode const& other) const;
+	
 private:
 	void CalculateAndSetSpecificity();
 
@@ -104,5 +106,9 @@ private:
 	StyleSheetNodeList children;
 };
 
+inline bool operator<(UniquePtr<StyleSheetNode> const& ptr1, UniquePtr<StyleSheetNode> const& ptr2)
+{
+	return (*ptr1) < (*ptr2);
+}
 } // namespace Rml
 #endif

--- a/Source/Core/StyleSheetSelector.cpp
+++ b/Source/Core/StyleSheetSelector.cpp
@@ -90,6 +90,26 @@ bool operator==(const CompoundSelector& a, const CompoundSelector& b)
 	return true;
 }
 
+bool operator<(const CompoundSelector& a, const CompoundSelector& b)
+{
+	if (a.tag != b.tag)
+		return a.tag < b.tag;
+	if (a.id != b.id)
+		return a.id < b.id;
+	if (a.class_names != b.class_names)
+		return a.class_names < b.class_names;
+	if (a.pseudo_class_names != b.pseudo_class_names)
+		return a.pseudo_class_names < b.pseudo_class_names;
+	if (a.attributes != b.attributes)
+		return a.attributes < b.attributes;
+	if (a.structural_selectors != b.structural_selectors)
+		return a.structural_selectors < b.structural_selectors;
+	if (a.combinator != b.combinator)
+		return a.combinator < b.combinator;
+
+	return false;
+}
+
 bool IsSelectorApplicable(const Element* element, const StructuralSelector& selector)
 {
 	RMLUI_ASSERT(element);

--- a/Source/Core/StyleSheetSelector.h
+++ b/Source/Core/StyleSheetSelector.h
@@ -147,6 +147,7 @@ struct CompoundSelector {
 	SelectorCombinator combinator = SelectorCombinator::Descendant; // Determines how to match with our parent node.
 };
 bool operator==(const CompoundSelector& a, const CompoundSelector& b);
+bool operator<(const CompoundSelector& a, const CompoundSelector& b);
 
 /// Returns true if the the node the given selector is discriminating for is applicable to a given element.
 /// @param element[in] The element to determine node applicability for.


### PR DESCRIPTION
So first up, sorry for spamming PRs :D

As mentioned in #399 , parsing a very large stylesheet (taken from https://materialdesignicons.com/ ) made the application startup noticeably slower. 

By turning the StyleSheetNode children list from a vector into a sorted set using the comparison methods for the CompoundSelector members, i was able to speedup the application startup (time to first render) from 2.3s to 1.0s. 
