### PR TITLE
HTML unicode escaping sequences

### DIFF
--- a/Source/Core/ElementText.cpp
+++ b/Source/Core/ElementText.cpp
@@ -424,7 +424,7 @@ void ElementText::OnPropertyChange(const PropertyIdSet& changed_properties)
 // Returns the RML of this element
 void ElementText::GetRML(String& content)
 {
-	content += text;
+	content += StringUtilities::EncodeRml(text);
 }
 
 // Updates the configuration this element uses for its font.

--- a/Source/Core/ElementText.cpp
+++ b/Source/Core/ElementText.cpp
@@ -54,9 +54,11 @@ ElementText::~ElementText() {}
 
 void ElementText::SetText(const String& _text)
 {
-	if (text != _text)
+	auto unescaped_text = StringUtilities::DecodeRml(_text);
+	
+	if (text != unescaped_text)
 	{
-		text = _text;
+		text = unescaped_text;
 
 		if (dirty_layout_on_change)
 			DirtyLayout();

--- a/Source/Core/ElementText.cpp
+++ b/Source/Core/ElementText.cpp
@@ -54,11 +54,9 @@ ElementText::~ElementText() {}
 
 void ElementText::SetText(const String& _text)
 {
-	auto unescaped_text = StringUtilities::DecodeRml(_text);
-	
-	if (text != unescaped_text)
+	if (text != _text)
 	{
-		text = unescaped_text;
+		text = _text;
 
 		if (dirty_layout_on_change)
 			DirtyLayout();

--- a/Source/Core/Factory.cpp
+++ b/Source/Core/Factory.cpp
@@ -387,9 +387,6 @@ bool Factory::InstanceElementText(Element* parent, const String& in_text)
 	if (only_white_space)
 		return true;
 	
-	// Unescape any escaped entities or unicode symbols
-	text = StringUtilities::DecodeRml(text);
-	
 	// See if we need to parse it as RML, and whether the text contains data expressions (curly brackets).
 	bool parse_as_rml = false;
 	bool has_data_expression = false;
@@ -456,6 +453,9 @@ bool Factory::InstanceElementText(Element* parent, const String& in_text)
 			return false;
 		}
 
+		// Unescape any escaped entities or unicode symbols
+		text = StringUtilities::DecodeRml(text);
+	
 		text_element->SetText(text);
 
 		// Add to active node.

--- a/Source/Core/Factory.cpp
+++ b/Source/Core/Factory.cpp
@@ -386,7 +386,10 @@ bool Factory::InstanceElementText(Element* parent, const String& in_text)
 	const bool only_white_space = std::all_of(text.begin(), text.end(), &StringUtilities::IsWhitespace);
 	if (only_white_space)
 		return true;
-
+	
+	// Unescape any escaped entities or unicode symbols
+	text = StringUtilities::DecodeRml(text);
+	
 	// See if we need to parse it as RML, and whether the text contains data expressions (curly brackets).
 	bool parse_as_rml = false;
 	bool has_data_expression = false;

--- a/Tests/Source/UnitTests/XMLParser.cpp
+++ b/Tests/Source/UnitTests/XMLParser.cpp
@@ -136,7 +136,8 @@ TEST_CASE("XMLParser.escaping_tags")
 	
 	TestsShell::RenderLoop();
 	
-	CHECK(document->GetNumChildren() == 1); CHECK(document->GetFirstChild()->GetTagName() == "#text");
+	CHECK(document->GetNumChildren() == 1); 
+	CHECK(document->GetFirstChild()->GetTagName() == "#text");
 	// Text-access should yield decoded value, while RML-access should yield encoded value
 	CHECK(static_cast<ElementText*>(document->GetFirstChild())->GetText() == "<p>&lt;span/&gt;</p>");
 	CHECK(document->GetInnerRML() == "&lt;p&gt;&amp;lt;span/&amp;gt;&lt;/p&gt;");

--- a/Tests/Source/UnitTests/XMLParser.cpp
+++ b/Tests/Source/UnitTests/XMLParser.cpp
@@ -96,8 +96,6 @@ TEST_CASE("XMLParser.escaping")
 	Context* context = TestsShell::GetContext();
 	REQUIRE(context);
 
-	// Style nodes should accept XML reserved characters, see https://github.com/mikke89/RmlUi/issues/341
-
 	ElementDocument* document = context->LoadDocumentFromMemory(document_escaping);
 	REQUIRE(document);
 	document->Show();

--- a/Tests/Source/UnitTests/XMLParser.cpp
+++ b/Tests/Source/UnitTests/XMLParser.cpp
@@ -68,6 +68,21 @@ static const String document_escaping = R"(
 </rml>
 )";
 
+static const String document_escaping_tags = R"(
+<rml>
+    <head>
+	<style>
+	* { 
+		font-family: LatoLatin;
+	}
+	</style>
+    </head>
+    <body>
+	&lt;p&gt;&amp;lt;span/&amp;gt;&lt;/p&gt;
+    </body>
+</rml>
+)";
+
 TEST_CASE("XMLParser")
 {
 	Context* context = TestsShell::GetContext();
@@ -95,18 +110,37 @@ TEST_CASE("XMLParser.escaping")
 {
 	Context* context = TestsShell::GetContext();
 	REQUIRE(context);
-
+	
 	ElementDocument* document = context->LoadDocumentFromMemory(document_escaping);
 	REQUIRE(document);
 	document->Show();
-
+	
 	TestsShell::RenderLoop();
-
+	
 	auto element = document->GetElementById("p");
 	REQUIRE(element);
 	
 	CHECK(element->GetInnerRML() == "\xe2\x82\xac\xe2\x82\xac");
+	
+	document->Close();
+	TestsShell::ShutdownShell();
+}
 
+TEST_CASE("XMLParser.escaping_tags")
+{
+	Context* context = TestsShell::GetContext();
+	REQUIRE(context);
+	
+	ElementDocument* document = context->LoadDocumentFromMemory(document_escaping_tags);
+	REQUIRE(document);
+	document->Show();
+	
+	TestsShell::RenderLoop();
+	
+	CHECK(document->GetNumChildren() == 1);
+	CHECK(document->GetFirstChild()->GetTagName() == "#text");
+	CHECK(StringUtilities::StripWhitespace(document->GetInnerRML()) == "<p>&lt;span/&gt;</p>");
+	
 	document->Close();
 	TestsShell::ShutdownShell();
 }

--- a/Tests/Source/UnitTests/XMLParser.cpp
+++ b/Tests/Source/UnitTests/XMLParser.cpp
@@ -53,6 +53,21 @@ static const String document_xml_tags_in_css = R"(
 </rml>
 )";
 
+static const String document_escaping = R"(
+<rml>
+    <head>
+	<style>
+	p { 
+		font-family: LatoLatin;
+	}
+	</style>
+    </head>
+    <body>
+	<p id="p">&#x20AC;&#8364;</p>
+    </body>
+</rml>
+)";
+
 TEST_CASE("XMLParser")
 {
 	Context* context = TestsShell::GetContext();
@@ -71,6 +86,28 @@ TEST_CASE("XMLParser")
 	CHECK(background.green == 0xff);
 	CHECK(background.blue == 0);
 	CHECK(background.alpha == 0xff);
+
+	document->Close();
+	TestsShell::ShutdownShell();
+}
+
+TEST_CASE("XMLParser.escaping")
+{
+	Context* context = TestsShell::GetContext();
+	REQUIRE(context);
+
+	// Style nodes should accept XML reserved characters, see https://github.com/mikke89/RmlUi/issues/341
+
+	ElementDocument* document = context->LoadDocumentFromMemory(document_escaping);
+	REQUIRE(document);
+	document->Show();
+
+	TestsShell::RenderLoop();
+
+	auto element = document->GetElementById("p");
+	REQUIRE(element);
+
+	CHECK(element->GetInnerRML() == "€€");
 
 	document->Close();
 	TestsShell::ShutdownShell();

--- a/Tests/Source/UnitTests/XMLParser.cpp
+++ b/Tests/Source/UnitTests/XMLParser.cpp
@@ -105,7 +105,7 @@ TEST_CASE("XMLParser.escaping")
 	auto element = document->GetElementById("p");
 	REQUIRE(element);
 	
-	CHECK(element->GetInnerRML() == std::string(u8"€€"));
+	CHECK(element->GetInnerRML() == "\xe2\x82\xac\xe2\x82\xac");
 
 	document->Close();
 	TestsShell::ShutdownShell();

--- a/Tests/Source/UnitTests/XMLParser.cpp
+++ b/Tests/Source/UnitTests/XMLParser.cpp
@@ -31,6 +31,7 @@
 #include <RmlUi/Core/Context.h>
 #include <RmlUi/Core/Element.h>
 #include <RmlUi/Core/ElementDocument.h>
+#include <RmlUi/Core/ElementText.h>
 #include <RmlUi/Core/Factory.h>
 #include <doctest.h>
 
@@ -77,9 +78,7 @@ static const String document_escaping_tags = R"(
 	}
 	</style>
     </head>
-    <body>
-	&lt;p&gt;&amp;lt;span/&amp;gt;&lt;/p&gt;
-    </body>
+    <body>&lt;p&gt;&amp;lt;span/&amp;gt;&lt;/p&gt;</body>
 </rml>
 )";
 
@@ -137,9 +136,10 @@ TEST_CASE("XMLParser.escaping_tags")
 	
 	TestsShell::RenderLoop();
 	
-	CHECK(document->GetNumChildren() == 1);
-	CHECK(document->GetFirstChild()->GetTagName() == "#text");
-	CHECK(StringUtilities::StripWhitespace(document->GetInnerRML()) == "<p>&lt;span/&gt;</p>");
+	CHECK(document->GetNumChildren() == 1); CHECK(document->GetFirstChild()->GetTagName() == "#text");
+	// Text-access should yield decoded value, while RML-access should yield encoded value
+	CHECK(static_cast<ElementText*>(document->GetFirstChild())->GetText() == "<p>&lt;span/&gt;</p>");
+	CHECK(document->GetInnerRML() == "&lt;p&gt;&amp;lt;span/&amp;gt;&lt;/p&gt;");
 	
 	document->Close();
 	TestsShell::ShutdownShell();

--- a/Tests/Source/UnitTests/XMLParser.cpp
+++ b/Tests/Source/UnitTests/XMLParser.cpp
@@ -105,7 +105,7 @@ TEST_CASE("XMLParser.escaping")
 	auto element = document->GetElementById("p");
 	REQUIRE(element);
 
-	CHECK(element->GetInnerRML() == "€€");
+	CHECK(element->GetInnerRML() == (const char*)u8"€€");
 
 	document->Close();
 	TestsShell::ShutdownShell();

--- a/Tests/Source/UnitTests/XMLParser.cpp
+++ b/Tests/Source/UnitTests/XMLParser.cpp
@@ -104,8 +104,8 @@ TEST_CASE("XMLParser.escaping")
 
 	auto element = document->GetElementById("p");
 	REQUIRE(element);
-
-	CHECK(element->GetInnerRML() == (const char*)u8"€€");
+	
+	CHECK(element->GetInnerRML() == std::string(u8"€€"));
 
 	document->Close();
 	TestsShell::ShutdownShell();


### PR DESCRIPTION
Like discussed in #399 , implementing HTML unicode unescaping seems more sensible right now than CSS-based.

This PR implements both decimal and hex decoding of html entities.