### PR TITLE
Add method to retrieve the DataTypeRegister during model binding.

### DIFF
--- a/Include/RmlUi/Core/DataModelHandle.h
+++ b/Include/RmlUi/Core/DataModelHandle.h
@@ -125,6 +125,10 @@ public:
 		type_register->GetTransformFuncRegister()->Register(name, std::move(transform_func));
 	}
 
+	// Returns the type register.
+	// The type register contains VariableDefinitions of all the data types registered to this data model's owning context.
+	DataTypeRegister* GetDataTypeRegister() const { return type_register; }
+
 	explicit operator bool() { return model && type_register; }
 
 private:


### PR DESCRIPTION
Without access to the DataTypeRegister, binding custom DataVariable types with RegisterCustomDataVariableDefinition has severe limitations, as described in #412.  This fixes that by letting you get the type register from the DataModelConstructor.

Fixes #412.