### PR TITLE
Added Plugin::OnPreShutdown to notify plugins that RmlUi will shutdown

### DIFF
--- a/Include/RmlUi/Core/Plugin.h
+++ b/Include/RmlUi/Core/Plugin.h
@@ -64,8 +64,6 @@ public:
 	/// Called when RmlUi is initialised, or immediately when the plugin registers itself if 
 	/// RmlUi has already been initialised.
 	virtual void OnInitialise();
-	/// Called before RmlUi starts to shut down.
-	virtual void OnPreShutdown();
 	/// Called when RmlUi shuts down.
 	virtual void OnShutdown();
 
@@ -87,6 +85,9 @@ public:
 	virtual void OnElementCreate(Element* element);
 	/// Called when an element is destroyed.
 	virtual void OnElementDestroy(Element* element);
+
+	/// Called before RmlUi starts to shut down.
+	virtual void OnPreShutdown();
 };
 
 } // namespace Rml

--- a/Include/RmlUi/Core/Plugin.h
+++ b/Include/RmlUi/Core/Plugin.h
@@ -64,6 +64,8 @@ public:
 	/// Called when RmlUi is initialised, or immediately when the plugin registers itself if 
 	/// RmlUi has already been initialised.
 	virtual void OnInitialise();
+	/// Called before RmlUi starts to shut down.
+	virtual void OnPreShutdown();
 	/// Called when RmlUi shuts down.
 	virtual void OnShutdown();
 

--- a/Source/Core/Core.cpp
+++ b/Source/Core/Core.cpp
@@ -162,6 +162,7 @@ void Shutdown()
 	contexts.clear();
 
 	// Notify all plugins we're being shutdown.
+	PluginRegistry::NotifyPreShutdown();
 	PluginRegistry::NotifyShutdown();
 
 	Factory::Shutdown();
@@ -357,7 +358,10 @@ void UnregisterPlugin(Plugin* plugin)
 	PluginRegistry::UnregisterPlugin(plugin);
 
 	if(initialised)
+	{
+		plugin->OnPreShutdown();
 		plugin->OnShutdown();
+	}
 }
 
 EventId RegisterEventType(const String& type, bool interruptible, bool bubbles, DefaultActionPhase default_action_phase)

--- a/Source/Core/Plugin.cpp
+++ b/Source/Core/Plugin.cpp
@@ -43,6 +43,10 @@ void Plugin::OnInitialise()
 {
 }
 
+void Plugin::OnPreShutdown()
+{
+}
+
 void Plugin::OnShutdown()
 {
 }

--- a/Source/Core/Plugin.cpp
+++ b/Source/Core/Plugin.cpp
@@ -43,10 +43,6 @@ void Plugin::OnInitialise()
 {
 }
 
-void Plugin::OnPreShutdown()
-{
-}
-
 void Plugin::OnShutdown()
 {
 }
@@ -93,6 +89,10 @@ void Plugin::OnElementCreate(Element* RMLUI_UNUSED_PARAMETER(element))
 void Plugin::OnElementDestroy(Element* RMLUI_UNUSED_PARAMETER(element))
 {
 	RMLUI_UNUSED(element);
+}
+
+void Plugin::OnPreShutdown()
+{
 }
 
 } // namespace Rml

--- a/Source/Core/PluginRegistry.cpp
+++ b/Source/Core/PluginRegistry.cpp
@@ -72,6 +72,13 @@ void PluginRegistry::NotifyInitialise()
 		basic_plugins[i]->OnInitialise();
 }
 
+// Calls OnPreShutdown() on all plugins.
+void PluginRegistry::NotifyPreShutdown()
+{
+	for (size_t i = 0; i < basic_plugins.size(); ++i)
+		basic_plugins[i]->OnPreShutdown();
+}
+
 // Calls OnShutdown() on all plugins.
 void PluginRegistry::NotifyShutdown()
 {

--- a/Source/Core/PluginRegistry.h
+++ b/Source/Core/PluginRegistry.h
@@ -50,6 +50,8 @@ public:
 
 	/// Calls OnInitialise() on all plugins.
 	static void NotifyInitialise();
+	/// Calls OnPreShutdown() on all plugins.
+	static void NotifyPreShutdown();
 	/// Calls OnShutdown() on all plugins.
 	static void NotifyShutdown();
 


### PR DESCRIPTION
This is related to an issue I discovered with my plugin, RmlSolLua.  When multiple plugins are attached, a crash can occur depending on the order that plugins are shut down due to Lua maintaining hold on unique_ptrs.  The solution to this is to initiate a garbage collection before you start shutting down RmlUi or experiment with the order in which you load your plugins.

This PR will call an OnPreShutdown function on every single plugin on a first pass, letting plugins prepare however they need for the impending shutdown.