### PR TITLE
Lua plugin: Add selection API to text input elements

### DIFF
--- a/Source/Lua/Elements/ElementFormControlInput.cpp
+++ b/Source/Lua/Elements/ElementFormControlInput.cpp
@@ -34,6 +34,31 @@
 namespace Rml {
 namespace Lua {
 
+//methods
+int ElementFormControlInputSelect(lua_State* /*L*/, ElementFormControlInput* obj)
+{
+    obj->Select();
+    return 0;
+}
+
+int ElementFormControlInputSetSelection(lua_State* L, ElementFormControlInput* obj)
+{
+    int start = (int)luaL_checkinteger(L, 1);
+    int end = (int)luaL_checkinteger(L, 2);
+    obj->SetSelectionRange(start, end);
+    return 0;
+}
+
+int ElementFormControlInputGetSelection(lua_State* L, ElementFormControlInput* obj)
+{
+    int selection_start = 0, selection_end = 0;
+    String selected_text;
+    obj->GetSelection(&selection_start, &selection_end, &selected_text);
+    lua_pushinteger(L, selection_start);
+    lua_pushinteger(L, selection_end);
+    lua_pushstring(L, selected_text.c_str());
+    return 3;
+}
 
 //getters
 int ElementFormControlInputGetAttrchecked(lua_State* L)
@@ -146,6 +171,9 @@ int ElementFormControlInputSetAttrstep(lua_State* L)
 
 RegType<ElementFormControlInput> ElementFormControlInputMethods[] = 
 {
+    RMLUI_LUAMETHOD(ElementFormControlInput,Select)
+    RMLUI_LUAMETHOD(ElementFormControlInput,SetSelection)
+    RMLUI_LUAMETHOD(ElementFormControlInput,GetSelection)
     {nullptr,nullptr},
 };
 

--- a/Source/Lua/Elements/ElementFormControlInput.h
+++ b/Source/Lua/Elements/ElementFormControlInput.h
@@ -36,6 +36,11 @@
 namespace Rml {
 namespace Lua {
 
+//methods
+int ElementFormControlInputSelect(lua_State* L, ElementFormControlInput* obj);
+int ElementFormControlInputSetSelection(lua_State* L, ElementFormControlInput* obj);
+int ElementFormControlInputGetSelection(lua_State* L, ElementFormControlInput* obj);
+
 //getters
 int ElementFormControlInputGetAttrchecked(lua_State* L);
 int ElementFormControlInputGetAttrmaxlength(lua_State* L);

--- a/Source/Lua/Elements/ElementFormControlTextArea.cpp
+++ b/Source/Lua/Elements/ElementFormControlTextArea.cpp
@@ -34,6 +34,32 @@
 namespace Rml {
 namespace Lua {
 
+//methods
+int ElementFormControlTextAreaSelect(lua_State* /*L*/, ElementFormControlTextArea* obj)
+{
+    obj->Select();
+    return 0;
+}
+
+int ElementFormControlTextAreaSetSelection(lua_State* L, ElementFormControlTextArea* obj)
+{
+    int start = (int)luaL_checkinteger(L, 1);
+    int end = (int)luaL_checkinteger(L, 2);
+    obj->SetSelectionRange(start, end);
+    return 0;
+}
+
+int ElementFormControlTextAreaGetSelection(lua_State* L, ElementFormControlTextArea* obj)
+{
+    int selection_start = 0, selection_end = 0;
+    String selected_text;
+    obj->GetSelection(&selection_start, &selection_end, &selected_text);
+    lua_pushinteger(L, selection_start);
+    lua_pushinteger(L, selection_end);
+    lua_pushstring(L, selected_text.c_str());
+    return 3;
+}
+
 //getters
 int ElementFormControlTextAreaGetAttrcols(lua_State* L)
 {
@@ -108,6 +134,9 @@ int ElementFormControlTextAreaSetAttrwordwrap(lua_State* L)
 
 RegType<ElementFormControlTextArea> ElementFormControlTextAreaMethods[] =
 {
+    RMLUI_LUAMETHOD(ElementFormControlTextArea,Select)
+    RMLUI_LUAMETHOD(ElementFormControlTextArea,SetSelection)
+    RMLUI_LUAMETHOD(ElementFormControlTextArea,GetSelection)
     { nullptr, nullptr },
 };
 

--- a/Source/Lua/Elements/ElementFormControlTextArea.h
+++ b/Source/Lua/Elements/ElementFormControlTextArea.h
@@ -36,6 +36,11 @@
 namespace Rml {
 namespace Lua {
 
+//methods
+int ElementFormControlTextAreaSelect(lua_State* L, ElementFormControlTextArea* obj);
+int ElementFormControlTextAreaSetSelection(lua_State* L, ElementFormControlTextArea* obj);
+int ElementFormControlTextAreaGetSelection(lua_State* L, ElementFormControlTextArea* obj);
+
 //getters
 int ElementFormControlTextAreaGetAttrcols(lua_State* L);
 int ElementFormControlTextAreaGetAttrmaxlength(lua_State* L);


### PR DESCRIPTION
This is a simple PR adding the new text input selection API to the Lua plugin.

See the entire discussion in #419.