### PR TITLE
Lua plugin: Fix selection API using 0-based indices

### DIFF
--- a/Source/Lua/Elements/ElementFormControlInput.cpp
+++ b/Source/Lua/Elements/ElementFormControlInput.cpp
@@ -43,8 +43,8 @@ int ElementFormControlInputSelect(lua_State* /*L*/, ElementFormControlInput* obj
 
 int ElementFormControlInputSetSelection(lua_State* L, ElementFormControlInput* obj)
 {
-    int start = (int)luaL_checkinteger(L, 1);
-    int end = (int)luaL_checkinteger(L, 2);
+    int start = (int)GetIndex(L, 1);
+    int end = (int)GetIndex(L, 2);
     obj->SetSelectionRange(start, end);
     return 0;
 }
@@ -54,8 +54,8 @@ int ElementFormControlInputGetSelection(lua_State* L, ElementFormControlInput* o
     int selection_start = 0, selection_end = 0;
     String selected_text;
     obj->GetSelection(&selection_start, &selection_end, &selected_text);
-    lua_pushinteger(L, selection_start);
-    lua_pushinteger(L, selection_end);
+    PushIndex(L, selection_start);
+    PushIndex(L, selection_end);
     lua_pushstring(L, selected_text.c_str());
     return 3;
 }

--- a/Source/Lua/Elements/ElementFormControlTextArea.cpp
+++ b/Source/Lua/Elements/ElementFormControlTextArea.cpp
@@ -43,8 +43,8 @@ int ElementFormControlTextAreaSelect(lua_State* /*L*/, ElementFormControlTextAre
 
 int ElementFormControlTextAreaSetSelection(lua_State* L, ElementFormControlTextArea* obj)
 {
-    int start = (int)luaL_checkinteger(L, 1);
-    int end = (int)luaL_checkinteger(L, 2);
+    int start = (int)GetIndex(L, 1);
+    int end = (int)GetIndex(L, 2);
     obj->SetSelectionRange(start, end);
     return 0;
 }
@@ -54,8 +54,8 @@ int ElementFormControlTextAreaGetSelection(lua_State* L, ElementFormControlTextA
     int selection_start = 0, selection_end = 0;
     String selected_text;
     obj->GetSelection(&selection_start, &selection_end, &selected_text);
-    lua_pushinteger(L, selection_start);
-    lua_pushinteger(L, selection_end);
+    PushIndex(L, selection_start);
+    PushIndex(L, selection_end);
     lua_pushstring(L, selected_text.c_str());
     return 3;
 }


### PR DESCRIPTION
This is a fix for my Lua rookie mistake in #434.

Since the selection range consists of an index/offset, it should be 1-based, as this is a convention in Lua.