### PR TITLE
On-demand rendering (power saving mode)

### DIFF
--- a/Backends/RmlUi_Backend.h
+++ b/Backends/RmlUi_Backend.h
@@ -58,7 +58,7 @@ Rml::RenderInterface* GetRenderInterface();
 
 // Polls and processes events from the current platform, and applies any relevant events to the provided RmlUi context and the key down callback.
 // @return False to indicate that the application should be closed.
-bool ProcessEvents(Rml::Context* context, KeyDownCallback key_down_callback = nullptr);
+bool ProcessEvents(Rml::Context* context, KeyDownCallback key_down_callback = nullptr, bool power_save = false);
 // Request application closure during the next event processing call.
 void RequestExit();
 

--- a/Backends/RmlUi_Backend_GLFW_GL2.cpp
+++ b/Backends/RmlUi_Backend_GLFW_GL2.cpp
@@ -127,7 +127,7 @@ Rml::RenderInterface* Backend::GetRenderInterface()
 	return &data->render_interface;
 }
 
-bool Backend::ProcessEvents(Rml::Context* context, KeyDownCallback key_down_callback)
+bool Backend::ProcessEvents(Rml::Context* context, KeyDownCallback key_down_callback, bool power_save)
 {
 	RMLUI_ASSERT(data && context);
 
@@ -148,7 +148,9 @@ bool Backend::ProcessEvents(Rml::Context* context, KeyDownCallback key_down_call
 	data->context = context;
 	data->key_down_callback = key_down_callback;
 
-	glfwPollEvents();
+	if(power_save)
+		glfwWaitEventsTimeout(Rml::Math::Min(context->GetNextUpdateDelay(), 10.0));
+	else glfwPollEvents();
 
 	data->context = nullptr;
 	data->key_down_callback = nullptr;

--- a/Backends/RmlUi_Backend_GLFW_GL3.cpp
+++ b/Backends/RmlUi_Backend_GLFW_GL3.cpp
@@ -139,7 +139,7 @@ Rml::RenderInterface* Backend::GetRenderInterface()
 	return &data->render_interface;
 }
 
-bool Backend::ProcessEvents(Rml::Context* context, KeyDownCallback key_down_callback)
+bool Backend::ProcessEvents(Rml::Context* context, KeyDownCallback key_down_callback, bool power_save)
 {
 	RMLUI_ASSERT(data && context);
 
@@ -160,7 +160,9 @@ bool Backend::ProcessEvents(Rml::Context* context, KeyDownCallback key_down_call
 	data->context = context;
 	data->key_down_callback = key_down_callback;
 
-	glfwPollEvents();
+	if(power_save)
+		glfwWaitEventsTimeout(Rml::Math::Min(context->GetNextUpdateDelay(), 10.0));
+	else glfwPollEvents();
 
 	data->context = nullptr;
 	data->key_down_callback = nullptr;

--- a/Backends/RmlUi_Backend_GLFW_VK.cpp
+++ b/Backends/RmlUi_Backend_GLFW_VK.cpp
@@ -182,7 +182,7 @@ bool Backend::ProcessEvents(Rml::Context* context, KeyDownCallback key_down_call
 	data->context = context;
 	data->key_down_callback = key_down_callback;
 
-	glfwWaitEventsTimeout(std::min(context->NextUpdateRequested(), 10.0));
+	glfwWaitEventsTimeout(std::min(context->GetNextUpdateDelay(), 10.0));
 
 	if (!WaitForValidSwapchain())
 		result = false;

--- a/Backends/RmlUi_Backend_GLFW_VK.cpp
+++ b/Backends/RmlUi_Backend_GLFW_VK.cpp
@@ -182,7 +182,7 @@ bool Backend::ProcessEvents(Rml::Context* context, KeyDownCallback key_down_call
 	data->context = context;
 	data->key_down_callback = key_down_callback;
 
-	glfwPollEvents();
+	glfwWaitEventsTimeout(std::min(context->NextUpdateRequested(), 10.0));
 
 	if (!WaitForValidSwapchain())
 		result = false;

--- a/Backends/RmlUi_Backend_GLFW_VK.cpp
+++ b/Backends/RmlUi_Backend_GLFW_VK.cpp
@@ -33,6 +33,7 @@
 #include <RmlUi/Core/Core.h>
 #include <RmlUi/Core/FileInterface.h>
 
+#include <GLFW/glfw3.h>
 #include <thread>
 #include <chrono>
 
@@ -160,7 +161,7 @@ static bool WaitForValidSwapchain()
 	return result;
 }
 
-bool Backend::ProcessEvents(Rml::Context* context, KeyDownCallback key_down_callback)
+bool Backend::ProcessEvents(Rml::Context* context, KeyDownCallback key_down_callback, bool power_save)
 {
 	RMLUI_ASSERT(data && context);
 
@@ -182,7 +183,9 @@ bool Backend::ProcessEvents(Rml::Context* context, KeyDownCallback key_down_call
 	data->context = context;
 	data->key_down_callback = key_down_callback;
 
-	glfwWaitEventsTimeout(std::min(context->GetNextUpdateDelay(), 10.0));
+	if(power_save)
+		glfwWaitEventsTimeout(Rml::Math::Min(context->GetNextUpdateDelay(), 10.0));
+	else glfwPollEvents();
 
 	if (!WaitForValidSwapchain())
 		result = false;

--- a/Backends/RmlUi_Backend_GLFW_VK.cpp
+++ b/Backends/RmlUi_Backend_GLFW_VK.cpp
@@ -26,16 +26,17 @@
  *
  */
 
+#include "RmlUi/Config/Config.h"
 #include "RmlUi_Backend.h"
 #include "RmlUi_Renderer_VK.h"
+// This space is intentional to prevent autoformat from reordering RmlUi_Renderer_VK behind RmlUi_Platform_GLFW
 #include "RmlUi_Platform_GLFW.h"
 #include <RmlUi/Core/Context.h>
 #include <RmlUi/Core/Core.h>
 #include <RmlUi/Core/FileInterface.h>
-
 #include <GLFW/glfw3.h>
+#include <cstdint>
 #include <thread>
-#include <chrono>
 
 static void SetupCallbacks(GLFWwindow* window);
 
@@ -90,10 +91,14 @@ bool Backend::Initialize(const char* window_name, int width, int height, bool al
 	data = Rml::MakeUnique<BackendData>();
 	data->window = window;
 
-	if (!data->render_interface.Initialize([](VkInstance instance, VkSurfaceKHR* out_surface) {
-			return glfwCreateWindowSurface(instance, data->window, nullptr, out_surface) == VkResult::VK_SUCCESS;
-			; 
-		}))
+	uint32_t count;
+	const char** extensions = glfwGetRequiredInstanceExtensions(&count);
+	RMLUI_VK_ASSERTMSG(extensions != nullptr, "Failed to query glfw vulkan extensions");
+	if (!data->render_interface.Initialize(Rml::Vector<const char*>(extensions, extensions + count),
+			[](VkInstance instance, VkSurfaceKHR* out_surface) {
+				return glfwCreateWindowSurface(instance, data->window, nullptr, out_surface) == VkResult::VK_SUCCESS;
+				;
+			}))
 	{
 		data.reset();
 		fprintf(stderr, "Could not initialize Vulkan render interface.");
@@ -179,13 +184,14 @@ bool Backend::ProcessEvents(Rml::Context* context, KeyDownCallback key_down_call
 		context->SetDimensions(window_size);
 		context->SetDensityIndependentPixelRatio(dp_ratio);
 	}
-	
+
 	data->context = context;
 	data->key_down_callback = key_down_callback;
 
-	if(power_save)
+	if (power_save)
 		glfwWaitEventsTimeout(Rml::Math::Min(context->GetNextUpdateDelay(), 10.0));
-	else glfwPollEvents();
+	else
+		glfwPollEvents();
 
 	if (!WaitForValidSwapchain())
 		result = false;

--- a/Backends/RmlUi_Backend_SDL_GL2.cpp
+++ b/Backends/RmlUi_Backend_SDL_GL2.cpp
@@ -253,7 +253,7 @@ Rml::RenderInterface* Backend::GetRenderInterface()
 	return &data->render_interface;
 }
 
-bool Backend::ProcessEvents(Rml::Context* context, KeyDownCallback key_down_callback)
+bool Backend::ProcessEvents(Rml::Context* context, KeyDownCallback key_down_callback, bool power_save)
 {
 	RMLUI_ASSERT(data && context);
 
@@ -261,7 +261,11 @@ bool Backend::ProcessEvents(Rml::Context* context, KeyDownCallback key_down_call
 	data->running = true;
 
 	SDL_Event ev;
-	while (SDL_PollEvent(&ev))
+	int has_event = 0;
+	if(power_save)
+		has_event = SDL_WaitEventTimeout(&ev, Rml::Math::Min(context->GetNextUpdateDelay(), 10.0)*1000);
+	else has_event = SDL_PollEvent(&ev);
+	while (has_event)
 	{
 		switch (ev.type)
 		{
@@ -307,6 +311,9 @@ bool Backend::ProcessEvents(Rml::Context* context, KeyDownCallback key_down_call
 		}
 		break;
 		}
+		if(power_save)
+			has_event = SDL_WaitEventTimeout(&ev, Rml::Math::Min(context->GetNextUpdateDelay(), 10.0)*1000);
+		else has_event = SDL_PollEvent(&ev);
 	}
 
 	return result;

--- a/Backends/RmlUi_Backend_SDL_GL2.cpp
+++ b/Backends/RmlUi_Backend_SDL_GL2.cpp
@@ -263,7 +263,7 @@ bool Backend::ProcessEvents(Rml::Context* context, KeyDownCallback key_down_call
 	SDL_Event ev;
 	int has_event = 0;
 	if(power_save)
-		has_event = SDL_WaitEventTimeout(&ev, Rml::Math::Min(context->GetNextUpdateDelay(), 10.0)*1000);
+		has_event = SDL_WaitEventTimeout(&ev, static_cast<int>(Rml::Math::Min(context->GetNextUpdateDelay(), 10.0)*1000));
 	else has_event = SDL_PollEvent(&ev);
 	while (has_event)
 	{

--- a/Backends/RmlUi_Backend_SDL_GL2.cpp
+++ b/Backends/RmlUi_Backend_SDL_GL2.cpp
@@ -311,9 +311,7 @@ bool Backend::ProcessEvents(Rml::Context* context, KeyDownCallback key_down_call
 		}
 		break;
 		}
-		if(power_save)
-			has_event = SDL_WaitEventTimeout(&ev, Rml::Math::Min(context->GetNextUpdateDelay(), 10.0)*1000);
-		else has_event = SDL_PollEvent(&ev);
+		has_event = SDL_PollEvent(&ev);
 	}
 
 	return result;

--- a/Backends/RmlUi_Backend_SDL_GL3.cpp
+++ b/Backends/RmlUi_Backend_SDL_GL3.cpp
@@ -242,7 +242,7 @@ bool Backend::ProcessEvents(Rml::Context* context, KeyDownCallback key_down_call
 	SDL_Event ev;
 	int has_event = 0;
 	if(power_save)
-		has_event = SDL_WaitEventTimeout(&ev, Rml::Math::Min(context->GetNextUpdateDelay(), 10.0)*1000);
+		has_event = SDL_WaitEventTimeout(&ev, static_cast<int>(Rml::Math::Min(context->GetNextUpdateDelay(), 10.0)*1000));
 	else has_event = SDL_PollEvent(&ev);
 	while (has_event)
 	{

--- a/Backends/RmlUi_Backend_SDL_GL3.cpp
+++ b/Backends/RmlUi_Backend_SDL_GL3.cpp
@@ -218,7 +218,7 @@ Rml::RenderInterface* Backend::GetRenderInterface()
 	return &data->render_interface;
 }
 
-bool Backend::ProcessEvents(Rml::Context* context, KeyDownCallback key_down_callback)
+bool Backend::ProcessEvents(Rml::Context* context, KeyDownCallback key_down_callback, bool power_save)
 {
 	RMLUI_ASSERT(data && context);
 
@@ -240,7 +240,11 @@ bool Backend::ProcessEvents(Rml::Context* context, KeyDownCallback key_down_call
 	data->running = true;
 
 	SDL_Event ev;
-	while (SDL_PollEvent(&ev))
+	int has_event = 0;
+	if(power_save)
+		has_event = SDL_WaitEventTimeout(&ev, Rml::Math::Min(context->GetNextUpdateDelay(), 10.0)*1000);
+	else has_event = SDL_PollEvent(&ev);
+	while (has_event)
 	{
 		switch (ev.type)
 		{
@@ -286,6 +290,9 @@ bool Backend::ProcessEvents(Rml::Context* context, KeyDownCallback key_down_call
 		}
 		break;
 		}
+		if(power_save)
+			has_event = SDL_WaitEventTimeout(&ev, Rml::Math::Min(context->GetNextUpdateDelay(), 10.0)*1000);
+		else has_event = SDL_PollEvent(&ev);
 	}
 
 	return result;

--- a/Backends/RmlUi_Backend_SDL_GL3.cpp
+++ b/Backends/RmlUi_Backend_SDL_GL3.cpp
@@ -290,9 +290,7 @@ bool Backend::ProcessEvents(Rml::Context* context, KeyDownCallback key_down_call
 		}
 		break;
 		}
-		if(power_save)
-			has_event = SDL_WaitEventTimeout(&ev, Rml::Math::Min(context->GetNextUpdateDelay(), 10.0)*1000);
-		else has_event = SDL_PollEvent(&ev);
+		has_event = SDL_PollEvent(&ev);
 	}
 
 	return result;

--- a/Backends/RmlUi_Backend_SDL_SDLrenderer.cpp
+++ b/Backends/RmlUi_Backend_SDL_SDLrenderer.cpp
@@ -129,7 +129,7 @@ bool Backend::ProcessEvents(Rml::Context* context, KeyDownCallback key_down_call
 	
 	int has_event = 0;
 	if(power_save)
-		has_event = SDL_WaitEventTimeout(&ev, Rml::Math::Min(context->GetNextUpdateDelay(), 10.0)*1000);
+		has_event = SDL_WaitEventTimeout(&ev, static_cast<int>(Rml::Math::Min(context->GetNextUpdateDelay(), 10.0)*1000));
 	else has_event = SDL_PollEvent(&ev);
 	while (has_event)
 	{

--- a/Backends/RmlUi_Backend_SDL_SDLrenderer.cpp
+++ b/Backends/RmlUi_Backend_SDL_SDLrenderer.cpp
@@ -163,9 +163,7 @@ bool Backend::ProcessEvents(Rml::Context* context, KeyDownCallback key_down_call
 		}
 		break;
 		}
-		if(power_save)
-			has_event = SDL_WaitEventTimeout(&ev, Rml::Math::Min(context->GetNextUpdateDelay(), 10.0)*1000);
-		else has_event = SDL_PollEvent(&ev);
+		has_event = SDL_PollEvent(&ev);
 	}
 
 	return result;

--- a/Backends/RmlUi_Backend_SDL_SDLrenderer.cpp
+++ b/Backends/RmlUi_Backend_SDL_SDLrenderer.cpp
@@ -120,14 +120,18 @@ Rml::RenderInterface* Backend::GetRenderInterface()
 	return &data->render_interface;
 }
 
-bool Backend::ProcessEvents(Rml::Context* context, KeyDownCallback key_down_callback)
+bool Backend::ProcessEvents(Rml::Context* context, KeyDownCallback key_down_callback, bool power_save)
 {
 	RMLUI_ASSERT(data && context);
 
 	bool result = data->running;
 	SDL_Event ev;
-
-	while (SDL_PollEvent(&ev))
+	
+	int has_event = 0;
+	if(power_save)
+		has_event = SDL_WaitEventTimeout(&ev, Rml::Math::Min(context->GetNextUpdateDelay(), 10.0)*1000);
+	else has_event = SDL_PollEvent(&ev);
+	while (has_event)
 	{
 		switch (ev.type)
 		{
@@ -159,6 +163,9 @@ bool Backend::ProcessEvents(Rml::Context* context, KeyDownCallback key_down_call
 		}
 		break;
 		}
+		if(power_save)
+			has_event = SDL_WaitEventTimeout(&ev, Rml::Math::Min(context->GetNextUpdateDelay(), 10.0)*1000);
+		else has_event = SDL_PollEvent(&ev);
 	}
 
 	return result;

--- a/Backends/RmlUi_Backend_SDL_VK.cpp
+++ b/Backends/RmlUi_Backend_SDL_VK.cpp
@@ -138,14 +138,18 @@ static bool WaitForValidSwapchain()
 	return result;
 }
 
-bool Backend::ProcessEvents(Rml::Context* context, KeyDownCallback key_down_callback)
+bool Backend::ProcessEvents(Rml::Context* context, KeyDownCallback key_down_callback, bool power_save)
 {
 	RMLUI_ASSERT(data && context);
 
 	bool result = data->running;
 	SDL_Event ev;
 
-	while (SDL_PollEvent(&ev))
+	int has_event = 0;
+	if(power_save)
+		has_event = SDL_WaitEventTimeout(&ev, Rml::Math::Min(context->GetNextUpdateDelay(), 10.0)*1000);
+	else has_event = SDL_PollEvent(&ev);
+	while (has_event)
 	{
 		switch (ev.type)
 		{
@@ -188,6 +192,9 @@ bool Backend::ProcessEvents(Rml::Context* context, KeyDownCallback key_down_call
 		}
 		break;
 		}
+		if(power_save)
+			has_event = SDL_WaitEventTimeout(&ev, Rml::Math::Min(context->GetNextUpdateDelay(), 10.0)*1000);
+		else has_event = SDL_PollEvent(&ev);
 	}
 
 	if (!WaitForValidSwapchain())

--- a/Backends/RmlUi_Backend_SDL_VK.cpp
+++ b/Backends/RmlUi_Backend_SDL_VK.cpp
@@ -165,7 +165,7 @@ bool Backend::ProcessEvents(Rml::Context* context, KeyDownCallback key_down_call
 
 	int has_event = 0;
 	if(power_save)
-		has_event = SDL_WaitEventTimeout(&ev, Rml::Math::Min(context->GetNextUpdateDelay(), 10.0)*1000);
+		has_event = SDL_WaitEventTimeout(&ev, static_cast<int>(Rml::Math::Min(context->GetNextUpdateDelay(), 10.0)*1000));
 	else has_event = SDL_PollEvent(&ev);
 	while (has_event)
 	{

--- a/Backends/RmlUi_Backend_SFML_GL2.cpp
+++ b/Backends/RmlUi_Backend_SFML_GL2.cpp
@@ -189,9 +189,12 @@ Rml::RenderInterface* Backend::GetRenderInterface()
 	return &data->render_interface;
 }
 
-bool Backend::ProcessEvents(Rml::Context* context, KeyDownCallback key_down_callback)
+bool Backend::ProcessEvents(Rml::Context* context, KeyDownCallback key_down_callback, bool power_save)
 {
 	RMLUI_ASSERT(data && context);
+
+	// SFML does not seem to provide a way to wait for events with a timeout.
+	(void)power_save;
 
 	// The contents of this function is intended to be copied directly into your main loop.
 	bool result = data->running;

--- a/Backends/RmlUi_Backend_Win32_GL2.cpp
+++ b/Backends/RmlUi_Backend_Win32_GL2.cpp
@@ -189,7 +189,20 @@ Rml::RenderInterface* Backend::GetRenderInterface()
 	return &data->render_interface;
 }
 
-bool Backend::ProcessEvents(Rml::Context* context, KeyDownCallback key_down_callback)
+static bool NextEvent(MSG& message, UINT timeout)
+{
+	if(timeout != 0)
+	{
+		UINT_PTR timer_id = SetTimer(nullptr, nullptr, timeout, nullptr);
+		BOOL res = GetMessage(&message);
+		KillTimer(nullptr, timer_id);
+		if(message.message != WM_TIMER || message.hwnd != nullptr || message.wParam != timer_id)
+			return res;
+	}
+	return PeekMessage(&message, nullptr, 0, 0, PM_REMOVE);
+}
+
+bool Backend::ProcessEvents(Rml::Context* context, KeyDownCallback key_down_callback, bool power_save)
 {
 	RMLUI_ASSERT(data && context);
 
@@ -206,13 +219,14 @@ bool Backend::ProcessEvents(Rml::Context* context, KeyDownCallback key_down_call
 	data->key_down_callback = key_down_callback;
 
 	MSG message;
-	while (PeekMessage(&message, nullptr, 0, 0, PM_NOREMOVE))
+	bool has_message = NextEvent(message, power_save ? Rml::Math::Min(context->GetNextUpdateDelay(), 10.0)*1000 : 0);
+	while (has_message)
 	{
-		GetMessage(&message, nullptr, 0, 0);
-
 		// Dispatch the message to our local event handler below.
 		TranslateMessage(&message);
 		DispatchMessage(&message);
+
+		has_message = NextEvent(message, 0);
 	}
 
 	data->context = nullptr;

--- a/Backends/RmlUi_Backend_Win32_GL2.cpp
+++ b/Backends/RmlUi_Backend_Win32_GL2.cpp
@@ -219,7 +219,7 @@ bool Backend::ProcessEvents(Rml::Context* context, KeyDownCallback key_down_call
 	data->key_down_callback = key_down_callback;
 
 	MSG message;
-	bool has_message = NextEvent(message, power_save ? static_cast<int>(Rml::Math::Min(context->GetNextUpdateDelay(), 10.0))*1000 : 0);
+	bool has_message = NextEvent(message, power_save ? static_cast<int>(Rml::Math::Min(context->GetNextUpdateDelay(), 10.0)*1000.0) : 0);
 	while (has_message)
 	{
 		// Dispatch the message to our local event handler below.

--- a/Backends/RmlUi_Backend_Win32_GL2.cpp
+++ b/Backends/RmlUi_Backend_Win32_GL2.cpp
@@ -193,9 +193,9 @@ static bool NextEvent(MSG& message, UINT timeout)
 {
 	if(timeout != 0)
 	{
-		UINT_PTR timer_id = SetTimer(nullptr, nullptr, timeout, nullptr);
-		BOOL res = GetMessage(&message);
-		KillTimer(nullptr, timer_id);
+		UINT_PTR timer_id = SetTimer(NULL, NULL, timeout, NULL);
+		BOOL res = GetMessage(&message, NULL, 0, 0);
+		KillTimer(NULL, timer_id);
 		if(message.message != WM_TIMER || message.hwnd != nullptr || message.wParam != timer_id)
 			return res;
 	}
@@ -219,7 +219,7 @@ bool Backend::ProcessEvents(Rml::Context* context, KeyDownCallback key_down_call
 	data->key_down_callback = key_down_callback;
 
 	MSG message;
-	bool has_message = NextEvent(message, power_save ? Rml::Math::Min(context->GetNextUpdateDelay(), 10.0)*1000 : 0);
+	bool has_message = NextEvent(message, power_save ? static_cast<int>(Rml::Math::Min(context->GetNextUpdateDelay(), 10.0))*1000 : 0);
 	while (has_message)
 	{
 		// Dispatch the message to our local event handler below.

--- a/Backends/RmlUi_Backend_Win32_VK.cpp
+++ b/Backends/RmlUi_Backend_Win32_VK.cpp
@@ -26,6 +26,7 @@
  *
  */
 
+#include "RmlUi/Config/Config.h"
 #include "RmlUi_Backend.h"
 #include "RmlUi_Include_Windows.h"
 #include "RmlUi_Platform_Win32.h"
@@ -144,7 +145,10 @@ bool Backend::Initialize(const char* window_name, int width, int height, bool al
 
 	data->window_handle = window_handle;
 
-	if (!data->render_interface.Initialize(CreateVulkanSurface))
+	Rml::Vector<const char*> extensions;
+	extensions.push_back(VK_KHR_WIN32_SURFACE_EXTENSION_NAME);
+	extensions.push_back(VK_KHR_SURFACE_EXTENSION_NAME);
+	if (!data->render_interface.Initialize(std::move(extensions), CreateVulkanSurface))
 	{
 		DisplayError(window_handle, "Could not initialize Vulkan render interface.");
 		::CloseWindow(window_handle);
@@ -218,7 +222,7 @@ bool Backend::ProcessEvents(Rml::Context* context, KeyDownCallback key_down_call
 
 	MSG message;
 	// Process events.
-	bool has_message = NextEvent(message, power_save ? static_cast<int>(Rml::Math::Min(context->GetNextUpdateDelay(), 10.0))*1000 : 0);
+	bool has_message = NextEvent(message, power_save ? static_cast<int>(Rml::Math::Min(context->GetNextUpdateDelay(), 10.0)*1000.0) : 0);
 	while (has_message || !data->render_interface.IsSwapchainValid())
 	{
 		if(has_message)

--- a/Backends/RmlUi_Backend_Win32_VK.cpp
+++ b/Backends/RmlUi_Backend_Win32_VK.cpp
@@ -191,9 +191,9 @@ static bool NextEvent(MSG& message, UINT timeout)
 {
 	if(timeout != 0)
 	{
-		UINT_PTR timer_id = SetTimer(nullptr, nullptr, timeout, nullptr);
-		BOOL res = GetMessage(&message);
-		KillTimer(nullptr, timer_id);
+		UINT_PTR timer_id = SetTimer(NULL, NULL, timeout, NULL);
+		BOOL res = GetMessage(&message, NULL, 0, 0);
+		KillTimer(NULL, timer_id);
 		if(message.message != WM_TIMER || message.hwnd != nullptr || message.wParam != timer_id)
 			return res;
 	}
@@ -218,7 +218,7 @@ bool Backend::ProcessEvents(Rml::Context* context, KeyDownCallback key_down_call
 
 	MSG message;
 	// Process events.
-	bool has_message = NextEvent(message, power_save ? Rml::Math::Min(context->GetNextUpdateDelay(), 10.0)*1000 : 0);
+	bool has_message = NextEvent(message, power_save ? static_cast<int>(Rml::Math::Min(context->GetNextUpdateDelay(), 10.0))*1000 : 0);
 	while (has_message || !data->render_interface.IsSwapchainValid())
 	{
 		if(has_message)

--- a/Backends/RmlUi_Renderer_VK.h
+++ b/Backends/RmlUi_Renderer_VK.h
@@ -114,7 +114,7 @@ public:
 
 	using CreateSurfaceCallback = bool (*)(VkInstance instance, VkSurfaceKHR* out_surface);
 
-	bool Initialize(CreateSurfaceCallback create_surface_callback);
+	bool Initialize(Rml::Vector<const char*> required_extensions, CreateSurfaceCallback create_surface_callback);
 	void Shutdown();
 
 	void BeginFrame();
@@ -485,7 +485,7 @@ private:
 private:
 	bool CreateTexture(Rml::TextureHandle& texture_handle, const Rml::byte* source, const Rml::Vector2i& dimensions, const Rml::String& name);
 
-	void Initialize_Instance() noexcept;
+	void Initialize_Instance(Rml::Vector<const char*> required_extensions) noexcept;
 	void Initialize_Device() noexcept;
 	void Initialize_PhysicalDevice(VkPhysicalDeviceProperties& out_physical_device_properties) noexcept;
 	void Initialize_Swapchain(VkExtent2D window_extent) noexcept;

--- a/Include/RmlUi/Core/Context.h
+++ b/Include/RmlUi/Core/Context.h
@@ -280,6 +280,20 @@ public:
 	/// @return The current documents base tag name.
 	const String& GetDocumentsBaseTag();
 
+	/// Updates the time until Update should get called again. This can be used by elements
+	/// and the app to implement on demand rendering. The context stores the lowest requested
+	/// timestamp, which can later retrieved using NextUpdateRequested().
+	/// @param[in] delay Maximum time until next update
+	void RequestNextUpdate(double delay);
+
+	/// Get the max delay until update and render should get called again. An application can choose
+	/// to only call update and render once the time has elapsed, but theres no harm in doing so
+	/// more often. The returned value can be infinity, in which case update should be invoked after
+	/// user input was received. A value of 0 means "render as fast as possible", for example if
+	/// an animation is playing.
+	/// @return Time until next update is expected.
+	double NextUpdateRequested() const;
+
 protected:
 	void Release() override;
 
@@ -359,6 +373,10 @@ private:
 	DataModels data_models;
 
 	UniquePtr<DataTypeRegister> default_data_type_register;
+
+	// Time in seconds until Update and Render should be called again. This allows applications to only redraw the ui if needed.
+	// See RequestNextUpdate() and NextUpdateRequested() for details.
+	double next_update_timeout;
 
 	// Internal callback for when an element is detached or removed from the hierarchy.
 	void OnElementDetach(Element* element);

--- a/Include/RmlUi/Core/Context.h
+++ b/Include/RmlUi/Core/Context.h
@@ -281,8 +281,9 @@ public:
 	const String& GetDocumentsBaseTag();
 
 	/// Updates the time until Update should get called again. This can be used by elements
-	/// and the app to implement on demand rendering. The context stores the lowest requested
-	/// timestamp, which can later retrieved using NextUpdateRequested().
+	/// and the app to implement on demand rendering and thus drastically save CPU/GPU and
+	/// reduce power consumption during inactivity. The context stores the lowest requested
+	/// timestamp, which can later retrieved using GetNextUpdateDelay().
 	/// @param[in] delay Maximum time until next update
 	void RequestNextUpdate(double delay);
 
@@ -292,7 +293,7 @@ public:
 	/// user input was received. A value of 0 means "render as fast as possible", for example if
 	/// an animation is playing.
 	/// @return Time until next update is expected.
-	double NextUpdateRequested() const;
+	double GetNextUpdateDelay() const;
 
 protected:
 	void Release() override;

--- a/Include/RmlUi/Core/Element.h
+++ b/Include/RmlUi/Core/Element.h
@@ -177,9 +177,9 @@ public:
 	virtual bool IsPointWithinElement(Vector2f point);
 
 	/// Returns the visibility of the element.
-	/// @param[in] recursive Check parent elements for visibility
+	/// @param[in] include_ancestors Check parent elements for visibility
 	/// @return True if the element is visible, false otherwise.
-	bool IsVisible(bool recursive = false) const;
+	bool IsVisible(bool include_ancestors = false) const;
 	/// Returns the z-index of the element.
 	/// @return The element's z-index.
 	float GetZIndex() const;

--- a/Include/RmlUi/Core/Element.h
+++ b/Include/RmlUi/Core/Element.h
@@ -177,8 +177,9 @@ public:
 	virtual bool IsPointWithinElement(Vector2f point);
 
 	/// Returns the visibility of the element.
+	/// @param[in] recursive Check parent elements for visibility
 	/// @return True if the element is visible, false otherwise.
-	bool IsVisible() const;
+	bool IsVisible(bool recursive = false) const;
 	/// Returns the z-index of the element.
 	/// @return The element's z-index.
 	float GetZIndex() const;

--- a/Include/RmlUi/Lottie/ElementLottie.h
+++ b/Include/RmlUi/Lottie/ElementLottie.h
@@ -50,6 +50,9 @@ public:
 	bool GetIntrinsicDimensions(Vector2f& dimensions, float& ratio) override;
 
 protected:
+	/// Updates the animation.
+	void OnUpdate() override;
+
 	/// Renders the animation.
 	void OnRender() override;
 

--- a/Samples/basic/bitmapfont/src/main.cpp
+++ b/Samples/basic/bitmapfont/src/main.cpp
@@ -106,7 +106,7 @@ int main(int /*argc*/, char** /*argv*/)
 	bool running = true;
 	while (running)
 	{
-		running = Backend::ProcessEvents(context, &Shell::ProcessKeyDownShortcuts);
+		running = Backend::ProcessEvents(context, &Shell::ProcessKeyDownShortcuts, true);
 
 		context->Update();
 

--- a/Samples/basic/demo/src/main.cpp
+++ b/Samples/basic/demo/src/main.cpp
@@ -476,7 +476,7 @@ int main(int /*argc*/, char** /*argv*/)
 	bool running = true;
 	while (running)
 	{
-		running = Backend::ProcessEvents(context, &Shell::ProcessKeyDownShortcuts);
+		running = Backend::ProcessEvents(context, &Shell::ProcessKeyDownShortcuts, true);
 
 		demo_window->Update();
 		context->Update();

--- a/Samples/basic/drag/src/main.cpp
+++ b/Samples/basic/drag/src/main.cpp
@@ -86,7 +86,7 @@ int main(int /*argc*/, char** /*argv*/)
 	bool running = true;
 	while (running)
 	{
-		running = Backend::ProcessEvents(context, &Shell::ProcessKeyDownShortcuts);
+		running = Backend::ProcessEvents(context, &Shell::ProcessKeyDownShortcuts, true);
 
 		context->Update();
 

--- a/Samples/basic/loaddocument/src/main.cpp
+++ b/Samples/basic/loaddocument/src/main.cpp
@@ -83,7 +83,7 @@ int main(int /*argc*/, char** /*argv*/)
 	while (running)
 	{
 		// Handle input and window events.
-		running = Backend::ProcessEvents(context, &Shell::ProcessKeyDownShortcuts);
+		running = Backend::ProcessEvents(context, &Shell::ProcessKeyDownShortcuts, true);
 
 		// This is a good place to update your game or application.
 

--- a/Samples/basic/lottie/src/main.cpp
+++ b/Samples/basic/lottie/src/main.cpp
@@ -82,7 +82,7 @@ int main(int /*argc*/, char** /*argv*/)
 	bool running = true;
 	while (running)
 	{
-		running = Backend::ProcessEvents(context, &Shell::ProcessKeyDownShortcuts);
+		running = Backend::ProcessEvents(context, &Shell::ProcessKeyDownShortcuts, true);
 
 		context->Update();
 

--- a/Samples/basic/svg/src/main.cpp
+++ b/Samples/basic/svg/src/main.cpp
@@ -82,7 +82,7 @@ int main(int /*argc*/, char** /*argv*/)
 	bool running = true;
 	while (running)
 	{
-		running = Backend::ProcessEvents(context, &Shell::ProcessKeyDownShortcuts);
+		running = Backend::ProcessEvents(context, &Shell::ProcessKeyDownShortcuts, true);
 
 		context->Update();
 

--- a/Samples/basic/treeview/src/main.cpp
+++ b/Samples/basic/treeview/src/main.cpp
@@ -89,7 +89,7 @@ int main(int /*argc*/, char** /*argv*/)
 	bool running = true;
 	while (running)
 	{
-		running = Backend::ProcessEvents(context, &Shell::ProcessKeyDownShortcuts);
+		running = Backend::ProcessEvents(context, &Shell::ProcessKeyDownShortcuts, true);
 
 		context->Update();
 

--- a/Samples/tutorial/datagrid/src/main.cpp
+++ b/Samples/tutorial/datagrid/src/main.cpp
@@ -75,7 +75,7 @@ int main(int /*argc*/, char** /*argv*/)
 	bool running = true;
 	while (running)
 	{
-		running = Backend::ProcessEvents(context, &Shell::ProcessKeyDownShortcuts);
+		running = Backend::ProcessEvents(context, &Shell::ProcessKeyDownShortcuts, true);
 
 		context->Update();
 

--- a/Samples/tutorial/datagrid_tree/src/main.cpp
+++ b/Samples/tutorial/datagrid_tree/src/main.cpp
@@ -79,7 +79,7 @@ int main(int /*argc*/, char** /*argv*/)
 	bool running = true;
 	while (running)
 	{
-		running = Backend::ProcessEvents(context, &Shell::ProcessKeyDownShortcuts);
+		running = Backend::ProcessEvents(context, &Shell::ProcessKeyDownShortcuts, true);
 
 		context->Update();
 

--- a/Samples/tutorial/drag/src/main.cpp
+++ b/Samples/tutorial/drag/src/main.cpp
@@ -69,7 +69,7 @@ int main(int /*argc*/, char** /*argv*/)
 	bool running = true;
 	while (running)
 	{
-		running = Backend::ProcessEvents(context, &Shell::ProcessKeyDownShortcuts);
+		running = Backend::ProcessEvents(context, &Shell::ProcessKeyDownShortcuts, true);
 
 		context->Update();
 

--- a/Samples/tutorial/template/src/main.cpp
+++ b/Samples/tutorial/template/src/main.cpp
@@ -62,7 +62,7 @@ int main(int /*argc*/, char** /*argv*/)
 	bool running = true;
 	while (running)
 	{
-		running = Backend::ProcessEvents(context, &Shell::ProcessKeyDownShortcuts);
+		running = Backend::ProcessEvents(context, &Shell::ProcessKeyDownShortcuts, true);
 
 		context->Update();
 

--- a/Source/Core/Context.cpp
+++ b/Source/Core/Context.cpp
@@ -41,6 +41,7 @@
 #include "DataModel.h"
 #include "EventDispatcher.h"
 #include "PluginRegistry.h"
+#include "RmlUi/Core/Debug.h"
 #include "ScrollController.h"
 #include "StreamFile.h"
 #include <algorithm>
@@ -54,7 +55,7 @@ static constexpr float DOUBLE_CLICK_TIME = 0.5f;    // [s]
 static constexpr float DOUBLE_CLICK_MAX_DIST = 3.f; // [dp]
 static constexpr float UNIT_SCROLL_LENGTH = 80.f;   // [dp]
 
-Context::Context(const String& name) : name(name), dimensions(0, 0), density_independent_pixel_ratio(1.0f), mouse_position(0, 0), clip_origin(-1, -1), clip_dimensions(-1, -1)
+Context::Context(const String& name) : name(name), dimensions(0, 0), density_independent_pixel_ratio(1.0f), mouse_position(0, 0), clip_origin(-1, -1), clip_dimensions(-1, -1), next_update_timeout(0)
 {
 	instancer = nullptr;
 
@@ -1469,10 +1470,11 @@ const String& Context::GetDocumentsBaseTag()
 }
 
 void Context::RequestNextUpdate(double delay) {
-	next_update_timeout = std::min(next_update_timeout, delay);
+	RMLUI_ASSERT(delay >= 0.0);
+	next_update_timeout = Math::Min(next_update_timeout, delay);
 }
 
-double Context::NextUpdateRequested() const {
+double Context::GetNextUpdateDelay() const {
 	return next_update_timeout;
 }
 

--- a/Source/Core/Element.cpp
+++ b/Source/Core/Element.cpp
@@ -187,8 +187,8 @@ void Element::Update(float dp_ratio, Vector2f vp_dimensions)
 		children[i]->Update(dp_ratio, vp_dimensions);
 
 	if(!animations.empty() && IsVisible(true)) {
-		Context* ctx = GetContext();
-		if(ctx) ctx->RequestNextUpdate(0);
+		if(Context* ctx = GetContext())
+			ctx->RequestNextUpdate(0);
 	}
 }
 
@@ -565,9 +565,9 @@ bool Element::IsPointWithinElement(const Vector2f point)
 }
 
 // Returns the visibility of the element.
-bool Element::IsVisible(bool recursive) const
+bool Element::IsVisible(bool include_ancestors) const
 {
-	if (!recursive)
+	if (!include_ancestors)
 		return visible;
 	const Element* element = this;
 	while (element)

--- a/Source/Core/Element.cpp
+++ b/Source/Core/Element.cpp
@@ -186,7 +186,7 @@ void Element::Update(float dp_ratio, Vector2f vp_dimensions)
 	for (size_t i = 0; i < children.size(); i++)
 		children[i]->Update(dp_ratio, vp_dimensions);
 
-	if(!animations.empty() && IsVisible()) {
+	if(!animations.empty() && IsVisible(true)) {
 		Context* ctx = GetContext();
 		if(ctx) ctx->RequestNextUpdate(0);
 	}
@@ -565,9 +565,18 @@ bool Element::IsPointWithinElement(const Vector2f point)
 }
 
 // Returns the visibility of the element.
-bool Element::IsVisible() const
+bool Element::IsVisible(bool recursive) const
 {
-	return visible;
+	if (!recursive)
+		return visible;
+	const Element* element = this;
+	while (element)
+	{
+		if (!element->visible)
+			return false;
+		element = element->parent;
+	}
+	return true;
 }
 
 // Returns the z-index of the element.

--- a/Source/Core/Element.cpp
+++ b/Source/Core/Element.cpp
@@ -185,6 +185,11 @@ void Element::Update(float dp_ratio, Vector2f vp_dimensions)
 
 	for (size_t i = 0; i < children.size(); i++)
 		children[i]->Update(dp_ratio, vp_dimensions);
+
+	if(!animations.empty() && IsVisible()) {
+		Context* ctx = GetContext();
+		if(ctx) ctx->RequestNextUpdate(0);
+	}
 }
 
 void Element::UpdateProperties(const float dp_ratio, const Vector2f vp_dimensions)

--- a/Source/Core/Elements/WidgetSlider.cpp
+++ b/Source/Core/Elements/WidgetSlider.cpp
@@ -34,6 +34,7 @@
 #include "../../../Include/RmlUi/Core/Input.h"
 #include "../../../Include/RmlUi/Core/Profiling.h"
 #include "../Clock.h"
+#include "../../../Include/RmlUi/Core/Context.h"
 
 namespace Rml {
 
@@ -159,6 +160,9 @@ void WidgetSlider::Update()
 				arrow_timers[i] += DEFAULT_REPEAT_PERIOD;
 				SetBarPosition(i == 0 ? OnLineDecrement() : OnLineIncrement());
 			}
+
+			Context* ctx = parent->GetContext();
+			if(ctx) ctx->RequestNextUpdate(arrow_timers[i]);
 		}
 	}
 }

--- a/Source/Core/Elements/WidgetSlider.cpp
+++ b/Source/Core/Elements/WidgetSlider.cpp
@@ -161,8 +161,8 @@ void WidgetSlider::Update()
 				SetBarPosition(i == 0 ? OnLineDecrement() : OnLineIncrement());
 			}
 
-			Context* ctx = parent->GetContext();
-			if(ctx) ctx->RequestNextUpdate(arrow_timers[i]);
+			if(Context* ctx = parent->GetContext())
+				ctx->RequestNextUpdate(arrow_timers[i]);
 		}
 	}
 }

--- a/Source/Core/Elements/WidgetTextInput.cpp
+++ b/Source/Core/Elements/WidgetTextInput.cpp
@@ -321,7 +321,7 @@ void WidgetTextInput::OnUpdate()
 			cursor_visible = !cursor_visible;
 		}
 
-		if(parent->IsVisible()) {
+		if(parent->IsVisible(true)) {
 			Context* ctx = parent->GetContext();
 			if(ctx) ctx->RequestNextUpdate(cursor_timer);
 		}

--- a/Source/Core/Elements/WidgetTextInput.cpp
+++ b/Source/Core/Elements/WidgetTextInput.cpp
@@ -322,8 +322,8 @@ void WidgetTextInput::OnUpdate()
 		}
 
 		if(parent->IsVisible(true)) {
-			Context* ctx = parent->GetContext();
-			if(ctx) ctx->RequestNextUpdate(cursor_timer);
+			if(Context* ctx = parent->GetContext())
+				ctx->RequestNextUpdate(cursor_timer);
 		}
 	}
 }

--- a/Source/Core/Elements/WidgetTextInput.cpp
+++ b/Source/Core/Elements/WidgetTextInput.cpp
@@ -39,6 +39,7 @@
 #include "../../../Include/RmlUi/Core/Math.h"
 #include "../../../Include/RmlUi/Core/StringUtilities.h"
 #include "../../../Include/RmlUi/Core/SystemInterface.h"
+#include "../../../Include/RmlUi/Core/Context.h"
 #include "../Clock.h"
 #include "ElementTextSelection.h"
 #include <algorithm>
@@ -318,6 +319,11 @@ void WidgetTextInput::OnUpdate()
 		{
 			cursor_timer += CURSOR_BLINK_TIME;
 			cursor_visible = !cursor_visible;
+		}
+
+		if(parent->IsVisible()) {
+			Context* ctx = parent->GetContext();
+			if(ctx) ctx->RequestNextUpdate(cursor_timer);
 		}
 	}
 }

--- a/Source/Core/ScrollController.cpp
+++ b/Source/Core/ScrollController.cpp
@@ -122,12 +122,14 @@ void ScrollController::ActivateSmoothscroll(Element* in_target, Vector2f delta_d
 		Reset();
 }
 
-void ScrollController::Update(Vector2i mouse_position, float dp_ratio)
+bool ScrollController::Update(Vector2i mouse_position, float dp_ratio)
 {
 	if (mode == Mode::Autoscroll)
 		UpdateAutoscroll(mouse_position, dp_ratio);
 	else if (mode == Mode::Smoothscroll)
 		UpdateSmoothscroll(dp_ratio);
+	
+	return mode != Mode::None;
 }
 
 void ScrollController::UpdateAutoscroll(Vector2i mouse_position, float dp_ratio)

--- a/Source/Core/ScrollController.h
+++ b/Source/Core/ScrollController.h
@@ -53,7 +53,7 @@ public:
 
 	void ActivateSmoothscroll(Element* target, Vector2f delta_distance, ScrollBehavior scroll_behavior);
 
-	void Update(Vector2i mouse_position, float dp_ratio);
+	bool Update(Vector2i mouse_position, float dp_ratio);
 
 	void IncrementSmoothscrollTarget(Vector2f delta_distance);
 

--- a/Source/Core/WidgetScroll.cpp
+++ b/Source/Core/WidgetScroll.cpp
@@ -171,8 +171,8 @@ void WidgetScroll::Update()
 					ScrollLineDown();
 			}
 
-			Context* ctx = parent->GetContext();
-			if(ctx) ctx->RequestNextUpdate(arrow_timers[i]);
+			if(Context* ctx = parent->GetContext())
+				ctx->RequestNextUpdate(arrow_timers[i]);
 		}
 	}
 }

--- a/Source/Core/WidgetScroll.cpp
+++ b/Source/Core/WidgetScroll.cpp
@@ -33,6 +33,7 @@
 #include "../../Include/RmlUi/Core/Event.h"
 #include "../../Include/RmlUi/Core/Factory.h"
 #include "../../Include/RmlUi/Core/Property.h"
+#include "../../Include/RmlUi/Core/Context.h"
 #include "Clock.h"
 #include "LayoutDetails.h"
 
@@ -169,6 +170,9 @@ void WidgetScroll::Update()
 				else
 					ScrollLineDown();
 			}
+
+			Context* ctx = parent->GetContext();
+			if(ctx) ctx->RequestNextUpdate(arrow_timers[i]);
 		}
 	}
 }

--- a/Source/Lottie/ElementLottie.cpp
+++ b/Source/Lottie/ElementLottie.cpp
@@ -63,6 +63,9 @@ bool ElementLottie::GetIntrinsicDimensions(Vector2f& dimensions, float& ratio)
 
 void ElementLottie::OnUpdate()
 {
+	if (animation_dirty)
+		LoadAnimation();
+
 	if (!animation)
 		return;
 
@@ -72,11 +75,10 @@ void ElementLottie::OnUpdate()
 		time_animation_start = t;
 
 	double _unused;
-	const auto frameDuration = 1.0 / animation->frameRate();
-	const auto delay = std::modf((t - time_animation_start) / frameDuration, &_unused) * frameDuration;
+	const double frame_duration = 1.0 / animation->frameRate();
+	const double delay = std::modf((t - time_animation_start) / frame_duration, &_unused) * frame_duration;
 	if(IsVisible(true)) {
-		Context* ctx = GetContext();
-		if (ctx)
+		if (Context* ctx = GetContext())
 			ctx->RequestNextUpdate(delay);
 	}
 }

--- a/Source/Lottie/ElementLottie.cpp
+++ b/Source/Lottie/ElementLottie.cpp
@@ -74,9 +74,11 @@ void ElementLottie::OnUpdate()
 	double _unused;
 	const auto frameDuration = 1.0 / animation->frameRate();
 	const auto delay = std::modf((t - time_animation_start) / frameDuration, &_unused) * frameDuration;
-	Context* ctx = GetContext();
-	if (ctx)
-		ctx->RequestNextUpdate(delay);
+	if(IsVisible(true)) {
+		Context* ctx = GetContext();
+		if (ctx)
+			ctx->RequestNextUpdate(delay);
+	}
 }
 
 void ElementLottie::OnRender()

--- a/Source/Lottie/ElementLottie.cpp
+++ b/Source/Lottie/ElementLottie.cpp
@@ -29,6 +29,7 @@
 #include "../../Include/RmlUi/Lottie/ElementLottie.h"
 #include "../../Include/RmlUi/Core/ComputedValues.h"
 #include "../../Include/RmlUi/Core/Core.h"
+#include "../../Include/RmlUi/Core/Context.h"
 #include "../../Include/RmlUi/Core/ElementDocument.h"
 #include "../../Include/RmlUi/Core/FileInterface.h"
 #include "../../Include/RmlUi/Core/GeometryUtilities.h"
@@ -58,6 +59,24 @@ bool ElementLottie::GetIntrinsicDimensions(Vector2f& dimensions, float& ratio)
 		ratio = dimensions.x / dimensions.y;
 
 	return true;
+}
+
+void ElementLottie::OnUpdate()
+{
+	if (!animation)
+		return;
+
+	const auto t = GetSystemInterface()->GetElapsedTime();
+
+	if (time_animation_start < 0.0)
+		time_animation_start = t;
+
+	double _unused;
+	const auto frameDuration = 1.0 / animation->frameRate();
+	const auto delay = std::modf((t - time_animation_start) / frameDuration, &_unused) * frameDuration;
+	Context* ctx = GetContext();
+	if (ctx)
+		ctx->RequestNextUpdate(delay);
 }
 
 void ElementLottie::OnRender()
@@ -182,9 +201,6 @@ void ElementLottie::UpdateTexture()
 		return;
 
 	const double t = GetSystemInterface()->GetElapsedTime();
-
-	if (time_animation_start < 0.0)
-		time_animation_start = t;
 
 	// Find the next animation frame to display.
 	// Here it is possible to add more logic to control playback speed, pause/resume, and more.


### PR DESCRIPTION
In todays edition of "Lets build a desktop app with RmlUi" we get on demand rendering.

Unlike a game, which tends to always have motion on screen, a desktop/gui app typically is fairly static. The idea here is to reduce the rate of updates and render commands when there are no changes to the onscreen content. This idea came up before in #417 and #331 and was briefly mentioned in [430](https://github.com/mikke89/RmlUi/pull/430#issuecomment-1484164523).

At its core are two functions for setting and getting a value that is updated by elements in the update phase. It is initialized to infinity before each cycle and can only be reduced but never increased. If an element needs updates (for example because an animation is playing) it can calculate the delay until the next visible change and store this value.

After the update was run the platform can now stop rendering for the calculated maximum duration and use a blocking call to wait for input events. The only way for the onscreen content to change at this point is by input events or the app doing changes, both of which will trigger an event and cause a rerender. This drastically reduces the cpu and gpu usage of an idle application.
This is a fairly unintrusive change, unless the app opts into using the calculated value, nothing changes. It can just render at full FPS and everything will behave correctly. You can also use the calculated value but apply a minimum/maximum to limit the frame rate within bounds.

Consider this an initial draft, while it works really well for the demo applications and I tried to find every case where regular refreshes are necessary (e.g. the blinking text cursor) I am not familiar enough with RmlUi to judge if I found all of them. I also didn't look into how it interacts with scripting at all.

I also only implemented support for it in the glfw_vk backend and I am unsure if it should stay there (or be a compile time decision for the samples).

There are some things I'd like to change though:
- The `RequestNextUpdate` and `NextUpdateRequested` functions should probably be in the header to make sure they get inlined as often as possible.
- Because its only a time delta `float` will probably do as well, though I am unsure if it make a difference performance wise and since all other timestamps use double I went with double here as well.
- I couldn't find a way to detect if an element is visible of hidden behind something else/outside the viewport. This is an issue because as soon as you have a infinite animation anywhere in the document the whole approach kinda falls apart. This is also the reason why you wont see an difference in the demo app unless you comment out the rotating cube. Ideally a `IsInViewport` function or something could be used to skip animations on non visible elements. I did use `IsVisible`, but that only checks if the element has the visibility set to visible, not if its actually visible to the user. This might be difficult to do especially with alpha though. (EDIT: I now check IsVisible recursively which is not perfect but at least better)

Let me know what you think about it.