### PR TITLE
Add up and down casting to databinding structs

### DIFF
--- a/Include/RmlUi/Core/DataVariable.h
+++ b/Include/RmlUi/Core/DataVariable.h
@@ -214,6 +214,18 @@ protected:
 	void* DereferencePointer(void* ptr) override { return PointerTraits<T>::Dereference(ptr); }
 };
 
+template <typename SourceType, typename TargetType>
+class DynamicPointerDefinition final : public BasePointerDefinition {
+public:
+	DynamicPointerDefinition(VariableDefinition* underlying_definition) : BasePointerDefinition(underlying_definition) {}
+
+protected:
+	void* DereferencePointer(void* ptr) override
+	{
+		return dynamic_cast<TargetType*>(static_cast<SourceType*>(PointerTraits<TargetType>::Dereference(ptr)));
+	}
+};
+
 template <typename Object, typename MemberType>
 class MemberObjectDefinition final : public BasePointerDefinition {
 public:


### PR DESCRIPTION
Having a list of base class elements is pretty common with elements of derived types in it. Thus i added this casting method that creates special `As<Class>` members to perform a cast.

This way was the least invasive way of adding this functionality