### PR TITLE
Add support for text-align for text inputs

### DIFF
--- a/Source/Core/Elements/WidgetTextInput.cpp
+++ b/Source/Core/Elements/WidgetTextInput.cpp
@@ -917,8 +917,8 @@ float WidgetTextInput::GetAlignmentSpecificTextOffset(const char* p_begin, int l
 	// offset position depending on text align
 	switch (text_align)
 	{
-	case Style::TextAlign::Right: return std::max(0.0f, (client_width - total_width));
-	case Style::TextAlign::Center: return std::max(0.0f, ((client_width - total_width) / 2));
+	case Style::TextAlign::Right: return Math::Max(0.0f, (client_width - total_width));
+	case Style::TextAlign::Center: return Math::Max(0.0f, ((client_width - total_width) / 2));
 	default: break;
 	}
 

--- a/Source/Core/Elements/WidgetTextInput.cpp
+++ b/Source/Core/Elements/WidgetTextInput.cpp
@@ -1132,17 +1132,19 @@ Vector2f WidgetTextInput::FormatText(float height_constraint)
 					orphan += ' ';
 			}
 		}
-		else if (last_line && text_align == Style::TextAlign::Right && lines.size() > 0)
-		{
-			// append single orphan to last line to properly align it with other lines when right aligned
-			orphan = ' ';
-		}
 
 		if (!orphan.empty())
 		{
 			line_content += orphan;
 			line.size += (int)orphan.size();
 			line_width += ElementUtilities::GetStringWidth(text_element, orphan);
+		}
+
+		// visually remove trailing space if right aligned
+		if (!last_line && text_align == Style::TextAlign::Right && !line_content.empty() && line_content.back() == ' ')
+		{
+			line_content.pop_back();
+			line_width -= ElementUtilities::GetStringWidth(text_element, " ");
 		}
 
 		// Now that we have the string of characters appearing on the new line, we split it into

--- a/Source/Core/Elements/WidgetTextInput.h
+++ b/Source/Core/Elements/WidgetTextInput.h
@@ -95,6 +95,8 @@ public:
 protected:
 	enum class CursorMovement { Begin = -4, BeginLine = -3, PreviousWord = -2, Left = -1, Right = 1, NextWord = 2, EndLine = 3, End = 4 };
 
+	float GetAlignmentSpecificTextOffset(const char* p_begin, int line_index) const;
+
 	/// Processes the "keydown" and "textinput" event to write to the input field, and the "focus" and
 	/// "blur" to set the state of the cursor.
 	void ProcessEvent(Event& event) override;

--- a/Tests/Data/VisualTests/text_alignment.rml
+++ b/Tests/Data/VisualTests/text_alignment.rml
@@ -36,5 +36,11 @@ line-break</textarea>
 		<br />
 		<textarea style="text-align:right" rows="3">right aligned overflow overflow overflow overflow
 line-break</textarea>
+		<br />
+		<textarea style="text-align:left;white-space: nowrap;" rows="3">left aligned nowrap nowrap nowrap nowrap nowrap</textarea>
+		<br />
+		<textarea style="text-align:center;white-space: nowrap;" rows="3">center aligned nowrap nowrap nowrap nowrap nowrap</textarea>
+		<br />
+		<textarea style="text-align:right;white-space: nowrap;" rows="3">right aligned nowrap nowrap nowrap nowrap nowrap</textarea>
 	</body>
 </rml>

--- a/Tests/Data/VisualTests/text_alignment.rml
+++ b/Tests/Data/VisualTests/text_alignment.rml
@@ -37,10 +37,10 @@ line-break</textarea>
 		<textarea style="text-align:right" rows="3">right aligned overflow overflow overflow overflow
 line-break</textarea>
 		<br />
-		<textarea style="text-align:left;white-space: nowrap;" rows="3">left aligned nowrap nowrap nowrap nowrap nowrap</textarea>
+		<textarea style="text-align:left" rows="3" wrap="nowrap">left aligned nowrap nowrap nowrap nowrap nowrap</textarea>
 		<br />
-		<textarea style="text-align:center;white-space: nowrap;" rows="3">center aligned nowrap nowrap nowrap nowrap nowrap</textarea>
+		<textarea style="text-align:center" rows="3" wrap="nowrap">center aligned nowrap nowrap nowrap nowrap nowrap</textarea>
 		<br />
-		<textarea style="text-align:right;white-space: nowrap;" rows="3">right aligned nowrap nowrap nowrap nowrap nowrap</textarea>
+		<textarea style="text-align:right" rows="3" wrap="nowrap">right aligned nowrap nowrap nowrap nowrap nowrap</textarea>
 	</body>
 </rml>

--- a/Tests/Data/VisualTests/text_alignment.rml
+++ b/Tests/Data/VisualTests/text_alignment.rml
@@ -32,9 +32,9 @@
 line-break</textarea>
 		<br />
 		<textarea style="text-align:center" rows="3">center aligned overflow overflow overflow overflow
-textarea</textarea>
+line-break</textarea>
 		<br />
 		<textarea style="text-align:right" rows="3">right aligned overflow overflow overflow overflow
-aligned</textarea>
+line-break</textarea>
 	</body>
 </rml>

--- a/Tests/Data/VisualTests/text_alignment.rml
+++ b/Tests/Data/VisualTests/text_alignment.rml
@@ -1,0 +1,40 @@
+<rml>
+
+	<head>
+		<title>Text-alignment property</title>
+		<link type="text/rcss" href="../style.rcss" />
+		<meta name="Description" content="Text-alignment property for inputs." />
+		<style>
+			body {
+				background: #ddd;
+				color: #444;
+			}
+
+			textarea {
+				background-color: #bbb;
+			}
+
+			h1 {
+				margin-top: 0.3em;
+				font-size: 1.1em;
+			}
+		</style>
+	</head>
+
+	<body>
+		<input style="text-align:left" value="left aligned" />
+		<br />
+		<input style="text-align:center" value="center aligned" />
+		<br />
+		<input style="text-align:right" value="right aligned" />
+		<br />
+		<textarea style="text-align:left" rows="3">left aligned overflow overflow overflow overflow
+line-break</textarea>
+		<br />
+		<textarea style="text-align:center" rows="3">center aligned overflow overflow overflow overflow
+textarea</textarea>
+		<br />
+		<textarea style="text-align:right" rows="3">right aligned overflow overflow overflow overflow
+aligned</textarea>
+	</body>
+</rml>


### PR DESCRIPTION
Fixes #454. Basically collect all line segments with their positions and lengths in left-aligned mode, then adjust positions according to max width and text alignment mode