### PR TITLE
Fix clipboard being pasted when Ctrl + Alt + V key combination is used

### DIFF
--- a/Source/Core/Elements/WidgetTextInput.cpp
+++ b/Source/Core/Elements/WidgetTextInput.cpp
@@ -400,6 +400,7 @@ void WidgetTextInput::ProcessEvent(Event& event)
 		bool numlock = event.GetParameter<int>("num_lock_key", 0) > 0;
 		bool shift = event.GetParameter<int>("shift_key", 0) > 0;
 		bool ctrl = event.GetParameter<int>("ctrl_key", 0) > 0;
+		bool alt = event.GetParameter<int>("alt_key", 0) > 0;
 		bool selection_changed = false;
 
 		switch (key_identifier)
@@ -482,7 +483,7 @@ void WidgetTextInput::ProcessEvent(Event& event)
 
 		case Input::KI_V:
 		{
-			if (ctrl)
+			if (ctrl && !alt)
 			{
 				String clipboard_text;
 				GetSystemInterface()->GetClipboardText(clipboard_text);


### PR DESCRIPTION
Fixes #464. This behavior matches other (system) programs as, if you try to use this key combination with any keyboard layout, no text will get appended to the input.