### PR TITLE
Lua plugin: Add StopImmediatePropagation to Rml::Event

### DIFF
--- a/Source/Lua/Event.cpp
+++ b/Source/Lua/Event.cpp
@@ -41,10 +41,16 @@ void ExtraInit<Event>(lua_State* /*L*/, int /*metatable_index*/)
 	return;
 }
 
-// method
+// methods
 int EventStopPropagation(lua_State* /*L*/, Event* obj)
 {
 	obj->StopPropagation();
+	return 0;
+}
+
+int EventStopImmediatePropagation(lua_State* /*L*/, Event* obj)
+{
+	obj->StopImmediatePropagation();
 	return 0;
 }
 
@@ -88,6 +94,7 @@ int EventGetAttrparameters(lua_State* L)
 
 RegType<Event> EventMethods[] = {
 	RMLUI_LUAMETHOD(Event, StopPropagation),
+	RMLUI_LUAMETHOD(Event, StopImmediatePropagation),
 	{nullptr, nullptr},
 };
 

--- a/Source/Lua/Event.h
+++ b/Source/Lua/Event.h
@@ -36,8 +36,9 @@ namespace Rml {
 namespace Lua {
 template <>
 void ExtraInit<Event>(lua_State* L, int metatable_index);
-// method
+// methods
 int EventStopPropagation(lua_State* L, Event* obj);
+int EventStopImmediatePropagation(lua_State* L, Event* obj);
 
 // getters
 int EventGetAttrcurrent_element(lua_State* L);


### PR DESCRIPTION
`StopPropagation` is not always sufficient, especially when it comes to elements that are implemented via widgets.

In my specific case, when working with key events of a text area element in Lua, it is useful to block the default behavior of arrow keys. So when the user navigates additional context menus, the cursor does not jump forth and back all the time.

Once this is merged, I will create a pull request for https://github.com/mikke89/RmlUiDoc to add this to the API reference documentation.