### PR TITLE
Make pixels_per_inch settable

### DIFF
--- a/Include/RmlUi/Core/Context.h
+++ b/Include/RmlUi/Core/Context.h
@@ -81,6 +81,13 @@ public:
 	/// @return The current density-independent pixel ratio of the context.
 	float GetDensityIndependentPixelRatio() const;
 
+	/// Changes the pixels per inch value used for ppi-based property units
+	/// @param[in] pixels_per_inch The new pixels per inch value of the context.
+	void SetPixelsPerInch(float pixels_per_inch);
+	/// Returns the pixels per inch value of the context.
+	/// @return The current pixels per inch of the context.
+	float GetPixelsPerInch() const;
+
 	/// Updates all elements in the context's documents.
 	/// This must be called before Context::Render, but after any elements have been changed, added or removed.
 	bool Update();
@@ -306,6 +313,7 @@ private:
 	String name;
 	Vector2i dimensions;
 	float density_independent_pixel_ratio;
+	float pixels_per_inch;
 	String documents_base_tag = "body";
 
 	SmallUnorderedSet<String> active_themes;

--- a/Include/RmlUi/Core/Element.h
+++ b/Include/RmlUi/Core/Element.h
@@ -596,11 +596,11 @@ public:
 	const ComputedValues& GetComputedValues() const;
 
 protected:
-	void Update(float dp_ratio, Vector2f vp_dimensions);
+	void Update(float pixels_per_inch, float dp_ratio, Vector2f vp_dimensions);
 	void Render();
 
 	/// Updates definition, computed values, and runs OnPropertyChange on this element.
-	void UpdateProperties(float dp_ratio, Vector2f vp_dimensions);
+	void UpdateProperties(float pixels_per_inch, float dp_ratio, Vector2f vp_dimensions);
 
 	/// Forces the element to generate a local stacking context, regardless of the value of its z-index property.
 	void ForceLocalStackingContext();

--- a/Source/Core/ComputeProperty.h
+++ b/Source/Core/ComputeProperty.h
@@ -37,33 +37,36 @@ namespace Rml {
 class Property;
 
 // Note that numbers and percentages are not lengths, they have to be resolved elsewhere.
-float ComputeLength(NumericValue value, float font_size, float document_font_size, float dp_ratio, Vector2f vp_dimensions);
+float ComputeLength(NumericValue value, float font_size, float document_font_size, float pixels_per_inch, float dp_ratio, Vector2f vp_dimensions);
 
-float ComputeAbsoluteLength(NumericValue value);
+float ComputeAbsoluteLength(NumericValue value, float pixels_per_inch);
 
 float ComputeAngle(NumericValue value);
 
-float ComputeFontsize(NumericValue value, const Style::ComputedValues& values, const Style::ComputedValues* parent_values,
-	const Style::ComputedValues* document_values, float dp_ratio, Vector2f vp_dimensions);
+float ComputeFontSize(NumericValue value, const Style::ComputedValues& values, const Style::ComputedValues* parent_values,
+	const Style::ComputedValues* document_values, float pixels_per_inch, float dp_ratio, Vector2f vp_dimensions);
 
 String ComputeFontFamily(String font_family);
 
 Style::Clip ComputeClip(const Property* property);
 
-Style::LineHeight ComputeLineHeight(const Property* property, float font_size, float document_font_size, float dp_ratio, Vector2f vp_dimensions);
-
-Style::VerticalAlign ComputeVerticalAlign(const Property* property, float line_height, float font_size, float document_font_size, float dp_ratio,
+Style::LineHeight ComputeLineHeight(const Property* property, float font_size, float document_font_size, float pixels_per_inch, float dp_ratio,
 	Vector2f vp_dimensions);
 
-Style::LengthPercentage ComputeLengthPercentage(const Property* property, float font_size, float document_font_size, float dp_ratio,
+Style::VerticalAlign ComputeVerticalAlign(const Property* property, float line_height, float font_size, float document_font_size,
+	float pixels_per_inch, float dp_ratio, Vector2f vp_dimensions);
+
+Style::LengthPercentage ComputeLengthPercentage(const Property* property, float font_size, float document_font_size, float pixels_per_inch,
+	float dp_ratio, Vector2f vp_dimensions);
+
+Style::LengthPercentageAuto ComputeLengthPercentageAuto(const Property* property, float font_size, float document_font_size, float pixels_per_inch,
+	float dp_ratio, Vector2f vp_dimensions);
+
+Style::LengthPercentage ComputeOrigin(const Property* property, float font_size, float document_font_size, float pixels_per_inch, float dp_ratio,
 	Vector2f vp_dimensions);
 
-Style::LengthPercentageAuto ComputeLengthPercentageAuto(const Property* property, float font_size, float document_font_size, float dp_ratio,
+Style::LengthPercentage ComputeMaxSize(const Property* property, float font_size, float document_font_size, float pixels_per_inch, float dp_ratio,
 	Vector2f vp_dimensions);
-
-Style::LengthPercentage ComputeOrigin(const Property* property, float font_size, float document_font_size, float dp_ratio, Vector2f vp_dimensions);
-
-Style::LengthPercentage ComputeMaxSize(const Property* property, float font_size, float document_font_size, float dp_ratio, Vector2f vp_dimensions);
 
 uint16_t ComputeBorderWidth(float computed_length);
 

--- a/Source/Core/Context.cpp
+++ b/Source/Core/Context.cpp
@@ -55,8 +55,8 @@ static constexpr float DOUBLE_CLICK_MAX_DIST = 3.f; // [dp]
 static constexpr float UNIT_SCROLL_LENGTH = 80.f;   // [dp]
 
 Context::Context(const String& name) :
-	name(name), dimensions(0, 0), density_independent_pixel_ratio(1.0f), mouse_position(0, 0), clip_origin(-1, -1), clip_dimensions(-1, -1),
-	next_update_timeout(0)
+	name(name), dimensions(0, 0), density_independent_pixel_ratio(1.0f), pixels_per_inch(0), mouse_position(0, 0), clip_origin(-1, -1),
+	clip_dimensions(-1, -1), next_update_timeout(0)
 {
 	instancer = nullptr;
 
@@ -174,6 +174,29 @@ float Context::GetDensityIndependentPixelRatio() const
 	return density_independent_pixel_ratio;
 }
 
+void Context::SetPixelsPerInch(float ppi)
+{
+	if (pixels_per_inch != ppi)
+	{
+		pixels_per_inch = ppi;
+
+		for (int i = 0; i < root->GetNumChildren(true); ++i)
+		{
+			ElementDocument* document = root->GetChild(i)->GetOwnerDocument();
+			if (document)
+			{
+				document->DirtyMediaQueries();
+				document->OnDpRatioChangeRecursive();
+			}
+		}
+	}
+}
+
+float Context::GetPixelsPerInch() const
+{
+	return pixels_per_inch;
+}
+
 bool Context::Update()
 {
 	RMLUI_ZoneScoped;
@@ -197,7 +220,7 @@ bool Context::Update()
 	root->dirty_definition = false;
 	root->dirty_child_definitions = false;
 
-	root->Update(density_independent_pixel_ratio, Vector2f(dimensions));
+	root->Update(pixels_per_inch, density_independent_pixel_ratio, Vector2f(dimensions));
 
 	for (int i = 0; i < root->GetNumChildren(); ++i)
 	{

--- a/Source/Core/ElementDocument.cpp
+++ b/Source/Core/ElementDocument.cpp
@@ -149,11 +149,12 @@ void ElementDocument::ProcessHeader(const DocumentHeader* document_header)
 	// Hide this document.
 	SetProperty(PropertyId::Visibility, Property(Style::Visibility::Hidden));
 
+	const float pixels_per_inch = (context ? context->GetPixelsPerInch() : 0.0f);
 	const float dp_ratio = (context ? context->GetDensityIndependentPixelRatio() : 1.0f);
 	const Vector2f vp_dimensions = (context ? Vector2f(context->GetDimensions()) : Vector2f(1.0f));
 
 	// Update properties so that e.g. visibility status can be queried properly immediately.
-	UpdateProperties(dp_ratio, vp_dimensions);
+	UpdateProperties(pixels_per_inch, dp_ratio, vp_dimensions);
 }
 
 Context* ElementDocument::GetContext()
@@ -382,9 +383,10 @@ void ElementDocument::LoadExternalScript(const String& /*source_path*/) {}
 
 void ElementDocument::UpdateDocument()
 {
+	const float pixels_per_inch = (context ? context->GetPixelsPerInch() : 0.0f);
 	const float dp_ratio = (context ? context->GetDensityIndependentPixelRatio() : 1.0f);
 	const Vector2f vp_dimensions = (context ? Vector2f(context->GetDimensions()) : Vector2f(1.0f));
-	Update(dp_ratio, vp_dimensions);
+	Update(pixels_per_inch, dp_ratio, vp_dimensions);
 	UpdateLayout();
 	UpdatePosition();
 }

--- a/Source/Core/ElementScroll.cpp
+++ b/Source/Core/ElementScroll.cpp
@@ -244,9 +244,10 @@ void ElementScroll::UpdateScrollElementProperties(Element* scroll_element)
 
 	Context* context = element->GetContext();
 
+	const float pixels_per_inch = (context ? context->GetPixelsPerInch() : 0.0f);
 	const float dp_ratio = (context ? context->GetDensityIndependentPixelRatio() : 1.0f);
 	const Vector2f vp_dimensions = (context ? Vector2f(context->GetDimensions()) : Vector2f(1.0f));
-	scroll_element->Update(dp_ratio, vp_dimensions);
+	scroll_element->Update(pixels_per_inch, dp_ratio, vp_dimensions);
 }
 
 ElementScroll::Scrollbar::Scrollbar() {}

--- a/Source/Core/ElementStyle.h
+++ b/Source/Core/ElementStyle.h
@@ -137,7 +137,8 @@ public:
 	/// Turns the local and inherited properties into computed values for this element. These values can in turn be used during the layout procedure.
 	/// Must be called in correct order, always parent before its children.
 	PropertyIdSet ComputeValues(Style::ComputedValues& values, const Style::ComputedValues* parent_values,
-		const Style::ComputedValues* document_values, bool values_are_default_initialized, float dp_ratio, Vector2f vp_dimensions);
+		const Style::ComputedValues* document_values, bool values_are_default_initialized, float pixels_per_inch, float dp_ratio,
+		Vector2f vp_dimensions);
 
 	/// Returns an iterator for iterating the local properties of this element.
 	/// Note: Modifying the element's style invalidates its iterator.

--- a/Source/Core/StyleSheetContainer.cpp
+++ b/Source/Core/StyleSheetContainer.cpp
@@ -53,6 +53,7 @@ bool StyleSheetContainer::UpdateCompiledStyleSheet(const Context* context)
 {
 	RMLUI_ZoneScoped;
 
+	const float pixels_per_inch = context->GetPixelsPerInch();
 	const float dp_ratio = context->GetDensityIndependentPixelRatio();
 	const Vector2i vp_dimensions_i(context->GetDimensions());
 	const Vector2f vp_dimensions(vp_dimensions_i);
@@ -73,27 +74,33 @@ bool StyleSheetContainer::UpdateCompiledStyleSheet(const Context* context)
 			switch (id)
 			{
 			case MediaQueryId::Width:
-				if (vp_dimensions.x != ComputeLength(property.second.GetNumericValue(), font_size, font_size, dp_ratio, vp_dimensions))
+				if (vp_dimensions.x !=
+					ComputeLength(property.second.GetNumericValue(), font_size, font_size, pixels_per_inch, dp_ratio, vp_dimensions))
 					all_match = false;
 				break;
 			case MediaQueryId::MinWidth:
-				if (vp_dimensions.x < ComputeLength(property.second.GetNumericValue(), font_size, font_size, dp_ratio, vp_dimensions))
+				if (vp_dimensions.x <
+					ComputeLength(property.second.GetNumericValue(), font_size, font_size, pixels_per_inch, dp_ratio, vp_dimensions))
 					all_match = false;
 				break;
 			case MediaQueryId::MaxWidth:
-				if (vp_dimensions.x > ComputeLength(property.second.GetNumericValue(), font_size, font_size, dp_ratio, vp_dimensions))
+				if (vp_dimensions.x >
+					ComputeLength(property.second.GetNumericValue(), font_size, font_size, pixels_per_inch, dp_ratio, vp_dimensions))
 					all_match = false;
 				break;
 			case MediaQueryId::Height:
-				if (vp_dimensions.y != ComputeLength(property.second.GetNumericValue(), font_size, font_size, dp_ratio, vp_dimensions))
+				if (vp_dimensions.y !=
+					ComputeLength(property.second.GetNumericValue(), font_size, font_size, pixels_per_inch, dp_ratio, vp_dimensions))
 					all_match = false;
 				break;
 			case MediaQueryId::MinHeight:
-				if (vp_dimensions.y < ComputeLength(property.second.GetNumericValue(), font_size, font_size, dp_ratio, vp_dimensions))
+				if (vp_dimensions.y <
+					ComputeLength(property.second.GetNumericValue(), font_size, font_size, pixels_per_inch, dp_ratio, vp_dimensions))
 					all_match = false;
 				break;
 			case MediaQueryId::MaxHeight:
-				if (vp_dimensions.y > ComputeLength(property.second.GetNumericValue(), font_size, font_size, dp_ratio, vp_dimensions))
+				if (vp_dimensions.y >
+					ComputeLength(property.second.GetNumericValue(), font_size, font_size, pixels_per_inch, dp_ratio, vp_dimensions))
 					all_match = false;
 				break;
 			case MediaQueryId::AspectRatio:


### PR DESCRIPTION
For better handling of high dpi screens and properly reflecting computations with units involving PPI, this value needs to be settable by the context.