### PR TITLE
Lua plugin: Return inserted element from AppendChild and InsertBefore

### DIFF
--- a/Source/Lua/Element.cpp
+++ b/Source/Lua/Element.cpp
@@ -101,11 +101,17 @@ int ElementAppendChild(lua_State* L, Element* obj)
 {
 	ElementPtr* element = LuaType<ElementPtr>::check(L, 1);
 	if (*element)
-		obj->AppendChild(std::move(*element));
+	{
+		Element* child = obj->AppendChild(std::move(*element));
+		LuaType<Element>::push(L, child, false);
+	}
 	else
+	{
 		Log::Message(Log::LT_WARNING, "Could not append child to element '%s', as the child was null. Was it already moved from?",
 			obj->GetAddress().c_str());
-	return 0;
+		lua_pushnil(L);
+	}
+	return 1;
 }
 
 int ElementBlur(lua_State* /*L*/, Element* obj)
@@ -223,11 +229,17 @@ int ElementInsertBefore(lua_State* L, Element* obj)
 	ElementPtr* element = LuaType<ElementPtr>::check(L, 1);
 	Element* adjacent = LuaType<Element>::check(L, 2);
 	if (*element)
-		obj->InsertBefore(std::move(*element), adjacent);
+	{
+		Element* inserted = obj->InsertBefore(std::move(*element), adjacent);
+		LuaType<Element>::push(L, inserted, false);
+	}
 	else
+	{
 		Log::Message(Log::LT_WARNING, "Could not insert child to element '%s', as the child was null. Was it already moved from?",
 			obj->GetAddress().c_str());
-	return 0;
+		lua_pushnil(L);
+	}
+	return 1;
 }
 
 int ElementIsClassSet(lua_State* L, Element* obj)


### PR DESCRIPTION
As discussed in #390, as a shortcoming of `ElementPtr`, methods accepting this type should at least return the "true" element type. Furthermore, this behavior is consistent with the C++ API.