### PR TITLE
Allow nested datamodels

### DIFF
--- a/Source/Core/Element.cpp
+++ b/Source/Core/Element.cpp
@@ -1963,6 +1963,10 @@ void Element::SetDataModel(DataModel* new_data_model)
 	if (data_model == new_data_model)
 		return;
 
+	// stop descent if a nested data model is encountered
+	if (data_model && new_data_model && data_model != new_data_model)
+		return;
+
 	if (data_model)
 		data_model->OnElementRemove(this);
 

--- a/Source/Core/Element.cpp
+++ b/Source/Core/Element.cpp
@@ -2022,11 +2022,6 @@ void Element::SetParent(Element* _parent)
 		else if (Context* context = GetContext())
 		{
 			String name = it->second.Get<String>();
-			if (parent->data_model)
-			{
-				Log::Message(Log::LT_INFO, "Nested data models encountered. Data model '%s' will replace parent model in element %s.", name.c_str(),
-					GetAddress().c_str());
-			}
 
 			if (DataModel* model = context->GetDataModelPtr(name))
 			{

--- a/Source/Core/Element.cpp
+++ b/Source/Core/Element.cpp
@@ -2015,15 +2015,15 @@ void Element::SetParent(Element* _parent)
 		{
 			SetDataModel(parent->data_model);
 		}
-		else if (parent->data_model)
-		{
-			String name = it->second.Get<String>();
-			Log::Message(Log::LT_ERROR, "Nested data models are not allowed. Data model '%s' given in element %s.", name.c_str(),
-				GetAddress().c_str());
-		}
 		else if (Context* context = GetContext())
 		{
 			String name = it->second.Get<String>();
+			if (parent->data_model)
+			{
+				Log::Message(Log::LT_INFO, "Nested data models encountered. Data model '%s' will replace parent model in element %s.", name.c_str(),
+					GetAddress().c_str());
+			}
+
 			if (DataModel* model = context->GetDataModelPtr(name))
 			{
 				model->AttachModelRootElement(this);


### PR DESCRIPTION
When trying to split the UI logic into multiple components, i frequently encounter the issue of not being allowed to nest the respective data models. After simply trying out disabling the check and not seeing any immediate issues as well as no unit test failures, i decided to make this change. I changed the previous error to a info message to let the developer know.

I don't (yet) know of any bad side effects, and if more work would be needed to facilitate this change, let me know. I feel like this is very important to be able to do. 