### PR TITLE
Benchmarks: Fix compile error caused by custom std::string allocator.

### DIFF
--- a/Tests/Source/Benchmarks/BackgroundBorder.cpp
+++ b/Tests/Source/Benchmarks/BackgroundBorder.cpp
@@ -130,7 +130,7 @@ TEST_CASE("backgrounds_and_borders")
 		document->QuerySelectorAll(elements, "#" + id + " > div");
 		REQUIRE(!elements.empty());
 
-		bench.run("Border " + id, [&] {
+		bench.run(("Border " + id).c_str(), [&] {
 			for (auto& element : elements)
 				element->SetProperty(Rml::PropertyId::BorderLeftColor, Rml::Property(Colourb(), Unit::COLOUR));
 			context->Update();

--- a/Tests/Source/Benchmarks/Selectors.cpp
+++ b/Tests/Source/Benchmarks/Selectors.cpp
@@ -282,7 +282,7 @@ TEST_CASE("Selectors")
 
 		bool hover_active = false;
 
-		bench.run(name, [&] {
+		bench.run(name.c_str(), [&] {
 			hover_active = !hover_active;
 			// Toggle some arbitrary pseudo class on the element to dirty the definition on this and all descendent elements.
 			el->SetPseudoClass("hover", hover_active);


### PR DESCRIPTION
It is possible to set custom allocator for `std::string` in `Include/RmlUi/Config/Config.h`:
```cpp
using String = std::basic_string<char, std::char_traits<char>, MyAllocator<char>>;
```

`ankerl::nanobench::Bench::run` expects as first parameter either `char const*` or `std::string const&`.
With custom allocator, `String` type cannot be implicitly converted to `std::string`.