### PR TITLE
MacOS - set compatability flag for GL3

### DIFF
--- a/Backends/RmlUi_Backend_GLFW_GL3.cpp
+++ b/Backends/RmlUi_Backend_GLFW_GL3.cpp
@@ -84,9 +84,7 @@ bool Backend::Initialize(const char* name, int width, int height, bool allow_res
 	glfwWindowHint(GLFW_RESIZABLE, allow_resize ? GLFW_TRUE : GLFW_FALSE);
 	glfwWindowHint(GLFW_SCALE_TO_MONITOR, GLFW_TRUE);
 
-#if __APPLE__
     glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);
-#endif
 
 	GLFWwindow* window = glfwCreateWindow(width, height, name, nullptr, nullptr);
 	if (!window)

--- a/Backends/RmlUi_Backend_GLFW_GL3.cpp
+++ b/Backends/RmlUi_Backend_GLFW_GL3.cpp
@@ -84,6 +84,10 @@ bool Backend::Initialize(const char* name, int width, int height, bool allow_res
 	glfwWindowHint(GLFW_RESIZABLE, allow_resize ? GLFW_TRUE : GLFW_FALSE);
 	glfwWindowHint(GLFW_SCALE_TO_MONITOR, GLFW_TRUE);
 
+#if __APPLE__
+    glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);
+#endif
+
 	GLFWwindow* window = glfwCreateWindow(width, height, name, nullptr, nullptr);
 	if (!window)
 		return false;


### PR DESCRIPTION
Fix GLFW error (0x10007): NSGL: The targeted version of macOS only supports forward-compatible core profile contexts for OpenGL 3.2 and above