### PR TITLE
Keyboard / spatial navigation

### DIFF
--- a/Include/RmlUi/Core/Context.h
+++ b/Include/RmlUi/Core/Context.h
@@ -384,7 +384,7 @@ private:
 	// Internal callback for when an element is detached or removed from the hierarchy.
 	void OnElementDetach(Element* element);
 	// Internal callback for when a new element gains focus.
-	bool OnFocusChange(Element* element);
+	bool OnFocusChange(Element* element, bool focus_visible);
 
 	// Generates an event for faking clicks on an element.
 	void GenerateClickEvent(Element* element);

--- a/Include/RmlUi/Core/Element.h
+++ b/Include/RmlUi/Core/Element.h
@@ -468,8 +468,9 @@ public:
 	//@{
 
 	/// Gives focus to the current element.
+	/// @param[in] focus_visible True to indicate that the focus should be visually indicated by setting the ':focus-visible' pseudo class.
 	/// @return True if the change focus request was successful
-	bool Focus();
+	bool Focus(bool focus_visible = false);
 	/// Removes focus from from this element.
 	void Blur();
 	/// Fakes a mouse click on this element.

--- a/Include/RmlUi/Core/ElementDocument.h
+++ b/Include/RmlUi/Core/ElementDocument.h
@@ -39,6 +39,7 @@ class DocumentHeader;
 class ElementText;
 class StyleSheet;
 class StyleSheetContainer;
+enum class NavigationSearchDirection;
 
 /**
      ModalFlag used for controlling the modal state of the document.
@@ -153,6 +154,8 @@ private:
 	Element* FindNextTabElement(Element* current_element, bool forward);
 	/// Searches forwards or backwards for a focusable element in the given substree
 	Element* SearchFocusSubtree(Element* element, bool forward);
+	/// Find the next element to navigate to, starting at the current element.
+	Element* FindNextNavigationElement(Element* current_element, NavigationSearchDirection direction, const Property& property);
 
 	/// Sets the dirty flag on the layout so the document will format its children before the next render.
 	void DirtyLayout() override;

--- a/Include/RmlUi/Core/ID.h
+++ b/Include/RmlUi/Core/ID.h
@@ -59,6 +59,7 @@ enum class ShorthandId : uint8_t {
 	TransformOrigin,
 	Flex,
 	FlexFlow,
+	Nav,
 
 	NumDefinedIds,
 	FirstCustomId = NumDefinedIds,
@@ -168,6 +169,11 @@ enum class PropertyId : uint8_t {
 	FlexShrink,
 	FlexWrap,
 	JustifyContent,
+
+	NavUp,
+	NavRight,
+	NavDown,
+	NavLeft,
 
 	NumDefinedIds,
 	FirstCustomId = NumDefinedIds,

--- a/Include/RmlUi/Core/StyleTypes.h
+++ b/Include/RmlUi/Core/StyleTypes.h
@@ -158,6 +158,8 @@ namespace Style {
 	enum class FlexWrap : uint8_t { Nowrap, Wrap, WrapReverse };
 	enum class JustifyContent : uint8_t { FlexStart, FlexEnd, Center, SpaceBetween, SpaceAround };
 
+	enum class Nav : uint8_t { None, Auto, Horizontal, Vertical };
+
 	class ComputedValues;
 
 } // namespace Style

--- a/Samples/assets/invader.rcss
+++ b/Samples/assets/invader.rcss
@@ -140,6 +140,7 @@ body
 	font-style: normal;
 	font-size: 15dp;
 	color: white;
+	nav: auto;
 }
 
 body.window
@@ -336,10 +337,11 @@ table input.text
 	background-color: white;
 
 	font-size: 15dp;
-
+}
+table input.text, table input.text:focus-visible
+{
 	decorator: none;
 }
-
 
 
 select

--- a/Samples/assets/invader.rcss
+++ b/Samples/assets/invader.rcss
@@ -48,8 +48,12 @@
 
 	text-l: 162px 192px 14px 31px;
 	text-c: 176px 192px 1px 31px;
+	text-focus-l: 162px 230px 14px 31px;
+	text-focus-c: 176px 230px 1px 31px;
 	textarea: 162px 193px 145px 31px;
 	textarea-inner: 173px 206px 127px 10px;
+	textarea-focus: 162px 231px 145px 31px;
+	textarea-focus-inner: 173px 244px 127px 10px;
 
 	selectbox-tl: 281px 275px 11px 9px;
 	selectbox-t:  292px 275px 1px 9px;
@@ -113,8 +117,11 @@
 	sliderarrowinc-hover: 28px 177px 27px 24px;
 	sliderarrowinc-active: 28px 202px 27px 24px;
 
-	range-track:       219px 194px  3px 32px;
-	range-track-inner: 220px 204px  1px 14px;
+	range-track:             219px 194px  3px 32px;
+	range-track-inner:       220px 204px  1px 14px;
+	range-track-focus:       219px 232px  3px 32px;
+	range-track-focus-inner: 220px 242px  1px 14px;
+
 	range-bar:         127px 191px 34px 32px;
 	range-dec:           3px 232px 17px 17px;
 	range-dec-hover:    21px 232px 17px 17px;
@@ -253,7 +260,9 @@ input.submit
 	margin-left: 0;
 }
 
-
+input, button, select {
+	nav: auto;
+}
 
 button,
 input.submit
@@ -277,8 +286,8 @@ input.submit:focus
 	font-effect: blur(3dp #fff);
 }
 
-button:hover,
-input.submit:hover
+button:hover, button:focus-visible,
+input.submit:hover, input.submit:focus-visible
 {
 	decorator: image(button-hover);
 }
@@ -305,6 +314,10 @@ input.text, input.password
 	cursor: text;
 	text-align: left;
 }
+input.text:focus-visible, input.password:focus-visible
+{
+	decorator: tiled-horizontal( text-focus-l, text-focus-c, auto );
+}
 
 textarea
 {
@@ -312,6 +325,10 @@ textarea
 	decorator: ninepatch( textarea, textarea-inner, 1.0 );
 	cursor: text;
 	text-align: left;
+}
+textarea:focus-visible
+{
+	decorator: ninepatch( textarea-focus, textarea-focus-inner, 1.0 );
 }
 
 input.text,
@@ -358,7 +375,10 @@ select selectvalue
 	height: 25dp;
 	padding: 12dp 10dp 0dp 10dp;
 
-	decorator: image( selectvalue  );
+	decorator: image( selectvalue );
+}
+select:focus-visible selectvalue {
+	decorator: image( selectvalue-hover );
 }
 
 select selectarrow
@@ -369,7 +389,7 @@ select selectarrow
 	decorator: image( selectarrow );
 }
 
-select:hover selectarrow
+select:hover selectarrow, select:focus-visible selectarrow
 {
 	decorator: image( selectarrow-hover );
 }
@@ -436,7 +456,7 @@ input.radio
 	decorator: image(radio);
 }
 
-input.radio:hover
+input.radio:hover, input.radio:focus-visible
 {
 	decorator: image(radio-hover);
 }
@@ -451,7 +471,7 @@ input.radio:checked
 	decorator: image(radio-checked);
 }
 
-input.radio:checked:hover
+input.radio:checked:hover, input.radio:checked:focus-visible
 {
 	decorator: image(radio-checked-hover);
 }
@@ -466,7 +486,7 @@ input.checkbox
 	decorator: image(checkbox);
 }
 
-input.checkbox:hover
+input.checkbox:hover, input.checkbox:focus-visible
 {
 	decorator: image(checkbox-hover);
 }
@@ -481,7 +501,7 @@ input.checkbox:checked
 	decorator: image(checkbox-checked);
 }
 
-input.checkbox:checked:hover
+input.checkbox:checked:hover, input.checkbox:checked:focus-visible
 {
 	decorator: image(checkbox-checked-hover);
 }
@@ -501,6 +521,9 @@ input.range slidertrack {
 	height: 22dp;
 	image-color: #ecc;
 	decorator: ninepatch( range-track, range-track-inner, 1.0 );
+}
+input.range:focus-visible slidertrack {
+	decorator: ninepatch( range-track-focus, range-track-focus-inner, 1.0 );
 }
 input.range sliderbar {
 	margin-left: -8dp;

--- a/Samples/basic/demo/data/demo.rml
+++ b/Samples/basic/demo/data/demo.rml
@@ -602,6 +602,14 @@ progress {
 {
 	height: 12dp;
 }
+form input, form textarea, form select
+{
+	nav: vertical;
+}
+form .nav-auto, form input.checkbox, form input.radio
+{
+	nav: auto;
+}
 </style>
 </head>
 
@@ -836,21 +844,21 @@ progress {
 		</div>
 		<h2>Email and password</h2>
 		<div>
-			<input type="text" name="email"/>
-			<input type="password" name="password"/>
+			<input type="text" name="email" class="nav-auto"/>
+			<input type="password" name="password" class="nav-auto"/>
 		</div>
 		<h2>Favorite animal</h2>
 		<div>
 			<label><input type="radio" name="animal" value="dog" checked/> Dog </label>
 			<label><input type="radio" name="animal" value="cat"/> Cat </label>
 			<label><input type="radio" name="animal" value="narwhal"/> Narwhal </label>
-			<label><input type="radio" name="animal" value="no"/> I don't like animals </label>
+			<label><input type="radio" name="animal" value="no" style="nav-down: #lasagne"/> I don't like animals </label>
 		</div>
 		<h2>Favorite meals</h2>
 		<div>
 			<label><input type="checkbox" name="meals" value="pizza" checked/> Pizza </label>
 			<label><input type="checkbox" name="meals" value="pasta" checked/> Pasta </label>
-			<label><input type="checkbox" name="meals" value="lasagne" checked/> Lasagne </label>
+			<label><input type="checkbox" name="meals" value="lasagne" id="lasagne" checked/> Lasagne </label>
 		</div>
 		<h2>Rating</h2>
 		<div>

--- a/Samples/invaders/data/game.rml
+++ b/Samples/invaders/data/game.rml
@@ -89,7 +89,7 @@
 			}
 		</style>
 	</head>
-	<body id="game_window">
+	<body id="game_window" onkeyup="onescape load pause">
 		<game id="game">
 			<div id="score_div">
 				<icon />

--- a/Samples/invaders/data/help.rml
+++ b/Samples/invaders/data/help.rml
@@ -21,7 +21,7 @@
 			}
 		</style>
 	</head>
-	<body template="window">
+	<body template="window" onkeydown="onescape goto main_menu">
 		<h1>Story</h1>
 		<p>
 			One day, without warning, they came for us; endless waves of the invaders, numbers too vast to count, fresh from the Martian foundries. Earth's orbital defences took a heavy toll, but were inevitably overrun, buying enough time only for a single rmlui ship to launch. The prototype X-42 'Defender'-class, not yet tested but piloted by the finest astronaut the Space Corps had to offer.

--- a/Samples/invaders/data/high_score.rml
+++ b/Samples/invaders/data/high_score.rml
@@ -44,7 +44,7 @@
 		}
 	</style>
 </head>
-<body template="window" onload="add_score">
+<body template="window" onload="add_score" onkeydown="onescape goto main_menu">
 	<table data-model="high_scores">
 		<thead>
 			<tr>

--- a/Samples/invaders/data/options.rml
+++ b/Samples/invaders/data/options.rml
@@ -24,7 +24,7 @@
 			}
 		</style>
 	</head>
-	<body template="window" onload="restore">
+	<body template="window" onload="restore" onkeydown="onescape goto main_menu">
 		<form onsubmit="store; goto main_menu" onchange="enable_accept">
 			<div>
 				<p>

--- a/Samples/invaders/data/pause.rml
+++ b/Samples/invaders/data/pause.rml
@@ -17,7 +17,7 @@
 			}
 		</style>
 	</head>
-	<body template="window" onload="pause" onunload="unpause">
+	<body template="window" onload="pause" onunload="unpause" onkeyup="onescape close">
 		<br />
 		<p>Are you sure you want to end this game?</p>
 		<button onclick="goto high_score; close game_window" autofocus>Yes</button>

--- a/Samples/invaders/data/start_game.rml
+++ b/Samples/invaders/data/start_game.rml
@@ -31,7 +31,7 @@
 			}
 		</style>
 	</head>
-	<body template="window">
+	<body template="window" onkeydown="onescape goto main_menu">
 		<form onsubmit="start">
 			<div>
 				<p>

--- a/Samples/invaders/src/ElementGame.cpp
+++ b/Samples/invaders/src/ElementGame.cpp
@@ -53,11 +53,6 @@ void ElementGame::ProcessEvent(Rml::Event& event)
 		bool key_down = (event == Rml::EventId::Keydown);
 		Rml::Input::KeyIdentifier key_identifier = (Rml::Input::KeyIdentifier)event.GetParameter<int>("key_identifier", 0);
 
-		if (key_identifier == Rml::Input::KI_ESCAPE && !key_down)
-		{
-			EventManager::LoadWindow("pause");
-		}
-
 		// Process left and right keys
 		if (key_down)
 		{

--- a/Samples/invaders/src/EventManager.cpp
+++ b/Samples/invaders/src/EventManager.cpp
@@ -67,22 +67,27 @@ void EventManager::ProcessEvent(Rml::Event& event, const Rml::String& value)
 	Rml::StringUtilities::ExpandString(commands, value, ';');
 	for (size_t i = 0; i < commands.size(); ++i)
 	{
-		// Check for a generic 'load' or 'exit' command.
+		// Check for custom commands.
 		Rml::StringList values;
 		Rml::StringUtilities::ExpandString(values, commands[i], ' ');
 
 		if (values.empty())
 			return;
 
+		if (values[0] == "onescape" && values.size() > 1)
+		{
+			Rml::Input::KeyIdentifier key_identifier = (Rml::Input::KeyIdentifier)event.GetParameter<int>("key_identifier", 0);
+			if (key_identifier == Rml::Input::KI_ESCAPE)
+				values.erase(values.begin());
+		}
+
 		if (values[0] == "goto" && values.size() > 1)
 		{
-			// Load the window, and if successful close the old window.
 			if (LoadWindow(values[1]))
 				event.GetTargetElement()->GetOwnerDocument()->Close();
 		}
 		else if (values[0] == "load" && values.size() > 1)
 		{
-			// Load the window.
 			LoadWindow(values[1]);
 		}
 		else if (values[0] == "close")

--- a/Samples/luainvaders/data/game.rml
+++ b/Samples/luainvaders/data/game.rml
@@ -87,17 +87,8 @@
 				decorator: image( icon-lives );
 			}
 		</style>
-		<script>
-Game = Game or {} --namespace for functions
-
-function Game.OnKeyDown(event, document)
-	if event.parameters['key_identifier'] == rmlui.key_identifier.ESCAPE then
-		document.context:LoadDocument('luainvaders/data/pause.rml'):Show()
-	end
-end
-		</script>
 	</head>
-	<body id="game_window" onkeydown="Game.OnKeyDown(event, document)" ongameover="Window.LoadMenu('high_score',document)">
+	<body id="game_window" ongameover="Window.LoadMenu('high_score',document)" onkeydown="if Window.EscapePressed(event) then Window.OpenDocument('pause',document) end">
 		<game id="game">
 			<div id="score_div">
 				<icon />

--- a/Samples/luainvaders/data/help.rml
+++ b/Samples/luainvaders/data/help.rml
@@ -21,7 +21,7 @@
 			}
 		</style>
 	</head>
-	<body template="luawindow">
+	<body template="luawindow" onkeydown="if Window.EscapePressed(event) then Window.LoadMenu('main_menu',document) end">
 		<h1>Story</h1>
 		<p>
 			One day, without warning, they came for us; endless waves of the invaders, numbers too vast to count, fresh from the Martian foundries. Earth's orbital defences took a heavy toll, but were inevitably overrun, buying enough time only for a single rmlui ship to launch. The prototype X-42 'Defender'-class, not yet tested but piloted by the finest astronaut the Space Corps had to offer.

--- a/Samples/luainvaders/data/high_score.rml
+++ b/Samples/luainvaders/data/high_score.rml
@@ -53,7 +53,7 @@ function HighScore.OnKeyDown(event)
 end
 	</script>
 </head>
-<body template="luawindow" onload="Window.OnWindowLoad(document) Game.SubmitHighScore()">
+<body template="luawindow" onload="Window.OnWindowLoad(document) Game.SubmitHighScore()" onkeydown="if Window.EscapePressed(event) then Window.LoadMenu('main_menu',document) end">
 	<table data-model="high_scores">
 		<thead>
 			<tr>

--- a/Samples/luainvaders/data/main_menu.rml
+++ b/Samples/luainvaders/data/main_menu.rml
@@ -27,8 +27,8 @@ function MainMenu.CloseLogo(document)
 end
 		</script>
 	</head>
-	<body template="luawindow" onload="Window.OnWindowLoad(document) document.context:LoadDocument('luainvaders/data/logo.rml'):Show()" onunload="MainMenu.CloseLogo(document)">
-		<button onclick="document.context:LoadDocument('luainvaders/data/start_game.rml'):Show() document:Close()">Start Game</button><br />
+	<body template="luawindow" onload="Window.OnWindowLoad(document) Window.OpenDocument('logo',document)" onunload="MainMenu.CloseLogo(document)">
+		<button onclick="Window.LoadMenu('start_game',document)">Start Game</button><br />
 		<button onclick="Window.LoadMenu('high_score',document)">High Scores</button><br />
 		<button onclick="Window.LoadMenu('options',document)">Options</button><br />
 		<button onclick="Window.LoadMenu('help',document)">Help</button><br />

--- a/Samples/luainvaders/data/options.rml
+++ b/Samples/luainvaders/data/options.rml
@@ -97,7 +97,7 @@ function Options.SaveOptions(event)
 end
 	</script>
 	</head>
-	<body template="luawindow" onload="Window.OnWindowLoad(document) Options.LoadOptions(document)">
+	<body template="luawindow" onload="Window.OnWindowLoad(document) Options.LoadOptions(document)" onkeydown="if Window.EscapePressed(event) then Window.LoadMenu('main_menu',document) end">
 		<form data-model="options" onsubmit="Options.SaveOptions(event) Window.LoadMenu('main_menu',document)" data-event-change="options_changed = true">
 			<div>
 				<p>

--- a/Samples/luainvaders/data/pause.rml
+++ b/Samples/luainvaders/data/pause.rml
@@ -17,7 +17,7 @@
 			}
 		</style>
 	</head>
-	<body template="luawindow" onload="Window.OnWindowLoad(document) Game.SetPaused(true)" onunload="Game.SetPaused(false)">
+	<body template="luawindow" onload="Window.OnWindowLoad(document) Game.SetPaused(true)" onunload="Game.SetPaused(false)" onkeydown="if Window.EscapePressed(event) then document:Close() end">
 		<br />
 		<p>Are you sure you want to end this game?</p>
 		<button onclick="Window.LoadMenu('high_score',document) document.context.documents['game_window']:Close()" autofocus>Yes</button>

--- a/Samples/luainvaders/data/start_game.rml
+++ b/Samples/luainvaders/data/start_game.rml
@@ -51,7 +51,7 @@ function StartGame.SetupGame(event,document)
 end
 		</script>
 	</head>
-	<body template="luawindow">
+	<body template="luawindow" onkeydown="if Window.EscapePressed(event) then Window.LoadMenu('main_menu',document) end">
 		<form onsubmit="StartGame.SetupGame(event,document)">
 			<div>
 				<p>

--- a/Samples/luainvaders/data/window.rml
+++ b/Samples/luainvaders/data/window.rml
@@ -14,8 +14,19 @@ function Window.LoadMenu(name,document)
 		doc:Show()
 		document:Close()
 	end
-
 	return doc
+end
+
+function Window.OpenDocument(name,document)
+	local doc = document.context:LoadDocument('luainvaders/data/' .. name .. '.rml')
+	if doc then
+		doc:Show()
+	end
+	return doc
+end
+
+function Window.EscapePressed(event)
+	return event.parameters['key_identifier'] == rmlui.key_identifier.ESCAPE
 end
 	</script>
 </head>

--- a/Source/Core/Context.cpp
+++ b/Source/Core/Context.cpp
@@ -987,7 +987,7 @@ void Context::OnElementDetach(Element* element)
 		scroll_controller->Reset();
 }
 
-bool Context::OnFocusChange(Element* new_focus)
+bool Context::OnFocusChange(Element* new_focus, bool focus_visible)
 {
 	RMLUI_ASSERT(new_focus);
 
@@ -1018,10 +1018,13 @@ bool Context::OnFocusChange(Element* new_focus)
 		element = element->GetParentNode();
 	}
 
-	Dictionary parameters;
-
 	// Send out blur/focus events.
+	Dictionary parameters;
 	SendEvents(old_chain, new_chain, EventId::Blur, parameters);
+
+	if (focus_visible)
+		parameters["focus_visible"] = true;
+
 	SendEvents(new_chain, old_chain, EventId::Focus, parameters);
 
 	focus = new_focus;

--- a/Source/Core/Element.cpp
+++ b/Source/Core/Element.cpp
@@ -1094,7 +1094,7 @@ void Element::SetInnerRML(const String& rml)
 		Factory::InstanceElementText(this, rml);
 }
 
-bool Element::Focus()
+bool Element::Focus(bool focus_visible)
 {
 	// Are we allowed focus?
 	Style::Focus focus_property = meta->computed_values.focus();
@@ -1106,7 +1106,7 @@ bool Element::Focus()
 	if (context == nullptr)
 		return false;
 
-	if (!context->OnFocusChange(this))
+	if (!context->OnFocusChange(this, focus_visible))
 		return false;
 
 	// Set this as the end of the focus chain.
@@ -1888,8 +1888,15 @@ void Element::ProcessDefaultAction(Event& event)
 		{
 		case EventId::Mouseover: SetPseudoClass("hover", true); break;
 		case EventId::Mouseout: SetPseudoClass("hover", false); break;
-		case EventId::Focus: SetPseudoClass("focus", true); break;
-		case EventId::Blur: SetPseudoClass("focus", false); break;
+		case EventId::Focus:
+			SetPseudoClass("focus", true);
+			if (event.GetParameter("focus_visible", false))
+				SetPseudoClass("focus-visible", true);
+			break;
+		case EventId::Blur:
+			SetPseudoClass("focus", false);
+			SetPseudoClass("focus-visible", false);
+			break;
 		default: break;
 		}
 	}

--- a/Source/Core/ElementDocument.cpp
+++ b/Source/Core/ElementDocument.cpp
@@ -509,7 +509,7 @@ void ElementDocument::ProcessDefaultAction(Event& event)
 			}
 		}
 		// Process ENTER being pressed on a focusable object (emulate click)
-		else if (key_identifier == Input::KI_RETURN || key_identifier == Input::KI_NUMPADENTER)
+		else if (key_identifier == Input::KI_RETURN || key_identifier == Input::KI_NUMPADENTER || key_identifier == Input::KI_SPACE)
 		{
 			Element* focus_node = GetFocusLeafNode();
 

--- a/Source/Core/ElementDocument.cpp
+++ b/Source/Core/ElementDocument.cpp
@@ -438,7 +438,7 @@ void ElementDocument::Show(ModalFlag modal_flag, FocusFlag focus_flag)
 		}
 
 		// Focus the window or element
-		bool focused = focus_element->Focus();
+		bool focused = focus_element->Focus(true);
 		if (focused && focus_element != this)
 			focus_element->ScrollIntoView(false);
 	}
@@ -625,7 +625,7 @@ void ElementDocument::ProcessDefaultAction(Event& event)
 		{
 			if (Element* element = FindNextTabElement(event.GetTargetElement(), !event.GetParameter<bool>("shift_key", false)))
 			{
-				if (element->Focus())
+				if (element->Focus(true))
 				{
 					element->ScrollIntoView(ScrollAlignment::Nearest);
 					event.StopPropagation();
@@ -672,7 +672,7 @@ void ElementDocument::ProcessDefaultAction(Event& event)
 			{
 				if (Element* next = FindNextNavigationElement(focus_node, direction, *nav_property))
 				{
-					if (next->Focus())
+					if (next->Focus(true))
 					{
 						next->ScrollIntoView(ScrollAlignment::Nearest);
 						event.StopPropagation();

--- a/Source/Core/ElementDocument.cpp
+++ b/Source/Core/ElementDocument.cpp
@@ -503,7 +503,7 @@ void ElementDocument::ProcessDefaultAction(Event& event)
 			{
 				if (element->Focus())
 				{
-					element->ScrollIntoView(false);
+					element->ScrollIntoView(ScrollAlignment::Nearest);
 					event.StopPropagation();
 				}
 			}

--- a/Source/Core/ElementStyle.cpp
+++ b/Source/Core/ElementStyle.cpp
@@ -869,6 +869,12 @@ PropertyIdSet ElementStyle::ComputeValues(Style::ComputedValues& values, const S
 		case PropertyId::FlexWrap:
 		case PropertyId::JustifyContent:
 			break;
+		// Navigation properties. Must be manually retrieved with 'GetProperty()'.
+		case PropertyId::NavUp:
+		case PropertyId::NavDown:
+		case PropertyId::NavLeft:
+		case PropertyId::NavRight:
+			break;
 		// Unhandled properties. Must be manually retrieved with 'GetProperty()'.
 		case PropertyId::FillImage:
 		case PropertyId::CaretColor:

--- a/Source/Core/Elements/ElementFormControl.cpp
+++ b/Source/Core/Elements/ElementFormControl.cpp
@@ -83,7 +83,7 @@ void ElementFormControl::OnAttributeChange(const ElementAttributes& changed_attr
 			Blur();
 		}
 		else
-			RemoveProperty("focus");
+			RemoveProperty(PropertyId::Focus);
 	}
 }
 

--- a/Source/Core/Elements/WidgetDropDown.cpp
+++ b/Source/Core/Elements/WidgetDropDown.cpp
@@ -552,13 +552,29 @@ void WidgetDropDown::ProcessEvent(Event& event)
 	{
 		Input::KeyIdentifier key_identifier = (Input::KeyIdentifier)event.GetParameter<int>("key_identifier", 0);
 
+		auto HasVerticalNavigation = [this](PropertyId id) {
+			if (const Property* p = parent_element->GetProperty(id))
+			{
+				if (p->unit != Unit::KEYWORD)
+					return true;
+				const Style::Nav nav = static_cast<Style::Nav>(p->Get<int>());
+				if (nav == Style::Nav::Auto || nav == Style::Nav::Vertical)
+					return true;
+			}
+			return false;
+		};
+
 		switch (key_identifier)
 		{
 		case Input::KI_UP:
+			if (!box_visible && HasVerticalNavigation(PropertyId::NavUp))
+				break;
 			SeekSelection(false);
 			event.StopPropagation();
 			break;
 		case Input::KI_DOWN:
+			if (!box_visible && HasVerticalNavigation(PropertyId::NavDown))
+				break;
 			SeekSelection(true);
 			event.StopPropagation();
 			break;

--- a/Source/Core/Elements/WidgetTextInput.cpp
+++ b/Source/Core/Elements/WidgetTextInput.cpp
@@ -525,6 +525,7 @@ void WidgetTextInput::ProcessEvent(Event& event)
 	{
 		if (event.GetTargetElement() == parent)
 		{
+			parent->SetPseudoClass("focus-visible", true);
 			if (UpdateSelection(false))
 				FormatElement();
 			ShowCursor(true, false);

--- a/Source/Core/Elements/WidgetTextInput.cpp
+++ b/Source/Core/Elements/WidgetTextInput.cpp
@@ -402,33 +402,34 @@ void WidgetTextInput::ProcessEvent(Event& event)
 		bool ctrl = event.GetParameter<int>("ctrl_key", 0) > 0;
 		bool alt = event.GetParameter<int>("alt_key", 0) > 0;
 		bool selection_changed = false;
+		bool out_of_bounds = false;
 
 		switch (key_identifier)
 		{
-		// clang-format off
+			// clang-format off
 		case Input::KI_NUMPAD4: if (numlock) break; //-fallthrough
-		case Input::KI_LEFT:    selection_changed = MoveCursorHorizontal(ctrl ? CursorMovement::PreviousWord : CursorMovement::Left, shift); break;
+		case Input::KI_LEFT:    selection_changed = MoveCursorHorizontal(ctrl ? CursorMovement::PreviousWord : CursorMovement::Left, shift, out_of_bounds); break;
 
 		case Input::KI_NUMPAD6: if (numlock) break; //-fallthrough
-		case Input::KI_RIGHT:   selection_changed = MoveCursorHorizontal(ctrl ? CursorMovement::NextWord : CursorMovement::Right, shift); break;
+		case Input::KI_RIGHT:   selection_changed = MoveCursorHorizontal(ctrl ? CursorMovement::NextWord : CursorMovement::Right, shift, out_of_bounds); break;
 
 		case Input::KI_NUMPAD8: if (numlock) break; //-fallthrough
-		case Input::KI_UP:      selection_changed = MoveCursorVertical(-1, shift); break;
+		case Input::KI_UP:      selection_changed = MoveCursorVertical(-1, shift, out_of_bounds); break;
 
 		case Input::KI_NUMPAD2: if (numlock) break; //-fallthrough
-		case Input::KI_DOWN:    selection_changed = MoveCursorVertical(1, shift); break;
+		case Input::KI_DOWN:    selection_changed = MoveCursorVertical(1, shift, out_of_bounds); break;
 
 		case Input::KI_NUMPAD7: if (numlock) break; //-fallthrough
-		case Input::KI_HOME:    selection_changed = MoveCursorHorizontal(ctrl ? CursorMovement::Begin : CursorMovement::BeginLine, shift); break;
+		case Input::KI_HOME:    selection_changed = MoveCursorHorizontal(ctrl ? CursorMovement::Begin : CursorMovement::BeginLine, shift, out_of_bounds); break;
 
 		case Input::KI_NUMPAD1: if (numlock) break; //-fallthrough
-		case Input::KI_END:     selection_changed = MoveCursorHorizontal(ctrl ? CursorMovement::End : CursorMovement::EndLine, shift); break;
+		case Input::KI_END:     selection_changed = MoveCursorHorizontal(ctrl ? CursorMovement::End : CursorMovement::EndLine, shift, out_of_bounds); break;
 
 		case Input::KI_NUMPAD9: if (numlock) break; //-fallthrough
-		case Input::KI_PRIOR:   selection_changed = MoveCursorVertical(-int(internal_dimensions.y / parent->GetLineHeight()) + 1, shift); break;
+		case Input::KI_PRIOR:   selection_changed = MoveCursorVertical(-int(internal_dimensions.y / parent->GetLineHeight()) + 1, shift, out_of_bounds); break;
 
 		case Input::KI_NUMPAD3: if (numlock) break; //-fallthrough
-		case Input::KI_NEXT:    selection_changed = MoveCursorVertical(int(internal_dimensions.y / parent->GetLineHeight()) - 1, shift); break;
+		case Input::KI_NEXT:    selection_changed = MoveCursorVertical(int(internal_dimensions.y / parent->GetLineHeight()) - 1, shift, out_of_bounds); break;
 
 		case Input::KI_BACK:
 		{
@@ -500,7 +501,8 @@ void WidgetTextInput::ProcessEvent(Event& event)
 		default: break;
 		}
 
-		event.StopPropagation();
+		if (!out_of_bounds || selection_changed)
+			event.StopPropagation();
 		if (selection_changed)
 			FormatText();
 	}
@@ -613,10 +615,11 @@ bool WidgetTextInput::AddCharacters(String string)
 
 bool WidgetTextInput::DeleteCharacters(CursorMovement direction)
 {
+	bool out_of_bounds;
 	// We set a selection of characters according to direction, and then delete it.
 	// If we already have a selection, we delete that first.
 	if (selection_length <= 0)
-		MoveCursorHorizontal(direction, true);
+		MoveCursorHorizontal(direction, true, out_of_bounds);
 
 	if (selection_length > 0)
 	{
@@ -636,8 +639,10 @@ void WidgetTextInput::CopySelection()
 	GetSystemInterface()->SetClipboardText(snippet);
 }
 
-bool WidgetTextInput::MoveCursorHorizontal(CursorMovement movement, bool select)
+bool WidgetTextInput::MoveCursorHorizontal(CursorMovement movement, bool select, bool& out_of_bounds)
 {
+	out_of_bounds = false;
+
 	const String& value = GetValue();
 
 	int cursor_line_index = 0, cursor_character_index = 0;
@@ -717,7 +722,9 @@ bool WidgetTextInput::MoveCursorHorizontal(CursorMovement movement, bool select)
 	case CursorMovement::End: absolute_cursor_index = INT_MAX; break;
 	}
 
+	const int unclamped_absolute_cursor_index = absolute_cursor_index;
 	absolute_cursor_index = Math::Clamp(absolute_cursor_index, 0, (int)GetValue().size());
+	out_of_bounds = (unclamped_absolute_cursor_index != absolute_cursor_index);
 
 	MoveCursorToCharacterBoundaries(seek_forward);
 	UpdateCursorPosition(true);
@@ -728,20 +735,23 @@ bool WidgetTextInput::MoveCursorHorizontal(CursorMovement movement, bool select)
 	return selection_changed;
 }
 
-bool WidgetTextInput::MoveCursorVertical(int distance, bool select)
+bool WidgetTextInput::MoveCursorVertical(int distance, bool select, bool& out_of_bounds)
 {
 	int cursor_line_index = 0, cursor_character_index = 0;
+	out_of_bounds = false;
 	GetRelativeCursorIndices(cursor_line_index, cursor_character_index);
 
 	cursor_line_index += distance;
 
 	if (cursor_line_index < 0)
 	{
+		out_of_bounds = true;
 		cursor_line_index = 0;
 		cursor_character_index = 0;
 	}
 	else if (cursor_line_index >= (int)lines.size())
 	{
+		out_of_bounds = true;
 		cursor_line_index = (int)lines.size() - 1;
 		cursor_character_index = (int)lines[cursor_line_index].editable_length;
 	}

--- a/Source/Core/Elements/WidgetTextInput.h
+++ b/Source/Core/Elements/WidgetTextInput.h
@@ -134,13 +134,15 @@ private:
 	/// Moves the cursor along the current line.
 	/// @param[in] movement Cursor movement operation.
 	/// @param[in] select True if the movement will also move the selection cursor, false if not.
+	/// @param[out] out_of_bounds Set to true if the resulting line position is out of bounds, false if not.
 	/// @return True if selection was changed.
-	bool MoveCursorHorizontal(CursorMovement movement, bool select);
+	bool MoveCursorHorizontal(CursorMovement movement, bool select, bool& out_of_bounds);
 	/// Moves the cursor up and down the text field.
 	/// @param[in] x How far to move the cursor.
 	/// @param[in] select True if the movement will also move the selection cursor, false if not.
+	/// @param[out] out_of_bounds Set to true if the resulting line position is out of bounds, false if not.
 	/// @return True if selection was changed.
-	bool MoveCursorVertical(int distance, bool select);
+	bool MoveCursorVertical(int distance, bool select, bool& out_of_bounds);
 	// Move the cursor to utf-8 boundaries, in case it was moved into the middle of a multibyte character.
 	/// @param[in] forward True to seek forward, else back.
 	void MoveCursorToCharacterBoundaries(bool forward);

--- a/Source/Core/StyleSheetSpecification.cpp
+++ b/Source/Core/StyleSheetSpecification.cpp
@@ -383,6 +383,12 @@ void StyleSheetSpecification::RegisterDefaultProperties()
 	RegisterProperty(PropertyId::TabIndex, "tab-index", "none", false, false).AddParser("keyword", "none, auto");
 	RegisterProperty(PropertyId::Focus, "focus", "auto", true, false).AddParser("keyword", "none, auto");
 
+	RegisterProperty(PropertyId::NavUp, "nav-up", "none", false, false).AddParser("keyword", "none, auto, horizontal, vertical").AddParser("string");
+	RegisterProperty(PropertyId::NavRight, "nav-right", "none", false, false).AddParser("keyword", "none, auto, horizontal, vertical").AddParser("string");
+	RegisterProperty(PropertyId::NavDown, "nav-down", "none", false, false).AddParser("keyword", "none, auto, horizontal, vertical").AddParser("string");
+	RegisterProperty(PropertyId::NavLeft, "nav-left", "none", false, false).AddParser("keyword", "none, auto, horizontal, vertical").AddParser("string");
+	RegisterShorthand(ShorthandId::Nav, "nav", "nav-up, nav-right, nav-down, nav-left", ShorthandType::Box);
+
 	RegisterProperty(PropertyId::ScrollbarMargin, "scrollbar-margin", "0", false, false).AddParser("length");
 	RegisterProperty(PropertyId::OverscrollBehavior, "overscroll-behavior", "auto", false, false).AddParser("keyword", "auto, contain");
 	RegisterProperty(PropertyId::PointerEvents, "pointer-events", "auto", true, false).AddParser("keyword", "none, auto");

--- a/Tests/Data/VisualTests/navigation_01.rml
+++ b/Tests/Data/VisualTests/navigation_01.rml
@@ -1,0 +1,163 @@
+<rml>
+<head>
+	<title>Spatial navigation 01</title>
+	<link type="text/rcss" href="../style.rcss"/>
+	<link rel="help" href="https://www.w3.org/TR/css-ui-4/#keyboard" />
+	<link rel="navigation" href="https://drafts.csswg.org/css-nav-1/" />
+	<meta name="Description" content="Keyboard navigation. Click on test document to enable navigation." />
+	<style>
+		body { nav: auto; }
+		body button {
+			padding: 5dp;
+			border: 1dp #333;
+			background: #aaa;
+			margin: 10dp 10dp;
+			display: block;
+			nav-down: auto;
+			text-align: center;
+		}
+		body button:hover {
+			background: #bbb;
+		}
+		body:focus button {
+			background: #fff;
+		}
+		body > div {
+			display: flow-root;
+		}
+		.left {
+			float: left;
+		}
+		.right {
+			float: right;
+		}
+		.column {
+			width: 50%;
+			box-sizing: border-box;
+		}
+		.box {
+			width: 50dp;
+			height: 50dp;
+			box-sizing: border-box;
+			background-color: #aea;
+			margin: 10dp;
+			border: 5dp #999;
+			tab-index: auto;
+			nav: auto;
+
+			display: inline-block;
+			vertical-align: center;
+		}
+		.box:focus {
+			background-color: #cfc;
+		}
+		.box:focus-visible {
+			border-color: #8df;
+		}
+		.w2 { width: 120dp; }
+		.w3 { width: 190dp; }
+		.w4 { width: 260dp; }
+		.s1 { margin-left: 80dp; }
+		.s2 { margin-left: 150dp; }
+	</style>
+</head>
+
+<body lock-navigation>
+<button>Enable document focus for keyboard navigation</button>
+<hr/>
+<div>
+	<div class="box"/>
+	<div class="box"/>
+	<div class="box"/>
+
+	<div class="box"/>
+	<div class="box"/>
+	<div class="box"/>
+
+	<div class="box"/>
+	<div class="box"/>
+	<div class="box"/>
+
+	<div class="box"/>
+	<div class="box"/>
+	<div class="box"/>
+</div>
+<hr/>
+<div>
+	<div class="column left">
+		<div class="box"/>
+		<div class="box"/>
+		<div class="box"/>
+
+		<div class="box"/>
+		<div class="box"/>
+		<div class="box"/>
+
+		<div class="box"/>
+		<div class="box"/>
+		<div class="box"/>
+	</div>
+	<div class="column right">
+		<div class="box"/>
+		<div class="box"/>
+		<div class="box"/>
+
+		<div class="box"/>
+		<div class="box"/>
+		<div class="box"/>
+
+		<div class="box"/>
+		<div class="box"/>
+		<div class="box"/>
+	</div>
+</div>
+<hr/>
+<div>
+	<div class="box w3"/><div class="box"/><br/>
+	<div class="box"/><br/>
+	<div class="box"/><div class="box"/><br/>
+	<div class="box w2"/><div class="box w2"/><br/>
+</div>
+<hr/>
+<div>
+	<div class="box w3"/><br/>
+	<div class="box"/><div class="box"/><div class="box"/><br/>
+	<div class="box"/><div class="box"/><br/>
+</div>
+<hr/>
+<div>
+	<div class="box w3"/><br/>
+	<div class="box"/><div class="box s1"/><br/>
+	<div class="box"/><div class="box"/><br/>
+</div>
+<hr/>
+<div>
+	<div class="box s1"/><br/>
+	<div class="box"/><div class="box s1"/><br/>
+	<div class="box"/><div class="box"/><br/>
+</div>
+<hr/>
+<div>
+	<div class="column left">
+		<div class="box w3"/><br/>
+		<div class="box"/><br/>
+		<div class="box"/><div class="box"/><div class="box"/><br/>
+		<div class="box w2"/><br/>
+	</div>
+	<div class="column right">
+		<div class="box w3"/><br/>
+		<div class="box"/><br/>
+		<div class="box"/><div class="box"/><div class="box"/><br/>
+		<div class="box w2"/><br/>
+	</div>
+</div>
+<hr/>
+<div>
+	<div class="box w3"/><div class="box w3"/><br/>
+	<div class="box"/><div class="box s2"/><br/>
+	<div class="box"/><div class="box"/><div class="box"/><div class="box"/><div class="box"/><div class="box"/><br/>
+	<div class="box w2"/><div class="box w2 s1"/><br/>
+</div>
+<handle size_target="#document"/>
+</body>
+</rml>

--- a/Tests/Data/VisualTests/navigation_02.rml
+++ b/Tests/Data/VisualTests/navigation_02.rml
@@ -1,0 +1,111 @@
+<rml>
+<head>
+	<title>Spatial navigation 02</title>
+	<link type="text/rcss" href="../style.rcss"/>
+	<link rel="help" href="https://www.w3.org/TR/css-ui-4/#keyboard" />
+	<link rel="navigation" href="https://drafts.csswg.org/css-nav-1/" />
+	<meta name="Description" content="Keyboard navigation with scroll containers. Click on test document to enable navigation." />
+	<meta name="Assert" content="Auto-navigation should not navigate between scroll containers. In the left column, manual navigation overrides have been added for entering and exiting the scroll container from the top and bottom boxes." />
+	<meta name="Assert" content="On the other hand, the right column is fully automatic and will be skipped over from the top and bottom boxes. To enter it, one must use mouse click or tab navigation." />
+	<style>
+		body { nav: auto; }
+		body button {
+			padding: 5dp;
+			border: 1dp #333;
+			background: #aaa;
+			margin: 10dp 10dp;
+			display: block;
+			nav-down: auto;
+			text-align: center;
+		}
+		body button:hover {
+			background: #bbb;
+		}
+		body:focus button {
+			background: #fff;
+		}
+		body > div {
+			display: flow-root;
+		}
+		.left {
+			float: left;
+		}
+		.right {
+			float: right;
+		}
+		.column {
+			width: 50%;
+			box-sizing: border-box;
+			overflow: auto;
+			height: 300dp;
+		}
+		.box {
+			width: 50dp;
+			height: 50dp;
+			box-sizing: border-box;
+			background-color: #aea;
+			margin: 10dp;
+			border: 5dp #999;
+			tab-index: auto;
+			nav: auto;
+
+			display: inline-block;
+			vertical-align: center;
+		}
+		.box:focus {
+			background-color: #cfc;
+		}
+		.box:focus-visible {
+			border-color: #8df;
+		}
+		.w2 { width: 120dp; }
+		.w3 { width: 190dp; }
+		.w4 { width: 260dp; }
+		.s1 { margin-left: 80dp; }
+		.s2 { margin-left: 150dp; }
+	</style>
+</head>
+
+<body lock-navigation>
+<button>Enable document focus for keyboard navigation</button>
+<hr/>
+<div>
+	<div class="box"/>
+	<div class="box w2"/>
+	<div class="box"/>
+	<div class="box"/>
+	<div id="top" class="box w2" style="nav-down: #left-top"/>
+</div>
+<hr/>
+<div>
+	<div class="column left">
+		<div class="box w3" id="left-top" style="nav-up: #top"/><br/>
+		<div class="box"/><br/>
+		<div class="box"/><div class="box"/><div class="box"/><br/>
+		<div class="box w2"/><br/>
+		<br/>
+		<div class="box s1"/><br/>
+		<div class="box"/><div class="box s1" id="left-bottom-c" style="nav-down: #bottom-c"/><br/>
+		<div class="box" id="left-bottom-a" style="nav-down: #bottom-a"/><div class="box" id="left-bottom-b" style="nav-down: #bottom-b"/><br/>
+	</div>
+	<div class="column right">
+		<div class="box w3"/><br/>
+		<div class="box"/><br/>
+		<div class="box"/><div class="box"/><div class="box"/><br/>
+		<div class="box w2"/><br/>
+		<br/>
+		<div class="box s1"/><br/>
+		<div class="box"/><div class="box s1"/><br/>
+		<div class="box"/><div class="box"/><br/>
+	</div>
+</div>
+<hr/>
+<div class="nav-up-to-left-column">
+	<div class="box" id="bottom-a" style="nav-up: #left-bottom-a"/>
+	<div class="box" id="bottom-b" style="nav-up: #left-bottom-b"/>
+	<div class="box" id="bottom-c" style="nav-up: #left-bottom-c"/>
+	<div class="box w3" id="bottom-d"/>
+</div>
+<handle size_target="#document"/>
+</body>
+</rml>

--- a/Tests/Source/VisualTests/TestNavigator.cpp
+++ b/Tests/Source/VisualTests/TestNavigator.cpp
@@ -33,6 +33,7 @@
 #include "TestViewer.h"
 #include <RmlUi/Core/Context.h>
 #include <RmlUi/Core/Element.h>
+#include <RmlUi/Core/ElementDocument.h>
 #include <RmlUi/Core/Math.h>
 #include <Shell.h>
 #include <cstdio>
@@ -230,6 +231,10 @@ void TestNavigator::ProcessEvent(Rml::Event& event)
 			{
 				element_filter_input->Blur();
 			}
+			else if (viewer->IsNavigationLocked())
+			{
+				element_filter_input->GetOwnerDocument()->Focus();
+			}
 			else if (goto_index >= 0)
 			{
 				goto_index = -1;
@@ -252,7 +257,7 @@ void TestNavigator::ProcessEvent(Rml::Event& event)
 	}
 
 	// Keydown events in target/bubble phase ignored when focusing on input.
-	if (event == Rml::EventId::Keydown && event.GetPhase() != Rml::EventPhase::Capture)
+	if (event == Rml::EventId::Keydown && event.GetPhase() != Rml::EventPhase::Capture && !viewer->IsNavigationLocked())
 	{
 		const auto key_identifier = (Rml::Input::KeyIdentifier)event.GetParameter<int>("key_identifier", 0);
 

--- a/Tests/Source/VisualTests/TestViewer.cpp
+++ b/Tests/Source/VisualTests/TestViewer.cpp
@@ -182,6 +182,19 @@ bool TestViewer::IsHelpVisible() const
 	return document_help->IsVisible();
 }
 
+bool TestViewer::IsNavigationLocked() const
+{
+	if (Element* element = context->GetFocusElement())
+	{
+		if (document_test && element->GetOwnerDocument() == document_test)
+		{
+			if (document_test->HasAttribute("lock-navigation"))
+				return true;
+		}
+	}
+	return false;
+}
+
 bool TestViewer::LoadTest(const Rml::String& directory, const Rml::String& filename, int test_index, int number_of_tests, int filtered_test_index,
 	int filtered_number_of_tests, int suite_index, int number_of_suites, bool keep_scroll_position)
 {

--- a/Tests/Source/VisualTests/TestViewer.h
+++ b/Tests/Source/VisualTests/TestViewer.h
@@ -47,6 +47,7 @@ public:
 	void ShowSource(SourceType type);
 	void ShowHelp(bool show);
 	bool IsHelpVisible() const;
+	bool IsNavigationLocked() const;
 
 	bool LoadTest(const Rml::String& directory, const Rml::String& filename, int test_index, int number_of_tests, int filtered_test_index,
 		int filtered_number_of_tests, int suite_index, int number_of_suites, bool keep_scroll_position = false);


### PR DESCRIPTION
Continuation of #519, including the work of @gleblebedev (thank you!), which has been partially squashed here.

Here are the new changes in this PR:

- Changes the navigation algorithm quite a bit.
- Adds some partially related pre-work.
- Introduces the `nav` shorthand property.
- Adds [`:focus-visible`](https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-visible) pseudo-property.
- Makes the `invaders` sample fully work with keyboard navigation, with `:focus-visible` to highlight the focus.
- Adds some visual tests where we can test how the algorithm behaves in different situations.
- Makes navigation take precedent in select elements, instead one can press space to open its options.
- Restrains auto navigation to stay within the nearest scroll container.

The algorithm is designed to always pick the nearest intersecting element along a given direction. If it finds none, it will effectively try to select one that may lie outside this intersection area as well. There are different design choices here, I tried to not make something too clever on purpose, it's better that it works predictably for the 95% use case. For other cases it is easier to override it manually.

Currently the `nav` shorthand is a "box" type shorthand - that is, taking 1 to 4 values and assigns them to the direction up/right/down/left, just like for padding and margin properties. We might want to consider instead to use special keywords like horizontal, vertical, and maybe others.

All feedback is very much welcome. I'll clean up the commits in the end before merging.