### PR TITLE
Fix SVGPlugin, adapt to lunasvg change of default bitmap format

### DIFF
--- a/Source/SVG/ElementSVG.cpp
+++ b/Source/SVG/ElementSVG.cpp
@@ -197,6 +197,8 @@ void ElementSVG::UpdateTexture()
 	auto p_callback = [this](RenderInterface* render_interface, const String& /*name*/, TextureHandle& out_handle, Vector2i& out_dimensions) -> bool {
 		RMLUI_ASSERT(svg_document);
 		lunasvg::Bitmap bitmap = svg_document->renderToBitmap(render_dimensions.x, render_dimensions.y);
+		// LunaSVG bitmaps are now ARGB
+		bitmap.convertToRGBA();
 		if (!bitmap.valid() || !bitmap.data())
 			return false;
 		if (!render_interface->GenerateTexture(out_handle, reinterpret_cast<const Rml::byte*>(bitmap.data()), render_dimensions))


### PR DESCRIPTION
In the demo the colors of the svg are wrong, because lunasvg has changed the default bitmap format to argb:
https://github.com/sammycage/lunasvg/issues/73

in the appveyor.yml it pulls version 2.3.1 of lunasvg, so this must be updated