### PR TITLE
Keep the selection begin index updated

### DIFF
--- a/Source/Core/Elements/WidgetTextInput.cpp
+++ b/Source/Core/Elements/WidgetTextInput.cpp
@@ -1301,7 +1301,7 @@ bool WidgetTextInput::UpdateSelection(bool selecting)
 	bool selection_changed = false;
 	if (!selecting)
 	{
-		selection_anchor_index = absolute_cursor_index;
+		selection_anchor_index = selection_begin_index = absolute_cursor_index;
 		selection_changed = ClearSelection();
 	}
 	else


### PR DESCRIPTION
The selection API, introduced thanks to #419, has a problem retrieving the cursor position if no text is selected. In particular, this is a problem with the `WidgetTextInput::GetSelection()` method, which is publicly accessible from classes such as `ElementFormControlInput`.

If you select some text, unselect text, and call the method, you will get the previous index, which may no longer be valid.

This pull request aims to address this issue. Constantly updating `selection_begin_index` is safe to do; when we want to work with some selection, we first check whether `selection_length` is greater than zero. Because of this reason, `selection_begin_index` may have whatever value, and it will not break anything... except for the getter mentioned above.