### PR TITLE
Pass the focused input via ActivateKeyboard

### DIFF
--- a/Backends/RmlUi_Platform_Win32.cpp
+++ b/Backends/RmlUi_Platform_Win32.cpp
@@ -148,7 +148,7 @@ void SystemInterface_Win32::GetClipboardText(Rml::String& text)
 	}
 }
 
-void SystemInterface_Win32::ActivateKeyboard(Rml::Vector2f caret_position, float /*line_height*/)
+void SystemInterface_Win32::ActivateKeyboard(Rml::Vector2f caret_position, float /*line_height*/, Rml::ElementFormControl* /*focused_input*/)
 {
 	// Adjust the position of the input method editor (IME) to the caret.
 	if (HIMC himc = ImmGetContext(window_handle))

--- a/Backends/RmlUi_Platform_Win32.h
+++ b/Backends/RmlUi_Platform_Win32.h
@@ -51,7 +51,7 @@ public:
 	void SetClipboardText(const Rml::String& text) override;
 	void GetClipboardText(Rml::String& text) override;
 
-	void ActivateKeyboard(Rml::Vector2f caret_position, float line_height) override;
+	void ActivateKeyboard(Rml::Vector2f caret_position, float line_height, Rml::ElementFormControl* focused_input) override;
 
 private:
 	HWND window_handle = nullptr;

--- a/Include/RmlUi/Core/SystemInterface.h
+++ b/Include/RmlUi/Core/SystemInterface.h
@@ -36,6 +36,8 @@
 
 namespace Rml {
 
+class ElementFormControl;
+
 /**
     RmlUi's System Interface.
 
@@ -93,7 +95,8 @@ public:
 	/// Activate keyboard (for touchscreen devices).
 	/// @param[in] caret_position Position of the caret in absolute window coordinates.
 	/// @param[in] line_height Height of the current line being edited.
-	virtual void ActivateKeyboard(Rml::Vector2f caret_position, float line_height);
+	/// @param[in] focused_input Affected input/textarea element.
+	virtual void ActivateKeyboard(Rml::Vector2f caret_position, float line_height, ElementFormControl* focused_input);
 
 	/// Deactivate keyboard (for touchscreen devices).
 	virtual void DeactivateKeyboard();

--- a/Source/Core/Elements/WidgetTextInput.cpp
+++ b/Source/Core/Elements/WidgetTextInput.cpp
@@ -1393,7 +1393,7 @@ void WidgetTextInput::SetKeyboardActive(bool active)
 			const Vector2f element_offset = parent->GetAbsoluteOffset() - scroll_offset;
 			const Vector2f absolute_cursor_position = element_offset + cursor_position + Vector2f(0, 1);
 			const float line_height = cursor_size.y - 2.f;
-			system->ActivateKeyboard(absolute_cursor_position, line_height);
+			system->ActivateKeyboard(absolute_cursor_position, line_height, parent);
 		}
 		else
 		{

--- a/Source/Core/SystemInterface.cpp
+++ b/Source/Core/SystemInterface.cpp
@@ -130,7 +130,7 @@ void SystemInterface::JoinPath(String& translated_path, const String& document_p
 	translated_path = Replace(url.GetPathedFileName(), '|', ':');
 }
 
-void SystemInterface::ActivateKeyboard(Rml::Vector2f /*caret_position*/, float /*line_height*/) {}
+void SystemInterface::ActivateKeyboard(Rml::Vector2f /*caret_position*/, float /*line_height*/, ElementFormControl* /*focused_input*/) {}
 
 void SystemInterface::DeactivateKeyboard() {}
 

--- a/Source/Debugger/DebuggerSystemInterface.cpp
+++ b/Source/Debugger/DebuggerSystemInterface.cpp
@@ -80,9 +80,9 @@ void DebuggerSystemInterface::GetClipboardText(String& text)
 	application_interface->GetClipboardText(text);
 }
 
-void DebuggerSystemInterface::ActivateKeyboard(Rml::Vector2f caret_position, float line_height)
+void DebuggerSystemInterface::ActivateKeyboard(Rml::Vector2f caret_position, float line_height, ElementFormControl* focused_input)
 {
-	application_interface->ActivateKeyboard(caret_position, line_height);
+	application_interface->ActivateKeyboard(caret_position, line_height, focused_input);
 }
 
 void DebuggerSystemInterface::DeactivateKeyboard()

--- a/Source/Debugger/DebuggerSystemInterface.h
+++ b/Source/Debugger/DebuggerSystemInterface.h
@@ -85,7 +85,7 @@ public:
 	void GetClipboardText(String& text) override;
 
 	/// Activate keyboard (for touchscreen devices).
-	void ActivateKeyboard(Rml::Vector2f caret_position, float line_height) override;
+	void ActivateKeyboard(Rml::Vector2f caret_position, float line_height, ElementFormControl* focused_input) override;
 
 	/// Deactivate keyboard (for touchscreen devices).
 	void DeactivateKeyboard() override;


### PR DESCRIPTION
Similarly to 89a357bda4400ed03b40551a7d8d38e7f579f8a4, I want to expand the options for integrating IME, specifically for a custom solution. Such integration must directly work with the focused text input. And what better way to do this than handling the `ActivateKeyboard()` method of the system interface?

The user of the library can then, for example, create an observer for the input element and later override parts of the text, move the cursor around, etc...

I admit this is a breaking change. But since `master` is currently heavily WIP, too, it is the best time to do so. 😉 