### PR TITLE
Fix the input cursor position for a selection range

### DIFF
--- a/Source/Core/Elements/WidgetTextInput.cpp
+++ b/Source/Core/Elements/WidgetTextInput.cpp
@@ -269,6 +269,7 @@ void WidgetTextInput::SetSelectionRange(int selection_start, int selection_end)
 	}
 
 	UpdateCursorPosition(true);
+	ShowCursor(true, true);
 
 	if (selection_changed)
 		FormatText();


### PR DESCRIPTION
If the user of the library changes the selection range or the input cursor position, the cursor position is updated but not applied to the scrollable element. This pull request introduces a simple yet effective fix to the problem.