### PR TITLE
Ignore selection range update when the element is not focused

### DIFF
--- a/Source/Core/Elements/WidgetTextInput.cpp
+++ b/Source/Core/Elements/WidgetTextInput.cpp
@@ -246,6 +246,9 @@ void WidgetTextInput::Select()
 
 void WidgetTextInput::SetSelectionRange(int selection_start, int selection_end)
 {
+	if (parent->GetContext()->GetFocusElement() != parent)
+		return;
+
 	const String& value = GetValue();
 	const int byte_start = ConvertCharacterOffsetToByteOffset(value, selection_start);
 	const int byte_end = ConvertCharacterOffsetToByteOffset(value, selection_end);

--- a/Source/Core/Elements/WidgetTextInput.cpp
+++ b/Source/Core/Elements/WidgetTextInput.cpp
@@ -246,7 +246,7 @@ void WidgetTextInput::Select()
 
 void WidgetTextInput::SetSelectionRange(int selection_start, int selection_end)
 {
-	if (parent->GetContext()->GetFocusElement() != parent)
+	if (!IsFocused())
 		return;
 
 	const String& value = GetValue();
@@ -380,6 +380,11 @@ void WidgetTextInput::OnLayout()
 Element* WidgetTextInput::GetElement() const
 {
 	return parent;
+}
+
+bool WidgetTextInput::IsFocused() const
+{
+	return cursor_timer > 0;
 }
 
 void WidgetTextInput::DispatchChangeEvent(bool linebreak)

--- a/Source/Core/Elements/WidgetTextInput.h
+++ b/Source/Core/Elements/WidgetTextInput.h
@@ -121,6 +121,9 @@ protected:
 	/// Gets the parent element containing the widget.
 	Element* GetElement() const;
 
+	/// Returns true if the text input element is currently focused.
+	bool IsFocused() const;
+
 	/// Dispatches a change event to the widget's element.
 	void DispatchChangeEvent(bool linebreak = false);
 


### PR DESCRIPTION
As hinted in https://github.com/mikke89/RmlUi/pull/542#issuecomment-1822928980, `SetSelectionRange()` should be closer to what browsers do; ignore such API calls when the input element is not focused. There is no reason for doing so.

_Chromium nowadays queues such events for a short period of time, perhaps to make the API call order less strict (i.e., you focus the element after setting the selection range). The exact reason is unknown to me._