### PR TITLE
Allow ElementTabSet::RemoveTab to work on tabsets with no panels.

### DIFF
--- a/Source/Core/Elements/ElementTabSet.cpp
+++ b/Source/Core/Elements/ElementTabSet.cpp
@@ -78,11 +78,14 @@ void ElementTabSet::RemoveTab(int tab_index)
 		return;
 
 	Element* panels = GetChildByTag("panels");
-	Element* tabs = GetChildByTag("tabs");
-
-	if (panels->GetNumChildren() > tab_index && tabs->GetNumChildren() > tab_index)
+	if (panels->GetNumChildren() > tab_index)
 	{
 		panels->RemoveChild(panels->GetChild(tab_index));
+	}
+
+	Element* tabs = GetChildByTag("tabs");
+	if (tabs->GetNumChildren() > tab_index)
+	{
 		tabs->RemoveChild(tabs->GetChild(tab_index));
 	}
 }


### PR DESCRIPTION
All the other methods in ElementTabSet seem to operate on tabs and panels independently, so why not this one too!

I bumped into this issue whilst using a tabset with no panels where I am using tabset in the same way that someone may use radio buttons.