### PR TITLE
Allow dynamic array indexing in a data address.

### DIFF
--- a/Include/RmlUi/Core/DataTypes.h
+++ b/Include/RmlUi/Core/DataTypes.h
@@ -62,14 +62,16 @@ template <typename Object, typename AssignType>
 using MemberSetterFunc = void (Object::*)(AssignType);
 
 using DirtyVariables = SmallUnorderedSet<String>;
+using DataAddress = Vector<struct DataAddressEntry>;
 
 struct DataAddressEntry {
-	DataAddressEntry(String name) : name(std::move(name)), index(-1) {}
-	DataAddressEntry(int index) : index(index) {}
+	DataAddressEntry(String name_) : name(std::move(name_)), index(-1) {}
+	DataAddressEntry(DataAddress address_) : address(std::move(address_)), index(-1) {}
+	DataAddressEntry(int index_) : index(index_) {}
 	String name;
+	DataAddress address;
 	int index;
 };
-using DataAddress = Vector<DataAddressEntry>;
 
 template <class T>
 struct PointerTraits {

--- a/Source/Core/DataExpression.cpp
+++ b/Source/Core/DataExpression.cpp
@@ -1021,15 +1021,28 @@ bool DataExpression::Run(const DataExpressionInterface& expression_interface, Va
 	return true;
 }
 
+static void CollectAddresses(StringList& list, const DataAddress& address)
+{
+	if (!address.empty())
+		list.push_back(address[0].name);
+
+	for (const DataAddressEntry& entry : address)
+	{
+		if (!entry.address.empty())
+			CollectAddresses(list, entry.address);
+	}
+}
+
 StringList DataExpression::GetVariableNameList() const
 {
 	StringList list;
 	list.reserve(addresses.size());
+
 	for (const DataAddress& address : addresses)
 	{
-		if (!address.empty())
-			list.push_back(address[0].name);
+		CollectAddresses(list, address);
 	}
+
 	return list;
 }
 

--- a/Source/Lua/LuaDataModel.cpp
+++ b/Source/Lua/LuaDataModel.cpp
@@ -31,6 +31,7 @@
 #include <RmlUi/Core/DataModelHandle.h>
 #include <RmlUi/Core/DataVariable.h>
 #include <RmlUi/Lua/Utilities.h>
+#include "../Core/DataModel.h"
 
 #define RMLDATAMODEL "RMLDATAMODEL"
 
@@ -133,7 +134,7 @@ public:
 	bool Get(void* ptr, Variant& variant) override;
 	bool Set(void* ptr, const Variant& variant) override;
 	int Size(void* ptr) override;
-	DataVariable Child(void* ptr, const DataAddressEntry& address) override;
+	DataVariable Child(const DataModel& data_model, void* ptr, const DataAddressEntry& address) override;
 
 protected:
 	const struct LuaDataModel* model;
@@ -142,7 +143,7 @@ protected:
 class LuaScalarDef final : public LuaTableDef {
 public:
 	LuaScalarDef(const struct LuaDataModel* model);
-	DataVariable Child(void* ptr, const DataAddressEntry& address) override;
+	DataVariable Child(const DataModel& data_model, void* ptr, const DataAddressEntry& address) override;
 };
 
 LuaTableDef::LuaTableDef(const struct LuaDataModel* model) : VariableDefinition(DataVariableType::Scalar), model(model) {}
@@ -206,7 +207,7 @@ int LuaTableDef::Size(void* ptr)
 	return size;
 }
 
-DataVariable LuaTableDef::Child(void* ptr, const DataAddressEntry& address)
+DataVariable LuaTableDef::Child(const DataModel& /*data_model*/, void* ptr, const DataAddressEntry& address)
 {
 	lua_State* L = model->dataL;
 	if (!L)
@@ -240,13 +241,13 @@ DataVariable LuaTableDef::Child(void* ptr, const DataAddressEntry& address)
 
 LuaScalarDef::LuaScalarDef(const struct LuaDataModel* model) : LuaTableDef(model) {}
 
-DataVariable LuaScalarDef::Child(void* ptr, const DataAddressEntry& address)
+DataVariable LuaScalarDef::Child(const DataModel& data_model, void* ptr, const DataAddressEntry& address)
 {
 	lua_State* L = model->dataL;
 	if (!L)
 		return DataVariable{};
 	lua_settop(L, model->top);
-	return LuaTableDef::Child(ptr, address);
+	return LuaTableDef::Child(data_model, ptr, address);
 }
 
 static void BindVariable(struct LuaDataModel* D, lua_State* L)


### PR DESCRIPTION
This change allows arrays to be dynamically indexed e.g. `data-checked="views[view_index].filter.chat" ` is now valid whereas previously in place of `view_index` you could only use an integer literal.

This seems to work though I am not sure if there are any complications that I do not know about given that I am quite new to RmlUI.

If you're happy with the approach I have taken here, I could add some unit tests to cover this use case.