### PR TITLE
Text input handler

### DIFF
--- a/CMake/FileList.cmake
+++ b/CMake/FileList.cmake
@@ -204,6 +204,7 @@ set(Core_PUB_HDR_FILES
     ${PROJECT_SOURCE_DIR}/Include/RmlUi/Core/StyleSheetTypes.h
     ${PROJECT_SOURCE_DIR}/Include/RmlUi/Core/StyleTypes.h
     ${PROJECT_SOURCE_DIR}/Include/RmlUi/Core/SystemInterface.h
+    ${PROJECT_SOURCE_DIR}/Include/RmlUi/Core/TextInputHandler.h
     ${PROJECT_SOURCE_DIR}/Include/RmlUi/Core/Texture.h
     ${PROJECT_SOURCE_DIR}/Include/RmlUi/Core/Traits.h
     ${PROJECT_SOURCE_DIR}/Include/RmlUi/Core/Transform.h

--- a/Include/RmlUi/Core.h
+++ b/Include/RmlUi/Core.h
@@ -82,6 +82,7 @@
 #include "Core/StyleSheetSpecification.h"
 #include "Core/StyleTypes.h"
 #include "Core/SystemInterface.h"
+#include "Core/TextInputHandler.h"
 #include "Core/Texture.h"
 #include "Core/Transform.h"
 #include "Core/TransformPrimitive.h"

--- a/Include/RmlUi/Core/Context.h
+++ b/Include/RmlUi/Core/Context.h
@@ -46,6 +46,7 @@ class DataModel;
 class DataModelConstructor;
 class DataTypeRegister;
 class ScrollController;
+class TextInputHandler;
 enum class EventId : uint16_t;
 
 /**
@@ -259,6 +260,13 @@ public:
 	/// @param[in] instancer The context's instancer.
 	void SetInstancer(ContextInstancer* instancer);
 
+	/// Sets a listener handling text input events.
+	/// @param[in] handler Text input event handler.
+	void SetTextInputHandler(TextInputHandler* handler);
+	/// Retrieves the handler for text input events.
+	/// @return The current text input handler, or nullptr if none is set.
+	TextInputHandler* GetTextInputHandler() const;
+
 	/// Creates a data model.
 	/// The returned constructor can be used to bind data variables. Elements can bind to the model using the attribute 'data-model="name"'.
 	/// @param[in] name The name of the data model.
@@ -311,6 +319,8 @@ private:
 	SmallUnorderedSet<String> active_themes;
 
 	ContextInstancer* instancer;
+
+	TextInputHandler* text_input_handler;
 
 	using ElementSet = SmallOrderedSet<Element*>;
 	using ElementList = Vector<Element*>;

--- a/Include/RmlUi/Core/TextInputHandler.h
+++ b/Include/RmlUi/Core/TextInputHandler.h
@@ -1,0 +1,52 @@
+/*
+ * This source file is part of RmlUi, the HTML/CSS Interface Middleware
+ *
+ * For the latest information, see http://github.com/mikke89/RmlUi
+ *
+ * Copyright (c) 2008-2010 CodePoint Ltd, Shift Technology Ltd
+ * Copyright (c) 2019-2023 The RmlUi Team, and contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+#ifndef RMLUI_CORE_TEXTINPUTHANDLER_H
+#define RMLUI_CORE_TEXTINPUTHANDLER_H
+
+#include "Header.h"
+
+namespace Rml {
+
+class ElementFormControl;
+
+class RMLUICORE_API TextInputHandler {
+public:
+	virtual ~TextInputHandler() {}
+
+	/// Called when a text input element is focused.
+	/// @param[in] element Text or password input field or text area.
+	virtual void OnFocus(ElementFormControl* /*element*/) {}
+
+	/// Called when a text input element loses focus.
+	/// @param[in] element Text or password input field or text area.
+	virtual void OnBlur(ElementFormControl* /*element*/) {}
+};
+
+} // namespace Rml
+#endif

--- a/Source/Core/Context.cpp
+++ b/Source/Core/Context.cpp
@@ -38,6 +38,7 @@
 #include "../../Include/RmlUi/Core/RenderInterface.h"
 #include "../../Include/RmlUi/Core/StreamMemory.h"
 #include "../../Include/RmlUi/Core/SystemInterface.h"
+#include "../../Include/RmlUi/Core/TextInputHandler.h"
 #include "../../Include/RmlUi/Core/Debug.h"
 #include "DataModel.h"
 #include "EventDispatcher.h"
@@ -59,6 +60,7 @@ Context::Context(const String& name) :
 	next_update_timeout(0)
 {
 	instancer = nullptr;
+	text_input_handler = nullptr;
 
 	root = Factory::InstanceElement(nullptr, "*", "#root", XMLAttributes());
 	root->SetId(name);
@@ -876,6 +878,16 @@ void Context::SetInstancer(ContextInstancer* _instancer)
 {
 	RMLUI_ASSERT(instancer == nullptr);
 	instancer = _instancer;
+}
+
+void Context::SetTextInputHandler(TextInputHandler* handler)
+{
+	text_input_handler = handler;
+}
+
+TextInputHandler* Context::GetTextInputHandler() const
+{
+	return text_input_handler;
 }
 
 DataModelConstructor Context::CreateDataModel(const String& name, DataTypeRegister* data_type_register)

--- a/Source/Core/Elements/WidgetTextInput.cpp
+++ b/Source/Core/Elements/WidgetTextInput.cpp
@@ -41,6 +41,7 @@
 #include "../../../Include/RmlUi/Core/Math.h"
 #include "../../../Include/RmlUi/Core/StringUtilities.h"
 #include "../../../Include/RmlUi/Core/SystemInterface.h"
+#include "../../../Include/RmlUi/Core/TextInputHandler.h"
 #include "../Clock.h"
 #include "ElementTextSelection.h"
 #include <algorithm>
@@ -538,6 +539,10 @@ void WidgetTextInput::ProcessEvent(Event& event)
 			if (UpdateSelection(false))
 				FormatElement();
 			ShowCursor(true, false);
+
+			if (Context* context = parent->GetContext())
+				if (TextInputHandler* text_input_handler = context->GetTextInputHandler())
+					text_input_handler->OnFocus(parent);
 		}
 	}
 	break;
@@ -547,6 +552,11 @@ void WidgetTextInput::ProcessEvent(Event& event)
 		{
 			if (ClearSelection())
 				FormatElement();
+
+			if (Context* context = parent->GetContext())
+				if (TextInputHandler* text_input_handler = context->GetTextInputHandler())
+					text_input_handler->OnBlur(parent);
+
 			ShowCursor(false, false);
 		}
 	}

--- a/Tests/Source/UnitTests/TextInputHandler.cpp
+++ b/Tests/Source/UnitTests/TextInputHandler.cpp
@@ -1,0 +1,103 @@
+/*
+ * This source file is part of RmlUi, the HTML/CSS Interface Middleware
+ *
+ * For the latest information, see http://github.com/mikke89/RmlUi
+ *
+ * Copyright (c) 2008-2010 CodePoint Ltd, Shift Technology Ltd
+ * Copyright (c) 2019-2023 The RmlUi Team, and contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+#include "../Common/TestsInterface.h"
+#include "../Common/TestsShell.h"
+#include <RmlUi/Core/ElementDocument.h>
+#include <RmlUi/Core/Elements/ElementFormControl.h>
+#include <RmlUi/Core/TextInputHandler.h>
+#include <doctest.h>
+
+using namespace Rml;
+
+static const String document_text_input_handler_rml = R"(
+<rml>
+<head>
+	<title>Test</title>
+	<link type="text/rcss" href="/assets/rml.rcss"/>
+</head>
+
+<body>
+	<input type="text" id="text_input"/>
+	<textarea id="text_area"></textarea>
+</body>
+</rml>
+)";
+
+TEST_CASE("Text input handler")
+{
+	Context* context = TestsShell::GetContext();
+	REQUIRE(context);
+
+	ElementDocument* document = context->LoadDocumentFromMemory(document_text_input_handler_rml);
+	REQUIRE(document);
+	document->Show();
+
+	Element* input = document->GetElementById("text_input");
+	REQUIRE(input);
+
+	Element* text_area = document->GetElementById("text_area");
+	REQUIRE(text_area);
+
+	SUBCASE("focus")
+	{
+		struct TestTextInputHandler : public Rml::TextInputHandler {
+			virtual void OnFocus(ElementFormControl* element) override
+			{
+				CHECK_MESSAGE(focused_input_id.empty(), "Focused: ", focused_input_id);
+				focused_input_id = element->GetId();
+			}
+
+			virtual void OnBlur(ElementFormControl* element) override
+			{
+				CHECK(focused_input_id == element->GetId());
+				focused_input_id.clear();
+			}
+
+			String focused_input_id;
+		};
+
+		TestTextInputHandler test_text_input_handler;
+		context->SetTextInputHandler(&test_text_input_handler);
+
+		input->Focus();
+		CHECK(test_text_input_handler.focused_input_id == "text_input");
+
+		text_area->Focus();
+		CHECK(test_text_input_handler.focused_input_id == "text_area");
+
+		// Unfocus any active text input element by focusing the document.
+		document->Focus();
+		CHECK(test_text_input_handler.focused_input_id.empty());
+
+		context->SetTextInputHandler(nullptr);
+	}
+
+	document->Close();
+	TestsShell::ShutdownShell();
+}


### PR DESCRIPTION
Replaces #540 as discussed in there.

## Motivation

For various reasons, such as implementing a custom IME system, working with the currently focused text input element is vital. The motivation for the original pull request, as explained in the description, was following the initial commit implementing parameters for IME, such as the cursor position or the line height. Admittedly, however, passing the element breaks the flexibility of the method because the keyboard may be activated without an element. This is why I am opening this request.

One of the suggestions was to use the focus event. This is, however, difficult for dynamically loaded content; the document handler would have to listen to all elements and would have to listen to any dynamic changes to the DOM if there are any.

We could instead add another attribute to the focus event, such as the target focus element. However, this would differ from CSS and require implementing an event listener for all events, filtering text input elements. Moreover, I think of these events as something that should be done on the frontend, not on the backend.

Because of the above reasons, I believe such a simple handler interface is easier to implement and work with and more reliable.

## Considerations

One of the problems I faced was invoking events of the text input handler. I do not like exposing the getter or any method in the public API, and I could not think of any better approach. On the other hand, I believe that the current solution is not the worst.

Another question is what should happen when the context gets destroyed and an element was focused before. I am unsure if the context currently blurs the focused element and if the handler should follow the behavior. Although, that is an edge case.