### PR TITLE
Add attributes and properties for language and direction

### DIFF
--- a/CMake/FileList.cmake
+++ b/CMake/FileList.cmake
@@ -205,6 +205,7 @@ set(Core_PUB_HDR_FILES
     ${PROJECT_SOURCE_DIR}/Include/RmlUi/Core/StyleTypes.h
     ${PROJECT_SOURCE_DIR}/Include/RmlUi/Core/SystemInterface.h
     ${PROJECT_SOURCE_DIR}/Include/RmlUi/Core/Texture.h
+    ${PROJECT_SOURCE_DIR}/Include/RmlUi/Core/TextShapingContext.h
     ${PROJECT_SOURCE_DIR}/Include/RmlUi/Core/Traits.h
     ${PROJECT_SOURCE_DIR}/Include/RmlUi/Core/Transform.h
     ${PROJECT_SOURCE_DIR}/Include/RmlUi/Core/TransformPrimitive.h

--- a/Include/RmlUi/Core.h
+++ b/Include/RmlUi/Core.h
@@ -82,6 +82,7 @@
 #include "Core/StyleSheetSpecification.h"
 #include "Core/StyleTypes.h"
 #include "Core/SystemInterface.h"
+#include "Core/TextShapingContext.h"
 #include "Core/Texture.h"
 #include "Core/Transform.h"
 #include "Core/TransformPrimitive.h"

--- a/Include/RmlUi/Core/ComputedValues.h
+++ b/Include/RmlUi/Core/ComputedValues.h
@@ -115,7 +115,7 @@ namespace Style {
 			font_weight(FontWeight::Normal), has_letter_spacing(0), font_style(FontStyle::Normal), has_font_effect(false),
 			pointer_events(PointerEvents::Auto), focus(Focus::Auto), text_align(TextAlign::Left), text_decoration(TextDecoration::None),
 			text_transform(TextTransform::None), white_space(WhiteSpace::Normal), word_break(WordBreak::Normal),
-			line_height_inherit_type(LineHeight::Number)
+			direction(Direction::Auto), line_height_inherit_type(LineHeight::Number)
 		{}
 
 		// Font face used to render text and resolve ex properties. Does not represent a true property
@@ -141,9 +141,13 @@ namespace Style {
 		WhiteSpace white_space : 3;
 		WordBreak word_break : 2;
 
+		Direction direction : 2;
+
 		LineHeight::InheritType line_height_inherit_type : 1;
 		float line_height = 12.f * 1.2f;
 		float line_height_inherit = 1.2f;
+
+		String language = "";
 	};
 
 	struct RareValues {
@@ -257,6 +261,8 @@ namespace Style {
 		Colourb        color()            const { return inherited.color; }
 		float          opacity()          const { return inherited.opacity; }
 		LineHeight     line_height()      const { return LineHeight(inherited.line_height, inherited.line_height_inherit_type, inherited.line_height_inherit); }
+		const String&  language()         const { return inherited.language; }
+		Direction      direction()        const { return inherited.direction; }
 
 		// -- Rare --
 		MinWidth          min_width()                  const { return LengthPercentage(rare.min_width_type, rare.min_width); }
@@ -349,6 +355,8 @@ namespace Style {
 		void color             (Colourb value)        { inherited.color              = value; }
 		void opacity           (float value)          { inherited.opacity            = value; }
 		void line_height       (LineHeight value)     { inherited.line_height = value.value; inherited.line_height_inherit_type = value.inherit_type; inherited.line_height_inherit = value.inherit_value;  }
+		void language          (const String& value)  { inherited.language           = value; }
+		void direction         (Direction value)      { inherited.direction          = value; }
 		// Rare
 		void min_width                 (MinWidth value)          { rare.min_width_type             = value.type; rare.min_width                  = value.value; }
 		void max_width                 (MaxWidth value)          { rare.max_width_type             = value.type; rare.max_width                  = value.value; }

--- a/Include/RmlUi/Core/FontEngineInterface.h
+++ b/Include/RmlUi/Core/FontEngineInterface.h
@@ -32,6 +32,7 @@
 #include "Geometry.h"
 #include "Header.h"
 #include "StyleTypes.h"
+#include "TextShapingContext.h"
 #include "Types.h"
 
 namespace Rml {
@@ -45,15 +46,6 @@ namespace Rml {
 
 class RMLUICORE_API FontEngineInterface {
 public:
-	/*
-		Data extracted from the properties of the text's element to help provide context for text shaping and spacing.
-	*/
-	struct TextShapingContext {
-		const Rml::String& language;
-		Rml::Style::Direction text_direction = Rml::Style::Direction::Auto;
-		float letter_spacing = 0.0f;
-	};
-
 	FontEngineInterface();
 	virtual ~FontEngineInterface();
 

--- a/Include/RmlUi/Core/FontEngineInterface.h
+++ b/Include/RmlUi/Core/FontEngineInterface.h
@@ -45,6 +45,15 @@ namespace Rml {
 
 class RMLUICORE_API FontEngineInterface {
 public:
+	/*
+		Data extracted from the properties of the text's element to help provide context for text shaping and spacing.
+	*/
+	struct TextShapingContext {
+		const Rml::String& language;
+		Rml::Style::Direction text_direction = Rml::Style::Direction::Auto;
+		float letter_spacing = 0.0f;
+	};
+
 	FontEngineInterface();
 	virtual ~FontEngineInterface();
 
@@ -90,11 +99,12 @@ public:
 	/// Called by RmlUi when it wants to retrieve the width of a string when rendered with this handle.
 	/// @param[in] handle The font handle.
 	/// @param[in] string The string to measure.
-	/// @param[in] letter_spacing The letter spacing size in pixels.
+	/// @param[in] text_shaping_context Additional parameters that provide context for text shaping.
 	/// @param[in] prior_character The optionally-specified character that immediately precedes the string. This may have an impact on the string
 	/// width due to kerning.
 	/// @return The width, in pixels, this string will occupy if rendered with this handle.
-	virtual int GetStringWidth(FontFaceHandle handle, const String& string, float letter_spacing, Character prior_character = Character::Null);
+	virtual int GetStringWidth(FontFaceHandle handle, const String& string, const TextShapingContext& text_shaping_context,
+		Character prior_character = Character::Null);
 
 	/// Called by RmlUi when it wants to retrieve the geometry required to render a single line of text.
 	/// @param[in] face_handle The font handle.
@@ -103,11 +113,11 @@ public:
 	/// @param[in] position The position of the baseline of the first character to render.
 	/// @param[in] colour The colour to render the text. Colour alpha is premultiplied with opacity.
 	/// @param[in] opacity The opacity of the text, should be applied to font effects.
-	/// @param[in] letter_spacing The letter spacing size in pixels.
+	/// @param[in] text_shaping_context Additional parameters that provide context for text shaping.
 	/// @param[out] geometry An array of geometries to generate the geometry into.
 	/// @return The width, in pixels, of the string geometry.
 	virtual int GenerateString(FontFaceHandle face_handle, FontEffectsHandle font_effects_handle, const String& string, const Vector2f& position,
-		const Colourb& colour, float opacity, float letter_spacing, GeometryList& geometry);
+		const Colourb& colour, float opacity, const TextShapingContext& text_shaping_context, GeometryList& geometry);
 
 	/// Called by RmlUi to determine if the text geometry is required to be re-generated. Whenever the returned version
 	/// is changed, all geometry belonging to the given face handle will be re-generated.

--- a/Include/RmlUi/Core/ID.h
+++ b/Include/RmlUi/Core/ID.h
@@ -175,8 +175,8 @@ enum class PropertyId : uint8_t {
 	NavDown,
 	NavLeft,
 
-	Language,
-	Direction,
+	RmlUi_Language,
+	RmlUi_Direction,
 
 	NumDefinedIds,
 	FirstCustomId = NumDefinedIds,

--- a/Include/RmlUi/Core/ID.h
+++ b/Include/RmlUi/Core/ID.h
@@ -175,6 +175,9 @@ enum class PropertyId : uint8_t {
 	NavDown,
 	NavLeft,
 
+	Language,
+	Direction,
+
 	NumDefinedIds,
 	FirstCustomId = NumDefinedIds,
 

--- a/Include/RmlUi/Core/StyleTypes.h
+++ b/Include/RmlUi/Core/StyleTypes.h
@@ -160,6 +160,8 @@ namespace Style {
 
 	enum class Nav : uint8_t { None, Auto, Horizontal, Vertical };
 
+	enum class Direction : uint8_t { Auto, Ltr, Rtl };
+
 	class ComputedValues;
 
 } // namespace Style

--- a/Include/RmlUi/Core/TextShapingContext.h
+++ b/Include/RmlUi/Core/TextShapingContext.h
@@ -1,0 +1,47 @@
+/*
+ * This source file is part of RmlUi, the HTML/CSS Interface Middleware
+ *
+ * For the latest information, see http://github.com/mikke89/RmlUi
+ *
+ * Copyright (c) 2008-2010 CodePoint Ltd, Shift Technology Ltd
+ * Copyright (c) 2019-2023 The RmlUi Team, and contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+#ifndef RMLUI_CORE_TEXTSHAPINGCONTEXT_H
+#define RMLUI_CORE_TEXTSHAPINGCONTEXT_H
+
+#include "StyleTypes.h"
+#include "Types.h"
+
+namespace Rml {
+
+/*
+    Data extracted from the properties of an element to help provide context for text shaping and spacing.
+*/
+struct TextShapingContext {
+	const String& language;
+	Style::Direction text_direction = Style::Direction::Auto;
+	float letter_spacing = 0.0f; // Measured in pixels.
+};
+
+} // namespace Rml
+#endif

--- a/Samples/basic/bitmapfont/src/FontEngineInterfaceBitmap.cpp
+++ b/Samples/basic/bitmapfont/src/FontEngineInterfaceBitmap.cpp
@@ -74,14 +74,15 @@ const FontMetrics& FontEngineInterfaceBitmap::GetFontMetrics(FontFaceHandle hand
 	return handle_bitmap->GetMetrics();
 }
 
-int FontEngineInterfaceBitmap::GetStringWidth(FontFaceHandle handle, const String& string, float /*letter_spacing*/, Character prior_character)
+int FontEngineInterfaceBitmap::GetStringWidth(FontFaceHandle handle, const String& string, const TextShapingContext& /*text_shaping_context*/,
+	Character prior_character)
 {
 	auto handle_bitmap = reinterpret_cast<FontFaceBitmap*>(handle);
 	return handle_bitmap->GetStringWidth(string, prior_character);
 }
 
 int FontEngineInterfaceBitmap::GenerateString(FontFaceHandle handle, FontEffectsHandle /*font_effects_handle*/, const String& string,
-	const Vector2f& position, const Colourb& colour, float /*opacity*/, float /*letter_spacing*/, GeometryList& geometry)
+	const Vector2f& position, const Colourb& colour, float /*opacity*/, const TextShapingContext& /*text_shaping_context*/, GeometryList& geometry)
 {
 	auto handle_bitmap = reinterpret_cast<FontFaceBitmap*>(handle);
 	return handle_bitmap->GenerateString(string, position, colour, geometry);

--- a/Samples/basic/bitmapfont/src/FontEngineInterfaceBitmap.h
+++ b/Samples/basic/bitmapfont/src/FontEngineInterfaceBitmap.h
@@ -49,6 +49,7 @@ using Rml::Style::FontWeight;
 using Rml::FontEffectList;
 using Rml::FontMetrics;
 using Rml::GeometryList;
+using Rml::TextShapingContext;
 
 class FontEngineInterfaceBitmap : public Rml::FontEngineInterface {
 public:

--- a/Samples/basic/bitmapfont/src/FontEngineInterfaceBitmap.h
+++ b/Samples/basic/bitmapfont/src/FontEngineInterfaceBitmap.h
@@ -73,11 +73,12 @@ public:
 	const FontMetrics& GetFontMetrics(FontFaceHandle handle) override;
 
 	/// Called by RmlUi when it wants to retrieve the width of a string when rendered with this handle.
-	int GetStringWidth(FontFaceHandle handle, const String& string, float letter_spacing, Character prior_character = Character::Null) override;
+	int GetStringWidth(FontFaceHandle handle, const String& string, const TextShapingContext& text_shaping_context,
+		Character prior_character = Character::Null) override;
 
 	/// Called by RmlUi when it wants to retrieve the geometry required to render a single line of text.
 	int GenerateString(FontFaceHandle face_handle, FontEffectsHandle font_effects_handle, const String& string, const Vector2f& position,
-		const Colourb& colour, float opacity, float letter_spacing, GeometryList& geometry) override;
+		const Colourb& colour, float opacity, const TextShapingContext& text_shaping_context, GeometryList& geometry) override;
 
 	/// Called by RmlUi to determine if the text geometry is required to be re-generated.eometry.
 	int GetVersion(FontFaceHandle handle) override;

--- a/Source/Core/Element.cpp
+++ b/Source/Core/Element.cpp
@@ -1648,7 +1648,7 @@ void Element::OnAttributeChange(const ElementAttributes& changed_attributes)
 		else if (attribute == "lang")
 		{
 			if (value.GetType() == Variant::STRING)
-				meta->style.SetProperty(PropertyId::Language, Property(value.GetReference<String>(), Unit::STRING));
+				meta->style.SetProperty(PropertyId::RmlUi_Language, Property(value.GetReference<String>(), Unit::STRING));
 			else if (value.GetType() != Variant::NONE)
 				Log::Message(Log::LT_WARNING, "Invalid 'lang' attribute, string type required. In element: %s", GetAddress().c_str());
 		}
@@ -1659,11 +1659,11 @@ void Element::OnAttributeChange(const ElementAttributes& changed_attributes)
 				const String& dir_value = value.GetReference<String>();
 
 				if (dir_value == "auto")
-					meta->style.SetProperty(PropertyId::Direction, Property(Style::Direction::Auto));
+					meta->style.SetProperty(PropertyId::RmlUi_Direction, Property(Style::Direction::Auto));
 				else if (dir_value == "ltr")
-					meta->style.SetProperty(PropertyId::Direction, Property(Style::Direction::Ltr));
+					meta->style.SetProperty(PropertyId::RmlUi_Direction, Property(Style::Direction::Ltr));
 				else if (dir_value == "rtl")
-					meta->style.SetProperty(PropertyId::Direction, Property(Style::Direction::Rtl));
+					meta->style.SetProperty(PropertyId::RmlUi_Direction, Property(Style::Direction::Rtl));
 				else
 					Log::Message(Log::LT_WARNING, "Invalid 'dir' attribute '%s', value must be 'auto', 'ltr', or 'rtl'. In element: %s",
 						dir_value.c_str(), GetAddress().c_str());

--- a/Source/Core/Element.cpp
+++ b/Source/Core/Element.cpp
@@ -1645,6 +1645,32 @@ void Element::OnAttributeChange(const ElementAttributes& changed_attributes)
 			else if (value.GetType() != Variant::NONE)
 				Log::Message(Log::LT_WARNING, "Invalid 'style' attribute, string type required. In element: %s", GetAddress().c_str());
 		}
+		else if (attribute == "lang")
+		{
+			if (value.GetType() == Variant::STRING)
+				meta->style.SetProperty(PropertyId::Language, Property(value.GetReference<String>(), Unit::STRING));
+			else if (value.GetType() != Variant::NONE)
+				Log::Message(Log::LT_WARNING, "Invalid 'lang' attribute, string type required. In element: %s", GetAddress().c_str());
+		}
+		else if (attribute == "dir")
+		{
+			if (value.GetType() == Variant::STRING)
+			{
+				const String& dir_value = value.GetReference<String>();
+
+				if (dir_value == "auto")
+					meta->style.SetProperty(PropertyId::Direction, Property(Style::Direction::Auto));
+				else if (dir_value == "ltr")
+					meta->style.SetProperty(PropertyId::Direction, Property(Style::Direction::Ltr));
+				else if (dir_value == "rtl")
+					meta->style.SetProperty(PropertyId::Direction, Property(Style::Direction::Rtl));
+				else
+					Log::Message(Log::LT_WARNING, "Invalid 'dir' attribute '%s', value must be 'auto', 'ltr', or 'rtl'. In element: %s",
+						dir_value.c_str(), GetAddress().c_str());
+			}
+			else if (value.GetType() != Variant::NONE)
+				Log::Message(Log::LT_WARNING, "Invalid 'dir' attribute, string type required. In element: %s", GetAddress().c_str());
+		}
 	}
 
 	// Any change to the attributes may affect which styles apply to the current element, in particular due to attribute selectors, ID selectors, and

--- a/Source/Core/ElementStyle.cpp
+++ b/Source/Core/ElementStyle.cpp
@@ -857,7 +857,7 @@ PropertyIdSet ElementStyle::ComputeValues(Style::ComputedValues& values, const S
 			break;
 
 		case PropertyId::RmlUi_Language:
-			values.language(p->value.GetReference<String>());
+			values.language(p->Get<String>());
 			break;
 		case PropertyId::RmlUi_Direction:
 			values.direction(p->Get<Direction>());

--- a/Source/Core/ElementStyle.cpp
+++ b/Source/Core/ElementStyle.cpp
@@ -856,6 +856,13 @@ PropertyIdSet ElementStyle::ComputeValues(Style::ComputedValues& values, const S
 			values.flex_basis(ComputeLengthPercentageAuto(p, font_size, document_font_size, dp_ratio, vp_dimensions));
 			break;
 
+		case PropertyId::RmlUi_Language:
+			values.language(p->value.GetReference<String>());
+			break;
+		case PropertyId::RmlUi_Direction:
+			values.direction(p->Get<Direction>());
+			break;
+
 		// Fetched from element's properties.
 		case PropertyId::Cursor:
 		case PropertyId::Transition:
@@ -875,9 +882,6 @@ PropertyIdSet ElementStyle::ComputeValues(Style::ComputedValues& values, const S
 		case PropertyId::NavLeft:
 		case PropertyId::NavRight:
 			break;
-		// Internationalization properties (internal). Must be manually retrieved with 'GetProperty()'.
-		case PropertyId::Language:
-		case PropertyId::Direction:
 		// Unhandled properties. Must be manually retrieved with 'GetProperty()'.
 		case PropertyId::FillImage:
 		case PropertyId::CaretColor:

--- a/Source/Core/ElementStyle.cpp
+++ b/Source/Core/ElementStyle.cpp
@@ -875,6 +875,9 @@ PropertyIdSet ElementStyle::ComputeValues(Style::ComputedValues& values, const S
 		case PropertyId::NavLeft:
 		case PropertyId::NavRight:
 			break;
+		// Internationalization properties (internal). Must be manually retrieved with 'GetProperty()'.
+		case PropertyId::Language:
+		case PropertyId::Direction:
 		// Unhandled properties. Must be manually retrieved with 'GetProperty()'.
 		case PropertyId::FillImage:
 		case PropertyId::CaretColor:

--- a/Source/Core/ElementText.cpp
+++ b/Source/Core/ElementText.cpp
@@ -36,6 +36,7 @@
 #include "../../Include/RmlUi/Core/GeometryUtilities.h"
 #include "../../Include/RmlUi/Core/Profiling.h"
 #include "../../Include/RmlUi/Core/Property.h"
+#include "../../Include/RmlUi/Core/TextShapingContext.h"
 #include "ComputeProperty.h"
 #include "ElementDefinition.h"
 #include "ElementStyle.h"
@@ -205,10 +206,8 @@ bool ElementText::GenerateLine(String& line, int& line_length, float& line_width
 	bool break_at_endline =
 		white_space_property == WhiteSpace::Pre || white_space_property == WhiteSpace::Prewrap || white_space_property == WhiteSpace::Preline;
 
-	const FontEngineInterface::TextShapingContext text_shaping_context{
-		GetProperty(PropertyId::Language)->value.GetReference<String>(),
-		GetProperty(PropertyId::Direction)->Get<Style::Direction>(),
-		computed.letter_spacing()
+	const TextShapingContext text_shaping_context{
+		computed.language(), computed.direction(), computed.letter_spacing()
 	};
 
 	TextTransform text_transform_property = computed.text_transform();
@@ -357,13 +356,13 @@ void ElementText::OnPropertyChange(const PropertyIdSet& changed_properties)
 		}
 	}
 
-	if (changed_properties.Contains(PropertyId::FontFamily) ||    //
-		changed_properties.Contains(PropertyId::FontWeight) ||    //
-		changed_properties.Contains(PropertyId::FontStyle) ||     //
-		changed_properties.Contains(PropertyId::FontSize) ||      //
-		changed_properties.Contains(PropertyId::LetterSpacing) || //
-		changed_properties.Contains(PropertyId::Language) ||      //
-		changed_properties.Contains(PropertyId::Direction))
+	if (changed_properties.Contains(PropertyId::FontFamily) ||     //
+		changed_properties.Contains(PropertyId::FontWeight) ||     //
+		changed_properties.Contains(PropertyId::FontStyle) ||      //
+		changed_properties.Contains(PropertyId::FontSize) ||       //
+		changed_properties.Contains(PropertyId::LetterSpacing) ||  //
+		changed_properties.Contains(PropertyId::RmlUi_Language) || //
+		changed_properties.Contains(PropertyId::RmlUi_Direction))
 	{
 		font_face_changed = true;
 
@@ -466,10 +465,8 @@ void ElementText::GenerateGeometry(const FontFaceHandle font_face_handle)
 
 void ElementText::GenerateGeometry(const FontFaceHandle font_face_handle, Line& line)
 {
-	const FontEngineInterface::TextShapingContext text_shaping_context{
-		GetProperty(PropertyId::Language)->value.GetReference<String>(),
-		GetProperty(PropertyId::Direction)->Get<Style::Direction>(),
-		GetComputedValues().letter_spacing()
+	const TextShapingContext text_shaping_context{
+		GetComputedValues().language(), GetComputedValues().direction(), GetComputedValues().letter_spacing()
 	};
 
 	line.width = GetFontEngineInterface()->GenerateString(font_face_handle, font_effects_handle, line.text, line.position, colour, opacity,

--- a/Source/Core/ElementText.cpp
+++ b/Source/Core/ElementText.cpp
@@ -197,7 +197,7 @@ bool ElementText::GenerateLine(String& line, int& line_length, float& line_width
 
 	// Determine how we are processing white-space while formatting the text.
 	using namespace Style;
-	auto& computed = GetComputedValues();
+	const auto& computed = GetComputedValues();
 	WhiteSpace white_space_property = computed.white_space();
 	bool collapse_white_space =
 		white_space_property == WhiteSpace::Normal || white_space_property == WhiteSpace::Nowrap || white_space_property == WhiteSpace::Preline;
@@ -206,10 +206,7 @@ bool ElementText::GenerateLine(String& line, int& line_length, float& line_width
 	bool break_at_endline =
 		white_space_property == WhiteSpace::Pre || white_space_property == WhiteSpace::Prewrap || white_space_property == WhiteSpace::Preline;
 
-	const TextShapingContext text_shaping_context{
-		computed.language(), computed.direction(), computed.letter_spacing()
-	};
-
+	const TextShapingContext text_shaping_context{ computed.language(), computed.direction(), computed.letter_spacing() };
 	TextTransform text_transform_property = computed.text_transform();
 	WordBreak word_break = computed.word_break();
 
@@ -465,9 +462,8 @@ void ElementText::GenerateGeometry(const FontFaceHandle font_face_handle)
 
 void ElementText::GenerateGeometry(const FontFaceHandle font_face_handle, Line& line)
 {
-	const TextShapingContext text_shaping_context{
-		GetComputedValues().language(), GetComputedValues().direction(), GetComputedValues().letter_spacing()
-	};
+	const auto& computed = GetComputedValues();
+	const TextShapingContext text_shaping_context{ computed.language(), computed.direction(), computed.letter_spacing() };
 
 	line.width = GetFontEngineInterface()->GenerateString(font_face_handle, font_effects_handle, line.text, line.position, colour, opacity,
 		text_shaping_context, geometry);

--- a/Source/Core/ElementUtilities.cpp
+++ b/Source/Core/ElementUtilities.cpp
@@ -34,6 +34,7 @@
 #include "../../Include/RmlUi/Core/Factory.h"
 #include "../../Include/RmlUi/Core/FontEngineInterface.h"
 #include "../../Include/RmlUi/Core/RenderInterface.h"
+#include "../../Include/RmlUi/Core/TextShapingContext.h"
 #include "DataController.h"
 #include "DataModel.h"
 #include "DataView.h"
@@ -155,9 +156,9 @@ float ElementUtilities::GetDensityIndependentPixelRatio(Element* element)
 
 int ElementUtilities::GetStringWidth(Element* element, const String& string, Character prior_character)
 {
-	const FontEngineInterface::TextShapingContext text_shaping_context{
-		element->GetProperty(PropertyId::Language)->value.GetReference<String>(),
-		element->GetProperty(PropertyId::Direction)->Get<Style::Direction>(),
+	const TextShapingContext text_shaping_context{
+		element->GetComputedValues().language(),
+		element->GetComputedValues().direction(),
 		element->GetComputedValues().letter_spacing()
 	};
 

--- a/Source/Core/ElementUtilities.cpp
+++ b/Source/Core/ElementUtilities.cpp
@@ -155,13 +155,17 @@ float ElementUtilities::GetDensityIndependentPixelRatio(Element* element)
 
 int ElementUtilities::GetStringWidth(Element* element, const String& string, Character prior_character)
 {
-	const float letter_spacing = element->GetComputedValues().letter_spacing();
+	const FontEngineInterface::TextShapingContext text_shaping_context{
+		element->GetProperty(PropertyId::Language)->value.GetReference<String>(),
+		element->GetProperty(PropertyId::Direction)->Get<Style::Direction>(),
+		element->GetComputedValues().letter_spacing()
+	};
 
 	FontFaceHandle font_face_handle = element->GetFontFaceHandle();
 	if (font_face_handle == 0)
 		return 0;
 
-	return GetFontEngineInterface()->GetStringWidth(font_face_handle, string, letter_spacing, prior_character);
+	return GetFontEngineInterface()->GetStringWidth(font_face_handle, string, text_shaping_context, prior_character);
 }
 
 bool ElementUtilities::GetClippingRegion(Vector2i& clip_origin, Vector2i& clip_dimensions, Element* element)

--- a/Source/Core/ElementUtilities.cpp
+++ b/Source/Core/ElementUtilities.cpp
@@ -156,11 +156,8 @@ float ElementUtilities::GetDensityIndependentPixelRatio(Element* element)
 
 int ElementUtilities::GetStringWidth(Element* element, const String& string, Character prior_character)
 {
-	const TextShapingContext text_shaping_context{
-		element->GetComputedValues().language(),
-		element->GetComputedValues().direction(),
-		element->GetComputedValues().letter_spacing()
-	};
+	const auto& computed = element->GetComputedValues();
+	const TextShapingContext text_shaping_context{ computed.language(), computed.direction(), computed.letter_spacing() };
 
 	FontFaceHandle font_face_handle = element->GetFontFaceHandle();
 	if (font_face_handle == 0)

--- a/Source/Core/FontEngineDefault/FontEngineInterfaceDefault.cpp
+++ b/Source/Core/FontEngineDefault/FontEngineInterfaceDefault.cpp
@@ -71,17 +71,19 @@ const FontMetrics& FontEngineInterfaceDefault::GetFontMetrics(FontFaceHandle han
 	return handle_default->GetFontMetrics();
 }
 
-int FontEngineInterfaceDefault::GetStringWidth(FontFaceHandle handle, const String& string, float letter_spacing, Character prior_character)
+int FontEngineInterfaceDefault::GetStringWidth(FontFaceHandle handle, const String& string, const TextShapingContext& text_shaping_context,
+	Character prior_character)
 {
 	auto handle_default = reinterpret_cast<FontFaceHandleDefault*>(handle);
-	return handle_default->GetStringWidth(string, letter_spacing, prior_character);
+	return handle_default->GetStringWidth(string, text_shaping_context.letter_spacing, prior_character);
 }
 
 int FontEngineInterfaceDefault::GenerateString(FontFaceHandle handle, FontEffectsHandle font_effects_handle, const String& string,
-	const Vector2f& position, const Colourb& colour, float opacity, float letter_spacing, GeometryList& geometry)
+	const Vector2f& position, const Colourb& colour, float opacity, const TextShapingContext& text_shaping_context, GeometryList& geometry)
 {
 	auto handle_default = reinterpret_cast<FontFaceHandleDefault*>(handle);
-	return handle_default->GenerateString(geometry, string, position, colour, opacity, letter_spacing, (int)font_effects_handle);
+	return handle_default->GenerateString(geometry, string, position, colour, opacity, text_shaping_context.letter_spacing,
+		(int)font_effects_handle);
 }
 
 int FontEngineInterfaceDefault::GetVersion(FontFaceHandle handle)

--- a/Source/Core/FontEngineDefault/FontEngineInterfaceDefault.h
+++ b/Source/Core/FontEngineDefault/FontEngineInterfaceDefault.h
@@ -56,11 +56,11 @@ public:
 	const FontMetrics& GetFontMetrics(FontFaceHandle handle) override;
 
 	/// Returns the width a string will take up if rendered with this handle.
-	int GetStringWidth(FontFaceHandle, const String& string, float letter_spacing, Character prior_character) override;
+	int GetStringWidth(FontFaceHandle, const String& string, const TextShapingContext& text_shaping_context, Character prior_character) override;
 
 	/// Generates the geometry required to render a single line of text.
 	int GenerateString(FontFaceHandle, FontEffectsHandle, const String& string, const Vector2f& position, const Colourb& colour, float opacity,
-		float letter_spacing, GeometryList& geometry) override;
+		const TextShapingContext& text_shaping_context, GeometryList& geometry) override;
 
 	/// Returns the current version of the font face.
 	int GetVersion(FontFaceHandle handle) override;

--- a/Source/Core/FontEngineInterface.cpp
+++ b/Source/Core/FontEngineInterface.cpp
@@ -62,13 +62,15 @@ const FontMetrics& FontEngineInterface::GetFontMetrics(FontFaceHandle /*handle*/
 	return metrics;
 }
 
-int FontEngineInterface::GetStringWidth(FontFaceHandle /*handle*/, const String& /*string*/, float /*letter_spacing*/, Character /*prior_character*/)
+int FontEngineInterface::GetStringWidth(FontFaceHandle /*handle*/, const String& /*string*/, const TextShapingContext& /*text_shaping_context*/,
+	Character /*prior_character*/)
 {
 	return 0;
 }
 
 int FontEngineInterface::GenerateString(FontFaceHandle /*face_handle*/, FontEffectsHandle /*font_effects_handle*/, const String& /*string*/,
-	const Vector2f& /*position*/, const Colourb& /*colour*/, float /*opacity*/, float /*letter_spacing*/, GeometryList& /*geometry*/)
+	const Vector2f& /*position*/, const Colourb& /*colour*/, float /*opacity*/, const TextShapingContext& /*text_shaping_context*/,
+	GeometryList& /*geometry*/)
 {
 	return 0;
 }

--- a/Source/Core/PropertyDefinition.cpp
+++ b/Source/Core/PropertyDefinition.cpp
@@ -29,7 +29,6 @@
 #include "../../Include/RmlUi/Core/PropertyDefinition.h"
 #include "../../Include/RmlUi/Core/Log.h"
 #include "../../Include/RmlUi/Core/StyleSheetSpecification.h"
-#include "../../Include/RmlUi/Core/StyleTypes.h"
 
 namespace Rml {
 
@@ -138,25 +137,9 @@ bool PropertyDefinition::GetValue(String& value, const Property& property) const
 					break;
 				}
 			}
-
+			// If we couldn't find it, exit now
 			if (parser_index < 0 || parser_index >= (int)parsers.size())
-			{
-				// Manually handle internal direction property
-				if (id == PropertyId::Direction)
-				{
-					switch (property.value.Get<Style::Direction>())
-					{
-					case Style::Direction::Auto: value = "auto"; break;
-					case Style::Direction::Ltr: value = "ltr"; break;
-					case Style::Direction::Rtl: value = "rtl"; break;
-					}
-
-					break;
-				}
-
-				// We couldn't find it, exit now
 				return false;
-			}
 		}
 
 		int keyword = property.value.Get<int>();

--- a/Source/Core/PropertyDefinition.cpp
+++ b/Source/Core/PropertyDefinition.cpp
@@ -29,6 +29,7 @@
 #include "../../Include/RmlUi/Core/PropertyDefinition.h"
 #include "../../Include/RmlUi/Core/Log.h"
 #include "../../Include/RmlUi/Core/StyleSheetSpecification.h"
+#include "../../Include/RmlUi/Core/StyleTypes.h"
 
 namespace Rml {
 
@@ -137,9 +138,25 @@ bool PropertyDefinition::GetValue(String& value, const Property& property) const
 					break;
 				}
 			}
-			// If we couldn't find it, exit now
+
 			if (parser_index < 0 || parser_index >= (int)parsers.size())
+			{
+				// Manually handle internal direction property
+				if (id == PropertyId::Direction)
+				{
+					switch (property.value.Get<Style::Direction>())
+					{
+					case Style::Direction::Auto: value = "auto"; break;
+					case Style::Direction::Ltr: value = "ltr"; break;
+					case Style::Direction::Rtl: value = "rtl"; break;
+					}
+
+					break;
+				}
+
+				// We couldn't find it, exit now
 				return false;
+			}
 		}
 
 		int keyword = property.value.Get<int>();

--- a/Source/Core/StyleSheetSpecification.cpp
+++ b/Source/Core/StyleSheetSpecification.cpp
@@ -430,8 +430,8 @@ void StyleSheetSpecification::RegisterDefaultProperties()
 	RegisterShorthand(ShorthandId::FlexFlow, "flex-flow", "flex-direction, flex-wrap", ShorthandType::FallThrough);
 
 	// Internationalization properties (internal)
-	RegisterProperty(PropertyId::Language, "language", "", true, false);
-	RegisterProperty(PropertyId::Direction, "direction", "auto", true, false);
+	RegisterProperty(PropertyId::RmlUi_Language, "--rmlui-language", "", true, true).AddParser("string");
+	RegisterProperty(PropertyId::RmlUi_Direction, "--rmlui-direction", "auto", true, true).AddParser("keyword", "auto, ltr, rtl");
 
 	RMLUI_ASSERTMSG(instance->properties.shorthand_map->AssertAllInserted(ShorthandId::NumDefinedIds), "Missing specification for one or more Shorthand IDs.");
 	RMLUI_ASSERTMSG(instance->properties.property_map->AssertAllInserted(PropertyId::NumDefinedIds), "Missing specification for one or more Property IDs.");

--- a/Source/Core/StyleSheetSpecification.cpp
+++ b/Source/Core/StyleSheetSpecification.cpp
@@ -429,6 +429,10 @@ void StyleSheetSpecification::RegisterDefaultProperties()
 	RegisterShorthand(ShorthandId::Flex, "flex", "flex-grow, flex-shrink, flex-basis", ShorthandType::Flex);
 	RegisterShorthand(ShorthandId::FlexFlow, "flex-flow", "flex-direction, flex-wrap", ShorthandType::FallThrough);
 
+	// Internationalization properties (internal)
+	RegisterProperty(PropertyId::Language, "language", "", true, false);
+	RegisterProperty(PropertyId::Direction, "direction", "auto", true, false);
+
 	RMLUI_ASSERTMSG(instance->properties.shorthand_map->AssertAllInserted(ShorthandId::NumDefinedIds), "Missing specification for one or more Shorthand IDs.");
 	RMLUI_ASSERTMSG(instance->properties.property_map->AssertAllInserted(PropertyId::NumDefinedIds), "Missing specification for one or more Property IDs.");
 	// clang-format on

--- a/Tests/Source/UnitTests/Localization.cpp
+++ b/Tests/Source/UnitTests/Localization.cpp
@@ -1,0 +1,100 @@
+/*
+ * This source file is part of RmlUi, the HTML/CSS Interface Middleware
+ *
+ * For the latest information, see http://github.com/mikke89/RmlUi
+ *
+ * Copyright (c) 2008-2010 CodePoint Ltd, Shift Technology Ltd
+ * Copyright (c) 2019-2023 The RmlUi Team, and contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+#include "../Common/TestsShell.h"
+#include <RmlUi/Core/Context.h>
+#include <RmlUi/Core/Core.h>
+#include <RmlUi/Core/Element.h>
+#include <RmlUi/Core/ElementDocument.h>
+#include <RmlUi/Core/StyleTypes.h>
+#include <RmlUi/Core/StringUtilities.h>
+#include <doctest.h>
+
+using namespace Rml;
+
+static const String document_localization_rml = R"(
+<rml>
+<head>
+</head>
+
+<body>
+	<div id="parent" lang="en" dir="ltr">
+		<span id="cell0"/>
+		<span id="cell1" lang="nl"/>
+		<span id="cell2" dir="auto"/>
+		<span id="cell3" lang="ar" dir="rtl"/>
+	</div>
+</body>
+</rml>
+)";
+
+TEST_CASE("Localization")
+{
+	Context* context = TestsShell::GetContext();
+	REQUIRE(context);
+
+	ElementDocument* document = context->LoadDocumentFromMemory(document_localization_rml);
+	REQUIRE(document);
+	document->Show();
+
+	Element* parent_element = document->GetElementById("parent");
+	REQUIRE(parent_element);
+	Element* cells[4]{};
+	for (int i = 0; i < 4; ++i)
+	{
+		cells[i] = document->GetElementById(CreateString(8, "cell%d", i));
+		REQUIRE(cells[i]);
+	}
+
+	TestsShell::RenderLoop();
+
+	SUBCASE("Language")
+	{
+		REQUIRE(document->GetProperty(PropertyId::Language)->Get<String>() == "");
+		REQUIRE(parent_element->GetProperty(PropertyId::Language)->Get<String>() == "en");
+
+		REQUIRE(cells[0]->GetProperty(PropertyId::Language)->Get<String>() == "en");
+		REQUIRE(cells[1]->GetProperty(PropertyId::Language)->Get<String>() == "nl");
+		REQUIRE(cells[2]->GetProperty(PropertyId::Language)->Get<String>() == "en");
+		REQUIRE(cells[3]->GetProperty(PropertyId::Language)->Get<String>() == "ar");
+	}
+
+	SUBCASE("Direction")
+	{
+		REQUIRE(document->GetProperty(PropertyId::Direction)->Get<Style::Direction>() == Style::Direction::Auto);
+		REQUIRE(parent_element->GetProperty(PropertyId::Direction)->Get<Style::Direction>() == Style::Direction::Ltr);
+
+		REQUIRE(cells[0]->GetProperty(PropertyId::Direction)->Get<Style::Direction>() == Style::Direction::Ltr);
+		REQUIRE(cells[1]->GetProperty(PropertyId::Direction)->Get<Style::Direction>() == Style::Direction::Ltr);
+		REQUIRE(cells[2]->GetProperty(PropertyId::Direction)->Get<Style::Direction>() == Style::Direction::Auto);
+		REQUIRE(cells[3]->GetProperty(PropertyId::Direction)->Get<Style::Direction>() == Style::Direction::Rtl);
+	}
+
+	document->Close();
+	TestsShell::ShutdownShell();
+}

--- a/Tests/Source/UnitTests/Localization.cpp
+++ b/Tests/Source/UnitTests/Localization.cpp
@@ -28,6 +28,7 @@
 
 #include "../Common/TestsShell.h"
 #include <RmlUi/Core/Context.h>
+#include <RmlUi/Core/ComputedValues.h>
 #include <RmlUi/Core/Core.h>
 #include <RmlUi/Core/Element.h>
 #include <RmlUi/Core/ElementDocument.h>
@@ -75,24 +76,64 @@ TEST_CASE("Localization")
 
 	SUBCASE("Language")
 	{
-		REQUIRE(document->GetProperty(PropertyId::Language)->Get<String>() == "");
-		REQUIRE(parent_element->GetProperty(PropertyId::Language)->Get<String>() == "en");
+		REQUIRE(document->GetProperty(PropertyId::RmlUi_Language)->Get<String>() == "");
+		REQUIRE(document->GetComputedValues().language() == "");
+		REQUIRE(parent_element->GetProperty(PropertyId::RmlUi_Language)->Get<String>() == "en");
+		REQUIRE(parent_element->GetComputedValues().language() == "en");
 
-		REQUIRE(cells[0]->GetProperty(PropertyId::Language)->Get<String>() == "en");
-		REQUIRE(cells[1]->GetProperty(PropertyId::Language)->Get<String>() == "nl");
-		REQUIRE(cells[2]->GetProperty(PropertyId::Language)->Get<String>() == "en");
-		REQUIRE(cells[3]->GetProperty(PropertyId::Language)->Get<String>() == "ar");
+		CHECK(cells[0]->GetProperty(PropertyId::RmlUi_Language)->Get<String>() == "en");
+		CHECK(cells[0]->GetComputedValues().language() == "en");
+		CHECK(cells[1]->GetProperty(PropertyId::RmlUi_Language)->Get<String>() == "nl");
+		CHECK(cells[1]->GetComputedValues().language() == "nl");
+		CHECK(cells[2]->GetProperty(PropertyId::RmlUi_Language)->Get<String>() == "en");
+		CHECK(cells[2]->GetComputedValues().language() == "en");
+		CHECK(cells[3]->GetProperty(PropertyId::RmlUi_Language)->Get<String>() == "ar");
+		CHECK(cells[3]->GetComputedValues().language() == "ar");
+
+		SUBCASE("Change language")
+		{
+			parent_element->SetAttribute("lang", "es");
+			TestsShell::RenderLoop();
+
+			REQUIRE(parent_element->GetProperty(PropertyId::RmlUi_Language)->Get<String>() == "es");
+			REQUIRE(parent_element->GetComputedValues().language() == "es");
+
+			CHECK(cells[0]->GetProperty(PropertyId::RmlUi_Language)->Get<String>() == "es");
+			CHECK(cells[0]->GetComputedValues().language() == "es");
+			CHECK(cells[1]->GetProperty(PropertyId::RmlUi_Language)->Get<String>() == "nl");
+			CHECK(cells[1]->GetComputedValues().language() == "nl");
+		}
 	}
 
 	SUBCASE("Direction")
 	{
-		REQUIRE(document->GetProperty(PropertyId::Direction)->Get<Style::Direction>() == Style::Direction::Auto);
-		REQUIRE(parent_element->GetProperty(PropertyId::Direction)->Get<Style::Direction>() == Style::Direction::Ltr);
+		REQUIRE(document->GetProperty(PropertyId::RmlUi_Direction)->Get<Style::Direction>() == Style::Direction::Auto);
+		REQUIRE(document->GetComputedValues().direction() == Style::Direction::Auto);
+		REQUIRE(parent_element->GetProperty(PropertyId::RmlUi_Direction)->Get<Style::Direction>() == Style::Direction::Ltr);
+		REQUIRE(parent_element->GetComputedValues().direction() == Style::Direction::Ltr);
 
-		REQUIRE(cells[0]->GetProperty(PropertyId::Direction)->Get<Style::Direction>() == Style::Direction::Ltr);
-		REQUIRE(cells[1]->GetProperty(PropertyId::Direction)->Get<Style::Direction>() == Style::Direction::Ltr);
-		REQUIRE(cells[2]->GetProperty(PropertyId::Direction)->Get<Style::Direction>() == Style::Direction::Auto);
-		REQUIRE(cells[3]->GetProperty(PropertyId::Direction)->Get<Style::Direction>() == Style::Direction::Rtl);
+		CHECK(cells[0]->GetProperty(PropertyId::RmlUi_Direction)->Get<Style::Direction>() == Style::Direction::Ltr);
+		CHECK(cells[0]->GetComputedValues().direction() == Style::Direction::Ltr);
+		CHECK(cells[1]->GetProperty(PropertyId::RmlUi_Direction)->Get<Style::Direction>() == Style::Direction::Ltr);
+		CHECK(cells[1]->GetComputedValues().direction() == Style::Direction::Ltr);
+		CHECK(cells[2]->GetProperty(PropertyId::RmlUi_Direction)->Get<Style::Direction>() == Style::Direction::Auto);
+		CHECK(cells[2]->GetComputedValues().direction() == Style::Direction::Auto);
+		CHECK(cells[3]->GetProperty(PropertyId::RmlUi_Direction)->Get<Style::Direction>() == Style::Direction::Rtl);
+		CHECK(cells[3]->GetComputedValues().direction() == Style::Direction::Rtl);
+
+		SUBCASE("Change direction")
+		{
+			parent_element->SetAttribute("dir", "rtl");
+			TestsShell::RenderLoop();
+
+			REQUIRE(parent_element->GetProperty(PropertyId::RmlUi_Direction)->Get<Style::Direction>() == Style::Direction::Rtl);
+			REQUIRE(parent_element->GetComputedValues().direction() == Style::Direction::Rtl);
+
+			CHECK(cells[0]->GetProperty(PropertyId::RmlUi_Direction)->Get<Style::Direction>() == Style::Direction::Rtl);
+			CHECK(cells[0]->GetComputedValues().direction() == Style::Direction::Rtl);
+			CHECK(cells[2]->GetProperty(PropertyId::RmlUi_Direction)->Get<Style::Direction>() == Style::Direction::Auto);
+			CHECK(cells[2]->GetComputedValues().direction() == Style::Direction::Auto);
+		}
 	}
 
 	document->Close();


### PR DESCRIPTION
This pull request adds more localisation support to RmlUi, based on the discussion in #553.

To summarise, it adds the following:  
- Two new internal properties (`language` and `direction`) that directly cannot be set with RCSS.
- Two new attributes for elements:
  - `lang`: represents the language of the element's text and sets the `language` property.
  - `dir`: represents the text-flow direction of the element's text and sets the `direction` property.
- A text-shaping context structure containing the language, direction, and letter-spacing, and it is used by the font engine interface.
- Unit tests for the new localisation properties.

I have created a new sample for text-shaping to show these properties in action, but I will save that for another pull request (after this one is done). Below are some images of this sample.

**Font rendering *without* text shaping.**
(English–Arabic–Hindi)
![Font rendering demonstration without text shaping.](https://github.com/mikke89/RmlUi/assets/39696157/1ee9810e-bc62-4d45-9a0b-b3921fa35582)

**Font rendering *with* text shaping.**
(English–Arabic–Hindi)
![Font rendering demonstration with text shaping.](https://github.com/mikke89/RmlUi/assets/39696157/cc7b750d-dcd6-4f9d-a121-b979853478a5)

