### PR TITLE
add support for the `not` prefix in media queries

### DIFF
--- a/Include/RmlUi/Core/StyleSheetTypes.h
+++ b/Include/RmlUi/Core/StyleSheetTypes.h
@@ -84,15 +84,21 @@ struct DecoratorDeclarationList {
 	String value;
 };
 
+enum class MediaQueryModifier {
+	None,
+	Not, // passes only if the query is false instead of true
+	Only // provided only for compatibility; does nothing
+};
+
 struct MediaBlock {
 	MediaBlock() {}
-	MediaBlock(PropertyDictionary _properties, SharedPtr<StyleSheet> _stylesheet, bool _match_value) :
-		properties(std::move(_properties)), stylesheet(std::move(_stylesheet)), match_value(_match_value)
+	MediaBlock(PropertyDictionary _properties, SharedPtr<StyleSheet> _stylesheet, MediaQueryModifier _modifier) :
+		properties(std::move(_properties)), stylesheet(std::move(_stylesheet)), modifier(_modifier)
 	{}
 
 	PropertyDictionary properties; // Media query properties
 	SharedPtr<StyleSheet> stylesheet;
-	bool match_value = true;
+	MediaQueryModifier modifier = MediaQueryModifier::None;
 };
 using MediaBlockList = Vector<MediaBlock>;
 

--- a/Include/RmlUi/Core/StyleSheetTypes.h
+++ b/Include/RmlUi/Core/StyleSheetTypes.h
@@ -86,8 +86,7 @@ struct DecoratorDeclarationList {
 
 enum class MediaQueryModifier {
 	None,
-	Not, // passes only if the query is false instead of true
-	Only // provided only for compatibility; does nothing
+	Not // passes only if the query is false instead of true
 };
 
 struct MediaBlock {

--- a/Include/RmlUi/Core/StyleSheetTypes.h
+++ b/Include/RmlUi/Core/StyleSheetTypes.h
@@ -86,12 +86,13 @@ struct DecoratorDeclarationList {
 
 struct MediaBlock {
 	MediaBlock() {}
-	MediaBlock(PropertyDictionary _properties, SharedPtr<StyleSheet> _stylesheet) :
-		properties(std::move(_properties)), stylesheet(std::move(_stylesheet))
+	MediaBlock(PropertyDictionary _properties, SharedPtr<StyleSheet> _stylesheet, bool _match_value) :
+		properties(std::move(_properties)), stylesheet(std::move(_stylesheet)), match_value(_match_value)
 	{}
 
 	PropertyDictionary properties; // Media query properties
 	SharedPtr<StyleSheet> stylesheet;
+	bool match_value = true;
 };
 using MediaBlockList = Vector<MediaBlock>;
 

--- a/Source/Core/StyleSheetContainer.cpp
+++ b/Source/Core/StyleSheetContainer.cpp
@@ -138,11 +138,11 @@ bool StyleSheetContainer::UpdateCompiledStyleSheet(const Context* context)
 			case MediaQueryId::NumDefinedIds: break;
 			}
 
-			if (!all_match)
+			if (all_match != media_block.match_value)
 				break;
 		}
 
-		if (all_match)
+		if (all_match == media_block.match_value)
 			new_active_media_block_indices.push_back(media_block_index);
 	}
 
@@ -194,7 +194,7 @@ SharedPtr<StyleSheetContainer> StyleSheetContainer::CombineStyleSheetContainer(c
 
 	for (const MediaBlock& media_block : media_blocks)
 	{
-		new_sheet->media_blocks.emplace_back(media_block.properties, media_block.stylesheet);
+		new_sheet->media_blocks.emplace_back(media_block.properties, media_block.stylesheet, media_block.match_value);
 	}
 
 	new_sheet->MergeStyleSheetContainer(container);
@@ -234,7 +234,7 @@ void StyleSheetContainer::MergeStyleSheetContainer(const StyleSheetContainer& ot
 	for (auto it = it_other_begin; it != other.media_blocks.end(); ++it)
 	{
 		const MediaBlock& block_other = *it;
-		media_blocks.emplace_back(block_other.properties, block_other.stylesheet);
+		media_blocks.emplace_back(block_other.properties, block_other.stylesheet, block_other.match_value);
 	}
 }
 

--- a/Source/Core/StyleSheetContainer.cpp
+++ b/Source/Core/StyleSheetContainer.cpp
@@ -65,6 +65,8 @@ bool StyleSheetContainer::UpdateCompiledStyleSheet(const Context* context)
 	{
 		const MediaBlock& media_block = media_blocks[media_block_index];
 		bool all_match = true;
+		bool expected_match_value = media_block.modifier == MediaQueryModifier::Not ? false : true;
+
 		for (const auto& property : media_block.properties.GetProperties())
 		{
 			const MediaQueryId id = static_cast<MediaQueryId>(property.first);
@@ -138,11 +140,11 @@ bool StyleSheetContainer::UpdateCompiledStyleSheet(const Context* context)
 			case MediaQueryId::NumDefinedIds: break;
 			}
 
-			if (all_match != media_block.match_value)
+			if (all_match != expected_match_value)
 				break;
 		}
 
-		if (all_match == media_block.match_value)
+		if (all_match == expected_match_value)
 			new_active_media_block_indices.push_back(media_block_index);
 	}
 
@@ -194,7 +196,7 @@ SharedPtr<StyleSheetContainer> StyleSheetContainer::CombineStyleSheetContainer(c
 
 	for (const MediaBlock& media_block : media_blocks)
 	{
-		new_sheet->media_blocks.emplace_back(media_block.properties, media_block.stylesheet, media_block.match_value);
+		new_sheet->media_blocks.emplace_back(media_block.properties, media_block.stylesheet, media_block.modifier);
 	}
 
 	new_sheet->MergeStyleSheetContainer(container);
@@ -234,7 +236,7 @@ void StyleSheetContainer::MergeStyleSheetContainer(const StyleSheetContainer& ot
 	for (auto it = it_other_begin; it != other.media_blocks.end(); ++it)
 	{
 		const MediaBlock& block_other = *it;
-		media_blocks.emplace_back(block_other.properties, block_other.stylesheet, block_other.match_value);
+		media_blocks.emplace_back(block_other.properties, block_other.stylesheet, block_other.modifier);
 	}
 }
 

--- a/Source/Core/StyleSheetParser.cpp
+++ b/Source/Core/StyleSheetParser.cpp
@@ -425,9 +425,7 @@ bool StyleSheetParser::ParseMediaFeatureMap(const String& rules, PropertyDiction
 			{
 				current_string = StringUtilities::StripWhitespace(StringUtilities::ToLower(std::move(current_string)));
 
-				bool is_not = current_string == "not";
-
-				if (is_not || current_string == "only")
+				if (current_string == "not")
 				{
 					// we can only ever see one "not" on the entire global query.
 					if (modifier != MediaQueryModifier::None)
@@ -436,7 +434,7 @@ bool StyleSheetParser::ParseMediaFeatureMap(const String& rules, PropertyDiction
 						return false;
 					}
 
-					modifier = is_not ? MediaQueryModifier::Not : MediaQueryModifier::Only;
+					modifier = MediaQueryModifier::Not;
 					current_string.clear();
 				}
 			}

--- a/Source/Core/StyleSheetParser.cpp
+++ b/Source/Core/StyleSheetParser.cpp
@@ -407,17 +407,15 @@ bool StyleSheetParser::ParseMediaFeatureMap(const String& rules, PropertyDiction
 
 	char character = 0;
 
-	size_t cursor = 0;
-
 	String name;
 
 	String current_string;
 
 	modifier = MediaQueryModifier::None;
 
-	do
+	for (size_t cursor = 0; cursor < rules.length(); cursor++)
 	{
-		character = rules[cursor++];
+		character = rules[cursor];
 
 		switch (character)
 		{
@@ -509,7 +507,7 @@ bool StyleSheetParser::ParseMediaFeatureMap(const String& rules, PropertyDiction
 		break;
 		default: current_string += character;
 		}
-	} while (cursor < rules.length());
+	}
 
 	if (properties.GetNumProperties() == 0)
 	{

--- a/Source/Core/StyleSheetParser.cpp
+++ b/Source/Core/StyleSheetParser.cpp
@@ -453,7 +453,9 @@ bool StyleSheetParser::ParseMediaFeatureMap(const String& rules, PropertyDiction
 
 			current_string = StringUtilities::StripWhitespace(StringUtilities::ToLower(std::move(current_string)));
 
-			if (!current_string.empty() && current_string != "and")
+			// allow an empty string to pass through only if we had just parsed a modifier.
+			if (current_string != "and" &&
+				(properties.GetNumProperties() != 0 || !current_string.empty()))
 			{
 				Log::Message(Log::LT_WARNING, "Unexpected '%s' in @media query list at %s:%d. Expected 'and'.", current_string.c_str(),
 					stream_file_name.c_str(), line_number);

--- a/Source/Core/StyleSheetParser.h
+++ b/Source/Core/StyleSheetParser.h
@@ -108,7 +108,6 @@ private:
 	bool ParseDecoratorBlock(const String& at_name, DecoratorSpecificationMap& decorator_map, const StyleSheet& style_sheet,
 		const SharedPtr<const PropertySource>& source);
 
-	// Attempts to parse the properties of a @media query
     /// Attempts to parse the properties of a @media query.
 	/// @param[in] rules The rules to parse.
 	/// @param[out] properties Parsed properties representing all values to be matched.

--- a/Source/Core/StyleSheetParser.h
+++ b/Source/Core/StyleSheetParser.h
@@ -109,7 +109,9 @@ private:
 		const SharedPtr<const PropertySource>& source);
 
 	// Attempts to parse the properties of a @media query
-	bool ParseMediaFeatureMap(PropertyDictionary& properties, const String& rules, bool &match_value);
+	// @param properties Properties to parse into
+	// @param modifier Output modifier
+	bool ParseMediaFeatureMap(const String& rules, PropertyDictionary& properties, MediaQueryModifier &modifier);
 
 	// Attempts to find one of the given character tokens in the active stream
 	// If it's found, buffer is filled with all content up until the token

--- a/Source/Core/StyleSheetParser.h
+++ b/Source/Core/StyleSheetParser.h
@@ -109,7 +109,7 @@ private:
 		const SharedPtr<const PropertySource>& source);
 
 	// Attempts to parse the properties of a @media query
-	bool ParseMediaFeatureMap(PropertyDictionary& properties, const String& rules);
+	bool ParseMediaFeatureMap(PropertyDictionary& properties, const String& rules, bool &match_value);
 
 	// Attempts to find one of the given character tokens in the active stream
 	// If it's found, buffer is filled with all content up until the token

--- a/Tests/Source/UnitTests/MediaQuery.cpp
+++ b/Tests/Source/UnitTests/MediaQuery.cpp
@@ -230,7 +230,7 @@ static const String document_media_query5_rml = R"(
 			}
 		}
 
-		@media only (theme: big) {
+		@media (theme: big) {
 			div {
 				height: 96px;
 				width: 96px;
@@ -264,14 +264,7 @@ static const String document_media_query6_rml = R"(
 			background: white;
 		}
 
-		@media only not (theme: big) {
-			div {
-				height: 32px;
-				width: 32px;
-			}
-		}
-
-		@media not only (theme: big) {
+		@media not not (theme: big) {
 			div {
 				height: 32px;
 				width: 32px;
@@ -496,8 +489,7 @@ TEST_CASE("mediaquery.theme")
 	TestsShell::ShutdownShell();
 }
 
-// test of `not` and `only`; `only` should work as normal, but
-// `not` should be an inverted case
+// test of `not`; `not` should be an inverted case
 TEST_CASE("mediaquery.theme.notonly")
 {
 	Context* context = TestsShell::GetContext();
@@ -547,14 +539,14 @@ TEST_CASE("mediaquery.theme.notonly")
 	TestsShell::ShutdownShell();
 }
 
-// test that `not` and `only` cannot be mixed
-TEST_CASE("mediaquery.theme.notonly_mix")
+// test that `not` cannot appear multiple times
+TEST_CASE("mediaquery.theme.notonly_one")
 {
 	Context* context = TestsShell::GetContext();
 	REQUIRE(context);
 	
-	INFO("Expected warnings: unexpected 'not'/'only'.");
-	TestsShell::SetNumExpectedWarnings(2);
+	INFO("Expected warnings: unexpected 'not'.");
+	TestsShell::SetNumExpectedWarnings(1);
 
 	ElementDocument* document = context->LoadDocumentFromMemory(document_media_query6_rml);
 	REQUIRE(document);

--- a/Tests/Source/UnitTests/MediaQuery.cpp
+++ b/Tests/Source/UnitTests/MediaQuery.cpp
@@ -204,6 +204,47 @@ static const String document_media_query4_rml = R"(
 </rml>
 )";
 
+static const String document_media_query5_rml = R"(
+<rml>
+<head>
+	<title>Test</title>
+	<link type="text/rcss" href="/assets/rml.rcss"/>
+	<style>
+		body {
+			left: 0;
+			top: 0;
+			right: 0;
+			bottom: 0;
+		}
+
+		div {
+			height: 48px;
+			width: 48px;
+			background: white;
+		}
+
+		@media not (theme: tiny) {
+			div {
+				height: 32px;
+				width: 32px;
+			}
+		}
+
+		@media only (theme: big) {
+			div {
+				height: 96px;
+				width: 96px;
+			}
+		}
+	</style>
+</head>
+
+<body>
+<div/>
+</body>
+</rml>
+)";
+
 TEST_CASE("mediaquery.basic")
 {
 	Context* context = TestsShell::GetContext();
@@ -367,6 +408,57 @@ TEST_CASE("mediaquery.theme")
 	context->Render();
 
 	CHECK(elems[0]->GetBox().GetSize().x == 32.0f);
+
+	document->Close();
+
+	TestsShell::ShutdownShell();
+}
+
+// test of `not` and `only`; `only` should work as normal, but
+// `not` should be an inverted case
+TEST_CASE("mediaquery.theme.notonly")
+{
+	Context* context = TestsShell::GetContext();
+	REQUIRE(context);
+
+	ElementDocument* document = context->LoadDocumentFromMemory(document_media_query5_rml);
+	REQUIRE(document);
+	document->Show();
+
+	context->Update();
+	context->Render();
+
+	TestsShell::RenderLoop();
+
+	ElementList elems;
+	document->GetElementsByTagName(elems, "div");
+	CHECK(elems.size() == 1);
+
+	CHECK(elems[0]->GetBox().GetSize().x == 32.0f);
+
+	context->ActivateTheme("big", true);
+	context->Update();
+	context->Render();
+
+	CHECK(elems[0]->GetBox().GetSize().x == 96.0f);
+
+	context->ActivateTheme("big", false);
+	context->Update();
+	context->Render();
+
+	CHECK(elems[0]->GetBox().GetSize().x == 32.0f);
+
+	context->ActivateTheme("tiny", true);
+	context->Update();
+	context->Render();
+
+	CHECK(elems[0]->GetBox().GetSize().x == 48.0f);
+
+	context->ActivateTheme("big", true);
+	context->Update();
+	context->Render();
+
+	CHECK(elems[0]->GetBox().GetSize().x == 96.0f);
 
 	document->Close();
 

--- a/Tests/Source/UnitTests/MediaQuery.cpp
+++ b/Tests/Source/UnitTests/MediaQuery.cpp
@@ -286,6 +286,47 @@ static const String document_media_query6_rml = R"(
 </rml>
 )";
 
+static const String document_media_query7_rml = R"(
+<rml>
+<head>
+	<title>Test</title>
+	<link type="text/rcss" href="/assets/rml.rcss"/>
+	<style>
+		body {
+			left: 0;
+			top: 0;
+			right: 0;
+			bottom: 0;
+		}
+
+		div {
+			height: 48px;
+			width: 48px;
+			background: white;
+		}
+
+		@media (theme: big) (theme: small) {
+			div {
+				height: 32px;
+				width: 32px;
+			}
+		}
+
+		@media not (theme: big) (theme: small) {
+			div {
+				height: 32px;
+				width: 32px;
+			}
+		}
+	</style>
+</head>
+
+<body>
+<div/>
+</body>
+</rml>
+)";
+
 TEST_CASE("mediaquery.basic")
 {
 	Context* context = TestsShell::GetContext();
@@ -512,10 +553,27 @@ TEST_CASE("mediaquery.theme.notonly_mix")
 	Context* context = TestsShell::GetContext();
 	REQUIRE(context);
 	
-	INFO("Expected warning: unexpected 'not'/'only'.");
+	INFO("Expected warnings: unexpected 'not'/'only'.");
 	TestsShell::SetNumExpectedWarnings(2);
 
 	ElementDocument* document = context->LoadDocumentFromMemory(document_media_query6_rml);
+	REQUIRE(document);
+	document->Close();
+
+	TestsShell::ShutdownShell();
+}
+
+
+// test that an `and` must be between multiple conditions.
+TEST_CASE("mediaquery.theme.condition_checks")
+{
+	Context* context = TestsShell::GetContext();
+	REQUIRE(context);
+	
+	INFO("Expected warnings: expected 'and'.");
+	TestsShell::SetNumExpectedWarnings(2);
+
+	ElementDocument* document = context->LoadDocumentFromMemory(document_media_query7_rml);
 	REQUIRE(document);
 	document->Close();
 

--- a/Tests/Source/UnitTests/MediaQuery.cpp
+++ b/Tests/Source/UnitTests/MediaQuery.cpp
@@ -245,6 +245,47 @@ static const String document_media_query5_rml = R"(
 </rml>
 )";
 
+static const String document_media_query6_rml = R"(
+<rml>
+<head>
+	<title>Test</title>
+	<link type="text/rcss" href="/assets/rml.rcss"/>
+	<style>
+		body {
+			left: 0;
+			top: 0;
+			right: 0;
+			bottom: 0;
+		}
+
+		div {
+			height: 48px;
+			width: 48px;
+			background: white;
+		}
+
+		@media only not (theme: big) {
+			div {
+				height: 32px;
+				width: 32px;
+			}
+		}
+
+		@media not only (theme: big) {
+			div {
+				height: 32px;
+				width: 32px;
+			}
+		}
+	</style>
+</head>
+
+<body>
+<div/>
+</body>
+</rml>
+)";
+
 TEST_CASE("mediaquery.basic")
 {
 	Context* context = TestsShell::GetContext();
@@ -460,6 +501,22 @@ TEST_CASE("mediaquery.theme.notonly")
 
 	CHECK(elems[0]->GetBox().GetSize().x == 96.0f);
 
+	document->Close();
+
+	TestsShell::ShutdownShell();
+}
+
+// test that `not` and `only` cannot be mixed
+TEST_CASE("mediaquery.theme.notonly_mix")
+{
+	Context* context = TestsShell::GetContext();
+	REQUIRE(context);
+	
+	INFO("Expected warning: unexpected 'not'/'only'.");
+	TestsShell::SetNumExpectedWarnings(2);
+
+	ElementDocument* document = context->LoadDocumentFromMemory(document_media_query6_rml);
+	REQUIRE(document);
 	document->Close();
 
 	TestsShell::ShutdownShell();


### PR DESCRIPTION
Adds basic support for the `not` prefix in media queries. I required this for my project as I wanted to construct menus with all potential elements added beforehand, semantically getting disabled via media queries if they don't currently apply to the situation (for instance, options menus may hide or show options depending on specific platforms, gyro availability, etc).