### PR TITLE
Use string parser for sprite sheet src property

### DIFF
--- a/Source/Core/StyleSheetParser.cpp
+++ b/Source/Core/StyleSheetParser.cpp
@@ -116,12 +116,12 @@ public:
 	{
 		if (name == "src")
 		{
-			if(!specification.ParsePropertyDeclaration(properties, id_src, value))
+			if (!specification.ParsePropertyDeclaration(properties, id_src, value))
 				return false;
 
-			if(const Property* property = properties.GetProperty(id_src))
+			if (const Property* property = properties.GetProperty(id_src))
 			{
-				if(property->unit == Unit::STRING)
+				if (property->unit == Unit::STRING)
 					image_source = property->Get<String>();
 			}
 		}
@@ -406,7 +406,7 @@ bool StyleSheetParser::ParseDecoratorBlock(const String& at_name, DecoratorSpeci
 	return true;
 }
 
-bool StyleSheetParser::ParseMediaFeatureMap(const String& rules, PropertyDictionary& properties, MediaQueryModifier &modifier)
+bool StyleSheetParser::ParseMediaFeatureMap(const String& rules, PropertyDictionary& properties, MediaQueryModifier& modifier)
 {
 	media_query_property_parser->SetTargetProperties(&properties);
 

--- a/Source/Core/StyleSheetParser.cpp
+++ b/Source/Core/StyleSheetParser.cpp
@@ -123,8 +123,6 @@ public:
 			{
 				if(property->unit == Unit::STRING)
 					image_source = property->Get<String>();
-			} else {
-				image_source = value;
 			}
 		}
 		else if (name == "resolution")

--- a/Source/Core/StyleSheetParser.cpp
+++ b/Source/Core/StyleSheetParser.cpp
@@ -86,12 +86,13 @@ private:
 
 	PropertyDictionary properties;
 	PropertySpecification specification;
-	PropertyId id_rx, id_ry, id_rw, id_rh, id_resolution;
+	PropertyId id_src, id_rx, id_ry, id_rw, id_rh, id_resolution;
 	ShorthandId id_rectangle;
 
 public:
 	SpritesheetPropertyParser() : specification(4, 1)
 	{
+		id_src = specification.RegisterProperty("src", "", false, false).AddParser("string").GetId();
 		id_rx = specification.RegisterProperty("rectangle-x", "", false, false).AddParser("length").GetId();
 		id_ry = specification.RegisterProperty("rectangle-y", "", false, false).AddParser("length").GetId();
 		id_rw = specification.RegisterProperty("rectangle-w", "", false, false).AddParser("length").GetId();
@@ -115,7 +116,16 @@ public:
 	{
 		if (name == "src")
 		{
-			image_source = value;
+			if(!specification.ParsePropertyDeclaration(properties, id_src, value))
+				return false;
+
+			if(const Property* property = properties.GetProperty(id_src))
+			{
+				if(property->unit == Unit::STRING)
+					image_source = property->Get<String>();
+			} else {
+				image_source = value;
+			}
 		}
 		else if (name == "resolution")
 		{

--- a/Tests/Source/UnitTests/StyleSheetParser.cpp
+++ b/Tests/Source/UnitTests/StyleSheetParser.cpp
@@ -26,7 +26,7 @@
  *
  */
 
-#include "../Common/TestsInterface.h"
+#include "../Common/TestsShell.h"
 #include <RmlUi/Core/Core.h>
 #include <RmlUi/Core/Spritesheet.h>
 #include <RmlUi/Core/StreamMemory.h>
@@ -34,8 +34,8 @@
 #include <RmlUi/Core/StyleSheetContainer.h>
 #include <doctest.h>
 
-static const char* spriteSheet = R"(
-@spritesheet testSheet {
+static const char* spritesheet = R"(
+@spritesheet test_sheet {
 	src: /assets/high_scores_alien_3.tga;
 	test00: 0px 0px 64px 64px;
 	test01: 64px 0px 64px 64px;
@@ -45,8 +45,8 @@ static const char* spriteSheet = R"(
 }
 )";
 
-static const char* spriteSheetWithPathStringEncoding = R"(
-@spritesheet testSheetWithPathStringEncoding {
+static const char* spritesheet_with_path_string_encoding = R"(
+@spritesheet test_sheet_with_path_string_encoding {
 	src: "/assets/test.tga";
 	test00: 0px 0px 128px 128px;
 	test01: 128px 0px 128px 128px;
@@ -58,29 +58,22 @@ static const char* spriteSheetWithPathStringEncoding = R"(
 
 using namespace Rml;
 
-TEST_CASE("spritesheet")
+TEST_CASE("style_sheet_parser.spritesheet")
 {
-	TestsSystemInterface system_interface;
-	TestsRenderInterface render_interface;
-
-	SetRenderInterface(&render_interface);
-	SetSystemInterface(&system_interface);
-
-	Initialise();
+	Context* context = TestsShell::GetContext();
 
 	{
 		StyleSheetContainer style_sheet_container;
-		StreamMemory spriteSheetStream{reinterpret_cast<const byte*>(spriteSheet), strlen(spriteSheet)};
-		style_sheet_container.LoadStyleSheetContainer(&spriteSheetStream, 0);
+		StreamMemory spritesheet_stream{reinterpret_cast<const byte*>(spritesheet), strlen(spritesheet)};
+		style_sheet_container.LoadStyleSheetContainer(&spritesheet_stream, 0);
 
-		Context* context = CreateContext("test", Vector2i(1024, 768));
 		style_sheet_container.UpdateCompiledStyleSheet(context);
 		const auto* styleSheet = style_sheet_container.GetCompiledStyleSheet();
 		CHECK(styleSheet != nullptr);
 
 		const auto* sprite00 = styleSheet->GetSprite("test00");
 		CHECK(sprite00 != nullptr);
-		CHECK(sprite00->sprite_sheet->name == "testSheet");
+		CHECK(sprite00->sprite_sheet->name == "test_sheet");
 		CHECK(sprite00->sprite_sheet->image_source == "/assets/high_scores_alien_3.tga");
 		CHECK(sprite00->rectangle.TopLeft() == Vector2f(0.f, 0.f));
 		CHECK(sprite00->rectangle.BottomRight() == Vector2f(64.f, 64.f));
@@ -88,7 +81,7 @@ TEST_CASE("spritesheet")
 
 		const auto* sprite01 = styleSheet->GetSprite("test01");
 		CHECK(sprite01 != nullptr);
-		CHECK(sprite01->sprite_sheet->name == "testSheet");
+		CHECK(sprite01->sprite_sheet->name == "test_sheet");
 		CHECK(sprite01->sprite_sheet->image_source == "/assets/high_scores_alien_3.tga");
 		CHECK(sprite01->rectangle.TopLeft() == Vector2f(64.f, 0.f));
 		CHECK(sprite01->rectangle.BottomRight() == Vector2f(128.f, 64.f));
@@ -96,7 +89,7 @@ TEST_CASE("spritesheet")
 
 		const auto* sprite10 = styleSheet->GetSprite("test10");
 		CHECK(sprite10 != nullptr);
-		CHECK(sprite10->sprite_sheet->name == "testSheet");
+		CHECK(sprite10->sprite_sheet->name == "test_sheet");
 		CHECK(sprite10->sprite_sheet->image_source == "/assets/high_scores_alien_3.tga");
 		CHECK(sprite10->rectangle.TopLeft() == Vector2f(0.f, 64.f));
 		CHECK(sprite10->rectangle.BottomRight() == Vector2f(64.f, 128.f));
@@ -104,71 +97,62 @@ TEST_CASE("spritesheet")
 
 		const auto* sprite11 = styleSheet->GetSprite("test11");
 		CHECK(sprite11 != nullptr);
-		CHECK(sprite11->sprite_sheet->name == "testSheet");
+		CHECK(sprite11->sprite_sheet->name == "test_sheet");
 		CHECK(sprite11->sprite_sheet->image_source == "/assets/high_scores_alien_3.tga");
 		CHECK(sprite11->rectangle.TopLeft() == Vector2f(64.f, 64.f));
 		CHECK(sprite11->rectangle.BottomRight() == Vector2f(128.f, 128.f));
 		CHECK(sprite11->sprite_sheet->display_scale == 1.f);
 	}
-	RemoveContext("test");
 
-	Shutdown();
+	TestsShell::ShutdownShell();
 }
 
-TEST_CASE("spritesheet with path string encoding")
+TEST_CASE("style_sheet_parser.spritesheet_with_path_string_encoding")
 {
-	TestsSystemInterface system_interface;
-	TestsRenderInterface render_interface;
-
-	SetRenderInterface(&render_interface);
-	SetSystemInterface(&system_interface);
-
-	Initialise();
+	Context* context = TestsShell::GetContext();
 
 	{
 		StyleSheetContainer style_sheet_container;
-		StreamMemory spriteSheetStream{reinterpret_cast<const byte*>(spriteSheetWithPathStringEncoding), strlen(spriteSheetWithPathStringEncoding)};
-		style_sheet_container.LoadStyleSheetContainer(&spriteSheetStream, 0);
+		StreamMemory spritesheet_stream{reinterpret_cast<const byte*>(spritesheet_with_path_string_encoding),
+			strlen(spritesheet_with_path_string_encoding)};
+		style_sheet_container.LoadStyleSheetContainer(&spritesheet_stream, 0);
 
-		Context* context = CreateContext("test", Vector2i(1024, 768));
 		style_sheet_container.UpdateCompiledStyleSheet(context);
-		const auto* styleSheet = style_sheet_container.GetCompiledStyleSheet();
-		CHECK(styleSheet != nullptr);
+		const auto* style_sheet = style_sheet_container.GetCompiledStyleSheet();
+		CHECK(style_sheet != nullptr);
 
-		const auto* sprite00 = styleSheet->GetSprite("test00");
+		const auto* sprite00 = style_sheet->GetSprite("test00");
 		CHECK(sprite00 != nullptr);
-		CHECK(sprite00->sprite_sheet->name == "testSheetWithPathStringEncoding");
+		CHECK(sprite00->sprite_sheet->name == "test_sheet_with_path_string_encoding");
 		CHECK(sprite00->sprite_sheet->image_source == "/assets/test.tga");
 		CHECK(sprite00->rectangle.TopLeft() == Vector2f(0.f, 0.f));
 		CHECK(sprite00->rectangle.BottomRight() == Vector2f(128.f, 128.f));
 		CHECK(sprite00->sprite_sheet->display_scale == 0.5f);
 
-		const auto* sprite01 = styleSheet->GetSprite("test01");
+		const auto* sprite01 = style_sheet->GetSprite("test01");
 		CHECK(sprite01 != nullptr);
-		CHECK(sprite01->sprite_sheet->name == "testSheetWithPathStringEncoding");
+		CHECK(sprite01->sprite_sheet->name == "test_sheet_with_path_string_encoding");
 		CHECK(sprite01->sprite_sheet->image_source == "/assets/test.tga");
 		CHECK(sprite01->rectangle.TopLeft() == Vector2f(128.f, 0.f));
 		CHECK(sprite01->rectangle.BottomRight() == Vector2f(256.f, 128.f));
 		CHECK(sprite01->sprite_sheet->display_scale == 0.5f);
 
-		const auto* sprite10 = styleSheet->GetSprite("test10");
+		const auto* sprite10 = style_sheet->GetSprite("test10");
 		CHECK(sprite10 != nullptr);
-		CHECK(sprite10->sprite_sheet->name == "testSheetWithPathStringEncoding");
+		CHECK(sprite10->sprite_sheet->name == "test_sheet_with_path_string_encoding");
 		CHECK(sprite10->sprite_sheet->image_source == "/assets/test.tga");
 		CHECK(sprite10->rectangle.TopLeft() == Vector2f(0.f, 128.f));
 		CHECK(sprite10->rectangle.BottomRight() == Vector2f(128.f, 256.f));
 		CHECK(sprite10->sprite_sheet->display_scale == 0.5f);
 
-		const auto* sprite11 = styleSheet->GetSprite("test11");
+		const auto* sprite11 = style_sheet->GetSprite("test11");
 		CHECK(sprite11 != nullptr);
-		CHECK(sprite11->sprite_sheet->name == "testSheetWithPathStringEncoding");
+		CHECK(sprite11->sprite_sheet->name == "test_sheet_with_path_string_encoding");
 		CHECK(sprite11->sprite_sheet->image_source == "/assets/test.tga");
 		CHECK(sprite11->rectangle.TopLeft() == Vector2f(128.f, 128.f));
 		CHECK(sprite11->rectangle.BottomRight() == Vector2f(256.f, 256.f));
 		CHECK(sprite11->sprite_sheet->display_scale == 0.5f);
 	}
 
-	RemoveContext("test");
-
-	Shutdown();
+	TestsShell::ShutdownShell();
 }

--- a/Tests/Source/UnitTests/StyleSheetParser.cpp
+++ b/Tests/Source/UnitTests/StyleSheetParser.cpp
@@ -68,10 +68,10 @@ TEST_CASE("style_sheet_parser.spritesheet")
 		style_sheet_container.LoadStyleSheetContainer(&spritesheet_stream, 0);
 
 		style_sheet_container.UpdateCompiledStyleSheet(context);
-		const auto* styleSheet = style_sheet_container.GetCompiledStyleSheet();
-		CHECK(styleSheet != nullptr);
+		const auto* style_sheet = style_sheet_container.GetCompiledStyleSheet();
+		CHECK(style_sheet != nullptr);
 
-		const auto* sprite00 = styleSheet->GetSprite("test00");
+		const auto* sprite00 = style_sheet->GetSprite("test00");
 		CHECK(sprite00 != nullptr);
 		CHECK(sprite00->sprite_sheet->name == "test_sheet");
 		CHECK(sprite00->sprite_sheet->image_source == "/assets/high_scores_alien_3.tga");
@@ -79,7 +79,7 @@ TEST_CASE("style_sheet_parser.spritesheet")
 		CHECK(sprite00->rectangle.BottomRight() == Vector2f(64.f, 64.f));
 		CHECK(sprite00->sprite_sheet->display_scale == 1.f);
 
-		const auto* sprite01 = styleSheet->GetSprite("test01");
+		const auto* sprite01 = style_sheet->GetSprite("test01");
 		CHECK(sprite01 != nullptr);
 		CHECK(sprite01->sprite_sheet->name == "test_sheet");
 		CHECK(sprite01->sprite_sheet->image_source == "/assets/high_scores_alien_3.tga");
@@ -87,7 +87,7 @@ TEST_CASE("style_sheet_parser.spritesheet")
 		CHECK(sprite01->rectangle.BottomRight() == Vector2f(128.f, 64.f));
 		CHECK(sprite01->sprite_sheet->display_scale == 1.f);
 
-		const auto* sprite10 = styleSheet->GetSprite("test10");
+		const auto* sprite10 = style_sheet->GetSprite("test10");
 		CHECK(sprite10 != nullptr);
 		CHECK(sprite10->sprite_sheet->name == "test_sheet");
 		CHECK(sprite10->sprite_sheet->image_source == "/assets/high_scores_alien_3.tga");
@@ -95,7 +95,7 @@ TEST_CASE("style_sheet_parser.spritesheet")
 		CHECK(sprite10->rectangle.BottomRight() == Vector2f(64.f, 128.f));
 		CHECK(sprite10->sprite_sheet->display_scale == 1.f);
 
-		const auto* sprite11 = styleSheet->GetSprite("test11");
+		const auto* sprite11 = style_sheet->GetSprite("test11");
 		CHECK(sprite11 != nullptr);
 		CHECK(sprite11->sprite_sheet->name == "test_sheet");
 		CHECK(sprite11->sprite_sheet->image_source == "/assets/high_scores_alien_3.tga");

--- a/Tests/Source/UnitTests/StyleSheetParser.cpp
+++ b/Tests/Source/UnitTests/StyleSheetParser.cpp
@@ -1,38 +1,37 @@
 /*
-* This source file is part of RmlUi, the HTML/CSS Interface Middleware
-*
-* For the latest information, see http://github.com/mikke89/RmlUi
-*
-* Copyright (c) 2008-2010 CodePoint Ltd, Shift Technology Ltd
-* Copyright (c) 2019-2024 The RmlUi Team, and contributors
-*
-* Permission is hereby granted, free of charge, to any person obtaining a copy
-* of this software and associated documentation files (the "Software"), to deal
-* in the Software without restriction, including without limitation the rights
-* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-* copies of the Software, and to permit persons to whom the Software is
-* furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included in
-* all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-* THE SOFTWARE.
-*
-*/
+ * This source file is part of RmlUi, the HTML/CSS Interface Middleware
+ *
+ * For the latest information, see http://github.com/mikke89/RmlUi
+ *
+ * Copyright (c) 2008-2010 CodePoint Ltd, Shift Technology Ltd
+ * Copyright (c) 2019-2024 The RmlUi Team, and contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
 
 #include "../Common/TestsInterface.h"
 #include <RmlUi/Core/Core.h>
-#include <RmlUi/Core/StyleSheetContainer.h>
-#include <RmlUi/Core/StyleSheet.h>
 #include <RmlUi/Core/Spritesheet.h>
 #include <RmlUi/Core/StreamMemory.h>
-
+#include <RmlUi/Core/StyleSheet.h>
+#include <RmlUi/Core/StyleSheetContainer.h>
 #include <doctest.h>
 
 static const char* spriteSheet = R"(
@@ -61,7 +60,6 @@ using namespace Rml;
 
 TEST_CASE("spritesheet")
 {
-
 	TestsSystemInterface system_interface;
 	TestsRenderInterface render_interface;
 
@@ -79,7 +77,6 @@ TEST_CASE("spritesheet")
 		styleSheetContainer.UpdateCompiledStyleSheet(context);
 		const auto* styleSheet = styleSheetContainer.GetCompiledStyleSheet();
 		CHECK(styleSheet != nullptr);
-
 
 		const auto* sprite00 = styleSheet->GetSprite("test00");
 		CHECK(sprite00 != nullptr);
@@ -112,7 +109,6 @@ TEST_CASE("spritesheet")
 		CHECK(sprite11->rectangle.TopLeft() == Vector2f(64.f, 64.f));
 		CHECK(sprite11->rectangle.BottomRight() == Vector2f(128.f, 128.f));
 		CHECK(sprite11->sprite_sheet->display_scale == 1.f);
-
 	}
 	RemoveContext("test");
 
@@ -121,7 +117,6 @@ TEST_CASE("spritesheet")
 
 TEST_CASE("spritesheet with path string encoding")
 {
-
 	TestsSystemInterface system_interface;
 	TestsRenderInterface render_interface;
 

--- a/Tests/Source/UnitTests/StyleSheetParser.cpp
+++ b/Tests/Source/UnitTests/StyleSheetParser.cpp
@@ -69,13 +69,13 @@ TEST_CASE("spritesheet")
 	Initialise();
 
 	{
-		StyleSheetContainer styleSheetContainer;
+		StyleSheetContainer style_sheet_container;
 		StreamMemory spriteSheetStream{reinterpret_cast<const byte*>(spriteSheet), strlen(spriteSheet)};
-		styleSheetContainer.LoadStyleSheetContainer(&spriteSheetStream, 0);
+		style_sheet_container.LoadStyleSheetContainer(&spriteSheetStream, 0);
 
 		Context* context = CreateContext("test", Vector2i(1024, 768));
-		styleSheetContainer.UpdateCompiledStyleSheet(context);
-		const auto* styleSheet = styleSheetContainer.GetCompiledStyleSheet();
+		style_sheet_container.UpdateCompiledStyleSheet(context);
+		const auto* styleSheet = style_sheet_container.GetCompiledStyleSheet();
 		CHECK(styleSheet != nullptr);
 
 		const auto* sprite00 = styleSheet->GetSprite("test00");
@@ -126,13 +126,13 @@ TEST_CASE("spritesheet with path string encoding")
 	Initialise();
 
 	{
-		StyleSheetContainer styleSheetContainer;
+		StyleSheetContainer style_sheet_container;
 		StreamMemory spriteSheetStream{reinterpret_cast<const byte*>(spriteSheetWithPathStringEncoding), strlen(spriteSheetWithPathStringEncoding)};
-		styleSheetContainer.LoadStyleSheetContainer(&spriteSheetStream, 0);
+		style_sheet_container.LoadStyleSheetContainer(&spriteSheetStream, 0);
 
 		Context* context = CreateContext("test", Vector2i(1024, 768));
-		styleSheetContainer.UpdateCompiledStyleSheet(context);
-		const auto* styleSheet = styleSheetContainer.GetCompiledStyleSheet();
+		style_sheet_container.UpdateCompiledStyleSheet(context);
+		const auto* styleSheet = style_sheet_container.GetCompiledStyleSheet();
 		CHECK(styleSheet != nullptr);
 
 		const auto* sprite00 = styleSheet->GetSprite("test00");

--- a/Tests/Source/UnitTests/StyleSheetParser.cpp
+++ b/Tests/Source/UnitTests/StyleSheetParser.cpp
@@ -1,0 +1,179 @@
+/*
+* This source file is part of RmlUi, the HTML/CSS Interface Middleware
+*
+* For the latest information, see http://github.com/mikke89/RmlUi
+*
+* Copyright (c) 2008-2010 CodePoint Ltd, Shift Technology Ltd
+* Copyright (c) 2019-2024 The RmlUi Team, and contributors
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+* THE SOFTWARE.
+*
+*/
+
+#include "../Common/TestsInterface.h"
+#include <RmlUi/Core/Core.h>
+#include <RmlUi/Core/StyleSheetContainer.h>
+#include <RmlUi/Core/StyleSheet.h>
+#include <RmlUi/Core/Spritesheet.h>
+#include <RmlUi/Core/StreamMemory.h>
+
+#include <doctest.h>
+
+static const char* spriteSheet = R"(
+@spritesheet testSheet {
+	src: /assets/high_scores_alien_3.tga;
+	test00: 0px 0px 64px 64px;
+	test01: 64px 0px 64px 64px;
+	test10: 0px 64px 64px 64px;
+	test11: 64px 64px 64px 64px;
+	resolution: 1x;
+}
+)";
+
+static const char* spriteSheetWithPathStringEncoding = R"(
+@spritesheet testSheetWithPathStringEncoding {
+	src: "/assets/test.tga";
+	test00: 0px 0px 128px 128px;
+	test01: 128px 0px 128px 128px;
+	test10: 0px 128px 128px 128px;
+	test11: 128px 128px 128px 128px;
+	resolution: 2x;
+}
+)";
+
+using namespace Rml;
+
+TEST_CASE("spritesheet")
+{
+
+	TestsSystemInterface system_interface;
+	TestsRenderInterface render_interface;
+
+	SetRenderInterface(&render_interface);
+	SetSystemInterface(&system_interface);
+
+	Initialise();
+
+	{
+		StyleSheetContainer styleSheetContainer;
+		StreamMemory spriteSheetStream{reinterpret_cast<const byte*>(spriteSheet), strlen(spriteSheet)};
+		styleSheetContainer.LoadStyleSheetContainer(&spriteSheetStream, 0);
+
+		Context* context = CreateContext("test", Vector2i(1024, 768));
+		styleSheetContainer.UpdateCompiledStyleSheet(context);
+		const auto* styleSheet = styleSheetContainer.GetCompiledStyleSheet();
+		CHECK(styleSheet != nullptr);
+
+
+		const auto* sprite00 = styleSheet->GetSprite("test00");
+		CHECK(sprite00 != nullptr);
+		CHECK(sprite00->sprite_sheet->name == "testSheet");
+		CHECK(sprite00->sprite_sheet->image_source == "/assets/high_scores_alien_3.tga");
+		CHECK(sprite00->rectangle.TopLeft() == Vector2f(0.f, 0.f));
+		CHECK(sprite00->rectangle.BottomRight() == Vector2f(64.f, 64.f));
+		CHECK(sprite00->sprite_sheet->display_scale == 1.f);
+
+		const auto* sprite01 = styleSheet->GetSprite("test01");
+		CHECK(sprite01 != nullptr);
+		CHECK(sprite01->sprite_sheet->name == "testSheet");
+		CHECK(sprite01->sprite_sheet->image_source == "/assets/high_scores_alien_3.tga");
+		CHECK(sprite01->rectangle.TopLeft() == Vector2f(64.f, 0.f));
+		CHECK(sprite01->rectangle.BottomRight() == Vector2f(128.f, 64.f));
+		CHECK(sprite01->sprite_sheet->display_scale == 1.f);
+
+		const auto* sprite10 = styleSheet->GetSprite("test10");
+		CHECK(sprite10 != nullptr);
+		CHECK(sprite10->sprite_sheet->name == "testSheet");
+		CHECK(sprite10->sprite_sheet->image_source == "/assets/high_scores_alien_3.tga");
+		CHECK(sprite10->rectangle.TopLeft() == Vector2f(0.f, 64.f));
+		CHECK(sprite10->rectangle.BottomRight() == Vector2f(64.f, 128.f));
+		CHECK(sprite10->sprite_sheet->display_scale == 1.f);
+
+		const auto* sprite11 = styleSheet->GetSprite("test11");
+		CHECK(sprite11 != nullptr);
+		CHECK(sprite11->sprite_sheet->name == "testSheet");
+		CHECK(sprite11->sprite_sheet->image_source == "/assets/high_scores_alien_3.tga");
+		CHECK(sprite11->rectangle.TopLeft() == Vector2f(64.f, 64.f));
+		CHECK(sprite11->rectangle.BottomRight() == Vector2f(128.f, 128.f));
+		CHECK(sprite11->sprite_sheet->display_scale == 1.f);
+
+	}
+	RemoveContext("test");
+
+	Shutdown();
+}
+
+TEST_CASE("spritesheet with path string encoding")
+{
+
+	TestsSystemInterface system_interface;
+	TestsRenderInterface render_interface;
+
+	SetRenderInterface(&render_interface);
+	SetSystemInterface(&system_interface);
+
+	Initialise();
+
+	{
+		StyleSheetContainer styleSheetContainer;
+		StreamMemory spriteSheetStream{reinterpret_cast<const byte*>(spriteSheetWithPathStringEncoding), strlen(spriteSheetWithPathStringEncoding)};
+		styleSheetContainer.LoadStyleSheetContainer(&spriteSheetStream, 0);
+
+		Context* context = CreateContext("test", Vector2i(1024, 768));
+		styleSheetContainer.UpdateCompiledStyleSheet(context);
+		const auto* styleSheet = styleSheetContainer.GetCompiledStyleSheet();
+		CHECK(styleSheet != nullptr);
+
+		const auto* sprite00 = styleSheet->GetSprite("test00");
+		CHECK(sprite00 != nullptr);
+		CHECK(sprite00->sprite_sheet->name == "testSheetWithPathStringEncoding");
+		CHECK(sprite00->sprite_sheet->image_source == "/assets/test.tga");
+		CHECK(sprite00->rectangle.TopLeft() == Vector2f(0.f, 0.f));
+		CHECK(sprite00->rectangle.BottomRight() == Vector2f(128.f, 128.f));
+		CHECK(sprite00->sprite_sheet->display_scale == 0.5f);
+
+		const auto* sprite01 = styleSheet->GetSprite("test01");
+		CHECK(sprite01 != nullptr);
+		CHECK(sprite01->sprite_sheet->name == "testSheetWithPathStringEncoding");
+		CHECK(sprite01->sprite_sheet->image_source == "/assets/test.tga");
+		CHECK(sprite01->rectangle.TopLeft() == Vector2f(128.f, 0.f));
+		CHECK(sprite01->rectangle.BottomRight() == Vector2f(256.f, 128.f));
+		CHECK(sprite01->sprite_sheet->display_scale == 0.5f);
+
+		const auto* sprite10 = styleSheet->GetSprite("test10");
+		CHECK(sprite10 != nullptr);
+		CHECK(sprite10->sprite_sheet->name == "testSheetWithPathStringEncoding");
+		CHECK(sprite10->sprite_sheet->image_source == "/assets/test.tga");
+		CHECK(sprite10->rectangle.TopLeft() == Vector2f(0.f, 128.f));
+		CHECK(sprite10->rectangle.BottomRight() == Vector2f(128.f, 256.f));
+		CHECK(sprite10->sprite_sheet->display_scale == 0.5f);
+
+		const auto* sprite11 = styleSheet->GetSprite("test11");
+		CHECK(sprite11 != nullptr);
+		CHECK(sprite11->sprite_sheet->name == "testSheetWithPathStringEncoding");
+		CHECK(sprite11->sprite_sheet->image_source == "/assets/test.tga");
+		CHECK(sprite11->rectangle.TopLeft() == Vector2f(128.f, 128.f));
+		CHECK(sprite11->rectangle.BottomRight() == Vector2f(256.f, 256.f));
+		CHECK(sprite11->sprite_sheet->display_scale == 0.5f);
+	}
+
+	RemoveContext("test");
+
+	Shutdown();
+}


### PR DESCRIPTION
Use a string parser for sprite sheet src property to enable "path" in addition to path as property value

BUG:
https://github.com/mikke89/RmlUi/issues/571

I didn't find a unit test for the sprite sheet. Maybe this should also be added?

