### PR TITLE
Fix read access violation in the `bitmapfont` demo

### DIFF
--- a/Samples/basic/bitmapfont/src/main.cpp
+++ b/Samples/basic/bitmapfont/src/main.cpp
@@ -115,11 +115,11 @@ int main(int /*argc*/, char** /*argv*/)
 		Backend::PresentFrame();
 	}
 
-	// Shutdown RmlUi.
-	Rml::Shutdown();
-
 	// Destroy the font interface before taking down the shell, this way font textures are properly released through the render interface.
 	font_interface.reset();
+
+	// Shutdown RmlUi.
+	Rml::Shutdown();
 
 	Backend::Shutdown();
 	Shell::Shutdown();


### PR DESCRIPTION
The `font_interface` should be cleared before `Rml::Shutdown`
A valid `render_interface` (non nullptr) is required for unloading `TextureResource` in the `font_interface`

https://github.com/mikke89/RmlUi/blob/c54ef6ebc1f3eedf8c70a18fb8266ba97b96d4c7/Samples/basic/bitmapfont/src/FontEngineBitmap.cpp#L43
