### PR TITLE
Add space-evenly property value for justify-content and align-content

### DIFF
--- a/Include/RmlUi/Core/StyleTypes.h
+++ b/Include/RmlUi/Core/StyleTypes.h
@@ -150,13 +150,13 @@ namespace Style {
 	enum class OriginX : uint8_t { Left, Center, Right };
 	enum class OriginY : uint8_t { Top, Center, Bottom };
 
-	enum class AlignContent : uint8_t { FlexStart, FlexEnd, Center, SpaceBetween, SpaceAround, Stretch };
+	enum class AlignContent : uint8_t { FlexStart, FlexEnd, Center, SpaceBetween, SpaceAround, SpaceEvenly, Stretch };
 	enum class AlignItems : uint8_t { FlexStart, FlexEnd, Center, Baseline, Stretch };
 	enum class AlignSelf : uint8_t { Auto, FlexStart, FlexEnd, Center, Baseline, Stretch };
 	using FlexBasis = LengthPercentageAuto;
 	enum class FlexDirection : uint8_t { Row, RowReverse, Column, ColumnReverse };
 	enum class FlexWrap : uint8_t { Nowrap, Wrap, WrapReverse };
-	enum class JustifyContent : uint8_t { FlexStart, FlexEnd, Center, SpaceBetween, SpaceAround };
+	enum class JustifyContent : uint8_t { FlexStart, FlexEnd, Center, SpaceBetween, SpaceAround, SpaceEvenly };
 
 	enum class Nav : uint8_t { None, Auto, Horizontal, Vertical };
 

--- a/Source/Core/Layout/FlexFormattingContext.cpp
+++ b/Source/Core/Layout/FlexFormattingContext.cpp
@@ -591,6 +591,21 @@ void FlexFormattingContext::Format(Vector2f& flex_resulting_content_size, Vector
 					}
 				}
 				break;
+				case JustifyContent::SpaceEvenly:
+				{
+					const float space_per_edge = remaining_free_space / float(2 * (num_items + 1));
+					for (int i = 0; i < num_items; i++)
+					{
+						FlexItem& item = line.items[i];
+						item.main_auto_margin_size_a = space_per_edge;
+						item.main_auto_margin_size_b = space_per_edge;
+						if (i == 0)
+							item.main_auto_margin_size_a *= 2.0f;
+						else if (i == num_items - 1)
+							item.main_auto_margin_size_b *= 2.0f;
+					}
+				}
+				break;
 				}
 			}
 		}
@@ -842,6 +857,21 @@ void FlexFormattingContext::Format(Vector2f& flex_resulting_content_size, Vector
 				{
 					line.cross_spacing_a = space_per_edge;
 					line.cross_spacing_b = space_per_edge;
+				}
+			}
+			break;
+			case AlignContent::SpaceEvenly:
+			{
+				const float space_per_edge = remaining_free_space / float(2 * (num_lines + 1));
+				for (int i = 0; i < num_lines; i++)
+				{
+					FlexLine& line = container.lines[i];
+					line.cross_spacing_a = space_per_edge;
+					line.cross_spacing_b = space_per_edge;
+					if (i == 0)
+						line.cross_spacing_a *= 2.0f;
+					else if (i == num_lines - 1)
+						line.cross_spacing_b *= 2.0f;
 				}
 			}
 			break;

--- a/Source/Core/StyleSheetSpecification.cpp
+++ b/Source/Core/StyleSheetSpecification.cpp
@@ -414,7 +414,7 @@ void StyleSheetSpecification::RegisterDefaultProperties()
 	RegisterProperty(PropertyId::FillImage, "fill-image", "", false, false).AddParser("string");
 
 	// Flexbox
-	RegisterProperty(PropertyId::AlignContent, "align-content", "stretch", false, true).AddParser("keyword", "flex-start, flex-end, center, space-between, space-around, stretch");
+	RegisterProperty(PropertyId::AlignContent, "align-content", "stretch", false, true).AddParser("keyword", "flex-start, flex-end, center, space-between, space-around, space-evenly, stretch");
 	RegisterProperty(PropertyId::AlignItems, "align-items", "stretch", false, true).AddParser("keyword", "flex-start, flex-end, center, baseline, stretch");
 	RegisterProperty(PropertyId::AlignSelf, "align-self", "auto", false, true).AddParser("keyword", "auto, flex-start, flex-end, center, baseline, stretch");
 	
@@ -424,7 +424,7 @@ void StyleSheetSpecification::RegisterDefaultProperties()
 	RegisterProperty(PropertyId::FlexGrow, "flex-grow", "0", false, true).AddParser("number");
 	RegisterProperty(PropertyId::FlexShrink, "flex-shrink", "1", false, true).AddParser("number");
 	RegisterProperty(PropertyId::FlexWrap, "flex-wrap", "nowrap", false, true).AddParser("keyword", "nowrap, wrap, wrap-reverse");
-	RegisterProperty(PropertyId::JustifyContent, "justify-content", "flex-start", false, true).AddParser("keyword", "flex-start, flex-end, center, space-between, space-around");
+	RegisterProperty(PropertyId::JustifyContent, "justify-content", "flex-start", false, true).AddParser("keyword", "flex-start, flex-end, center, space-between, space-around, space-evenly");
 
 	RegisterShorthand(ShorthandId::Flex, "flex", "flex-grow, flex-shrink, flex-basis", ShorthandType::Flex);
 	RegisterShorthand(ShorthandId::FlexFlow, "flex-flow", "flex-direction, flex-wrap", ShorthandType::FallThrough);

--- a/Tests/Tools/convert_css_test_suite_to_rml.py
+++ b/Tests/Tools/convert_css_test_suite_to_rml.py
@@ -243,8 +243,6 @@ def process_file(in_file):
 
 		line = re.sub(r'flex: none;', r'flex: 0 0 auto;', line, flags = re.IGNORECASE)
 		line = re.sub(r'align-content:\s*(start|end)', r'align-content: flex-\1', line, flags = re.IGNORECASE)
-		line = re.sub(r'align-content:\s*space-evenly', r'align-content: space-around', line, flags = re.IGNORECASE)
-		line = re.sub(r'justify-content:\s*space-evenly', r'justify-content: space-around', line, flags = re.IGNORECASE)
 		line = re.sub(r'justify-content:\s*left', r'justify-content: flex-start', line, flags = re.IGNORECASE)
 		line = re.sub(r'justify-content:\s*right', r'justify-content: flex-end', line, flags = re.IGNORECASE)
 		line = re.sub(r'table-layout:[^;}]*[;}]', r'', line, flags = re.IGNORECASE)


### PR DESCRIPTION
This is a small change, adding support for `space-evenly` to the flex-box properties [`justify-content`](https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content) and [`align-content`](https://developer.mozilla.org/en-US/docs/Web/CSS/align-content). It is similar to `space-around`, but the gaps between the items and the container edges are equal to the gaps between the items (instead of the gaps between the edges and items being half the size of the space of the gaps between items).

I couldn't find any unit tests that explicitly check all of the flex-box spacings, but I did test it visually, and it works nicely.

**`space-around`**:
![space-around](https://github.com/mikke89/RmlUi/assets/39696157/4f2fdcda-9946-4b85-8787-202ced71b7a0)

**`space-evenly`**:
![space-evenly](https://github.com/mikke89/RmlUi/assets/39696157/d7ff366c-51b7-4c1a-bc57-d8e88e4c19f1)
