### PR TITLE
Fix opposite intention of AllTexturesReleased conditional check

### DIFF
--- a/Source/Core/TextureDatabase.cpp
+++ b/Source/Core/TextureDatabase.cpp
@@ -151,11 +151,11 @@ bool TextureDatabase::AllTexturesReleased()
 	if (texture_database)
 	{
 		for (const auto& texture : texture_database->textures)
-			if (!texture.second->IsLoaded())
+			if (texture.second->IsLoaded())
 				return false;
 
 		for (const auto& texture : texture_database->callback_textures)
-			if (!texture->IsLoaded())
+			if (texture->IsLoaded())
 				return false;
 	}
 


### PR DESCRIPTION
Change is pretty intuitive, the current function will return true if any texture is released when it should be the other way around. The fix is to just change the conditional logic to return true if a texture is still loaded instead.
This hasn't usually been caught since during shutdown the texture maps are usually already erased.