### PR TITLE
Be consistent about using non-namespaced versions of standard integer types, see #470

### DIFF
--- a/Backends/RmlUi_Renderer_GL3.cpp
+++ b/Backends/RmlUi_Renderer_GL3.cpp
@@ -452,7 +452,7 @@ public:
 	void Insert(ProgramId id, UniformId uniform, GLint location) { map[ToKey(id, uniform)] = location; }
 
 private:
-	using Key = std::uint64_t;
+	using Key = uint64_t;
 	Key ToKey(ProgramId id, UniformId uniform) const { return (static_cast<Key>(id) << 32) | static_cast<Key>(uniform); }
 	Rml::UnorderedMap<Key, GLint> map;
 };

--- a/Tests/Dependencies/doctest/doctest.h
+++ b/Tests/Dependencies/doctest/doctest.h
@@ -3371,7 +3371,7 @@ namespace timer_large_integer
 #if defined(DOCTEST_PLATFORM_WINDOWS)
     using type = ULONGLONG;
 #else // DOCTEST_PLATFORM_WINDOWS
-    using type = std::uint64_t;
+    using type = uint64_t;
 #endif // DOCTEST_PLATFORM_WINDOWS
 }
 


### PR DESCRIPTION
I have tested Backends/RmlUi_Renderer_GL3.cpp, and confirmed that it does not compile before the changes (for me) and does compile after the changes (for me). I used `cmake -DBUILD_TESTING=ON -DBUILD_SAMPLES=ON -DSAMPLES_BACKEND=SDL_GL3 -DCMAKE_TOOLCHAIN_FILE=[OMITTED] ..` to build with, the toolchain file points to a vcpkg folder that includes an installed SDL2 package.

I have **not tested** Tests/Dependencies/doctest/doctest.h, I do not know how to compile that code. I am running on Linux, in case it matters. Maybe `DOCTEST_PLATFORM_WINDOWS` has to not be defined to test it.

See #470 and https://github.com/mikke89/RmlUi/commit/313cbab6570a45fba1a08534da7c3b46b812fa48 for general problem and earlier fix.