### PR TITLE
Pass the composition to TextInputContext via a parameter

### DIFF
--- a/Backends/RmlUi_Platform_Win32.cpp
+++ b/Backends/RmlUi_Platform_Win32.cpp
@@ -698,7 +698,7 @@ void TextInputMethodEditor_Win32::ConfirmComposition(Rml::StringView composition
 	if (input_context != nullptr)
 	{
 		input_context->SetCompositionRange(composition_range_start, composition_range_end);
-		input_context->CommitComposition();
+		input_context->CommitComposition(Rml::String(composition));
 	}
 
 	// Move the cursor to the end of the string.

--- a/Backends/RmlUi_Platform_Win32.cpp
+++ b/Backends/RmlUi_Platform_Win32.cpp
@@ -698,7 +698,7 @@ void TextInputMethodEditor_Win32::ConfirmComposition(Rml::StringView composition
 	if (input_context != nullptr)
 	{
 		input_context->SetCompositionRange(composition_range_start, composition_range_end);
-		input_context->CommitComposition(Rml::String(composition));
+		input_context->CommitComposition(composition);
 	}
 
 	// Move the cursor to the end of the string.

--- a/Include/RmlUi/Core/TextInputContext.h
+++ b/Include/RmlUi/Core/TextInputContext.h
@@ -74,6 +74,7 @@ public:
 	/// @param[in] text The string to replace the character range with.
 	/// @param[in] start The first character to be replaced.
 	/// @param[in] end The first character *after* the range.
+	/// @note This method does not respect internal restrictions, such as the maximum length.
 	virtual void SetText(StringView text, int start, int end) = 0;
 
 	/// Update the range of the text being composed (for IME).
@@ -81,8 +82,10 @@ public:
 	/// @param[in] end The first character *after* the range.
 	virtual void SetCompositionRange(int start, int end) = 0;
 
-	/// Commit the current IME composition.
-	virtual void CommitComposition() = 0;
+	/// Commit an composition string (from IME), and respect internal restrictions (e.g., the maximum length).
+	/// @param[in] composition The string to replace the composition range with.
+	/// @note If the composition range equals to [0, 0], it takes no action.
+	virtual void CommitComposition(String composition) = 0;
 };
 
 } // namespace Rml

--- a/Include/RmlUi/Core/TextInputContext.h
+++ b/Include/RmlUi/Core/TextInputContext.h
@@ -85,7 +85,7 @@ public:
 	/// Commit an composition string (from IME), and respect internal restrictions (e.g., the maximum length).
 	/// @param[in] composition The string to replace the composition range with.
 	/// @note If the composition range equals to [0, 0], it takes no action.
-	virtual void CommitComposition(String composition) = 0;
+	virtual void CommitComposition(StringView composition) = 0;
 };
 
 } // namespace Rml

--- a/Source/Core/Elements/WidgetTextInput.cpp
+++ b/Source/Core/Elements/WidgetTextInput.cpp
@@ -90,7 +90,7 @@ public:
 	void SetCursorPosition(int position) override;
 	void SetText(StringView text, int start, int end) override;
 	void SetCompositionRange(int start, int end) override;
-	void CommitComposition(String composition) override;
+	void CommitComposition(StringView composition) override;
 
 private:
 	TextInputHandler* handler;
@@ -145,7 +145,7 @@ void WidgetTextInputContext::SetCompositionRange(int start, int end)
 	owner->SetCompositionRange(start, end);
 }
 
-void WidgetTextInputContext::CommitComposition(String composition)
+void WidgetTextInputContext::CommitComposition(StringView composition)
 {
 	int start_byte, end_byte;
 	owner->GetCompositionRange(start_byte, end_byte);
@@ -169,12 +169,13 @@ void WidgetTextInputContext::CommitComposition(String composition)
 		if (value_length + composition_length - (start - end) > owner->GetMaxLength())
 		{
 			int new_length = owner->GetMaxLength() - (value_length - composition_length);
-			composition.erase(StringUtilities::ConvertCharacterOffsetToByteOffset(composition, new_length));
+			int new_length_byte = StringUtilities::ConvertCharacterOffsetToByteOffset(composition, new_length);
+			composition = StringView(composition.begin(), composition.begin() + new_length_byte);
 		}
 	}
 
 	RMLUI_ASSERTMSG(end_byte >= start_byte, "Invalid end character offset.");
-	value.replace(start_byte, end_byte - start_byte, composition.data(), composition.size());
+	value.replace(start_byte, end_byte - start_byte, composition.begin(), composition.size());
 
 	element->SetValue(value);
 }

--- a/Source/Core/Elements/WidgetTextInput.cpp
+++ b/Source/Core/Elements/WidgetTextInput.cpp
@@ -90,13 +90,12 @@ public:
 	void SetCursorPosition(int position) override;
 	void SetText(StringView text, int start, int end) override;
 	void SetCompositionRange(int start, int end) override;
-	void CommitComposition() override;
+	void CommitComposition(String composition) override;
 
 private:
 	TextInputHandler* handler;
 	WidgetTextInput* owner;
 	ElementFormControl* element;
-	String composition;
 };
 
 WidgetTextInputContext::WidgetTextInputContext(TextInputHandler* handler, WidgetTextInput* owner, ElementFormControl* element) :
@@ -139,8 +138,6 @@ void WidgetTextInputContext::SetText(StringView text, int start, int end)
 	value.replace(start, end - start, text.begin(), text.size());
 
 	element->SetValue(value);
-
-	composition = String(text);
 }
 
 void WidgetTextInputContext::SetCompositionRange(int start, int end)
@@ -148,7 +145,7 @@ void WidgetTextInputContext::SetCompositionRange(int start, int end)
 	owner->SetCompositionRange(start, end);
 }
 
-void WidgetTextInputContext::CommitComposition()
+void WidgetTextInputContext::CommitComposition(String composition)
 {
 	int start_byte, end_byte;
 	owner->GetCompositionRange(start_byte, end_byte);


### PR DESCRIPTION
We previously used an internal state for this, which is unclear from the API. Furthermore, this was wrong and outdated after all the changes made to TextInputContext throughout the time; a method called "SetText" should not be used to set any composition, as it may be used for purposes other than just IME.

I noticed this issue when writing the documentation. 😄 