### PR TITLE
Use HarfBuzz's advances instead of FreeType's

### DIFF
--- a/Samples/basic/harfbuzz/src/FontEngineInterfaceHarfBuzz.cpp
+++ b/Samples/basic/harfbuzz/src/FontEngineInterfaceHarfBuzz.cpp
@@ -45,8 +45,8 @@ bool FontEngineInterfaceHarfBuzz::LoadFontFace(const String& file_name, int face
 	return FontProvider::LoadFontFace(file_name, face_index, fallback_face, weight);
 }
 
-bool FontEngineInterfaceHarfBuzz::LoadFontFace(Span<const byte> data, int face_index, const String& font_family, Style::FontStyle style, Style::FontWeight weight,
-	bool fallback_face)
+bool FontEngineInterfaceHarfBuzz::LoadFontFace(Span<const byte> data, int face_index, const String& font_family, Style::FontStyle style,
+	Style::FontWeight weight, bool fallback_face)
 {
 	return FontProvider::LoadFontFace(data, face_index, font_family, style, weight, fallback_face);
 }

--- a/Samples/basic/harfbuzz/src/FontFaceHandleHarfBuzz.h
+++ b/Samples/basic/harfbuzz/src/FontFaceHandleHarfBuzz.h
@@ -119,12 +119,6 @@ private:
 	// Build and append fallback glyph to 'fallback_glyphs'.
 	bool AppendFallbackGlyph(Character character);
 
-	// Build a kerning cache for common characters.
-	void FillKerningPairCache();
-
-	// Return the kerning for a codepoint pair.
-	int GetKerning(FontGlyphIndex lhs, FontGlyphIndex rhs) const;
-
 	/// Retrieve a glyph from the given code index, building and appending a new glyph if not already built.
 	/// @param[in] glyph_index  The glyph index.
 	/// @param[in-out] character  The character codepoint, can be changed e.g. to the replacement character if no glyph is found..
@@ -168,13 +162,6 @@ private:
 	// Each font layer that generated geometry or textures, indexed by the font-effect's fingerprint key.
 	FontLayerCache layer_cache;
 
-	// Pre-cache kerning pairs for some ascii subset of all characters.
-	using AsciiPair = uint16_t;
-	using KerningIntType = int16_t;
-	using KerningPairs = UnorderedMap<AsciiPair, KerningIntType>;
-	KerningPairs kerning_pair_cache;
-
-	bool has_kerning = false;
 	bool is_layers_dirty = false;
 	int version = 0;
 

--- a/Samples/basic/harfbuzz/src/FreeTypeInterface.cpp
+++ b/Samples/basic/harfbuzz/src/FreeTypeInterface.cpp
@@ -80,32 +80,6 @@ bool AppendGlyph(FontFaceHandleFreetype face, int font_size, FontGlyphIndex glyp
 	return true;
 }
 
-int GetKerning(FontFaceHandleFreetype face, int font_size, FontGlyphIndex lhs, FontGlyphIndex rhs)
-{
-	FT_Face ft_face = (FT_Face)face;
-
-	RMLUI_ASSERT(FT_HAS_KERNING(ft_face));
-
-	// Set face size again in case it was used at another size in another font face handle.
-	// Font size value of zero assumes it is already set.
-	if (font_size > 0)
-	{
-		float bitmap_scaling_factor = 1.0f;
-		if (!SetFontSize(ft_face, font_size, bitmap_scaling_factor) || bitmap_scaling_factor != 1.0f)
-			return 0;
-	}
-
-	FT_Vector ft_kerning;
-
-	FT_Error ft_error = FT_Get_Kerning(ft_face, lhs, rhs, FT_KERNING_DEFAULT, &ft_kerning);
-
-	if (ft_error)
-		return 0;
-
-	int kerning = ft_kerning.x >> 6;
-	return kerning;
-}
-
 FontGlyphIndex GetGlyphIndexFromCharacter(FontFaceHandleFreetype face, Character character)
 {
 	return FT_Get_Char_Index((FT_Face)face, (FT_ULong)character);

--- a/Samples/basic/harfbuzz/src/FreeTypeInterface.h
+++ b/Samples/basic/harfbuzz/src/FreeTypeInterface.h
@@ -42,10 +42,6 @@ bool InitialiseFaceHandle(FontFaceHandleFreetype face, int font_size, FontGlyphM
 // Build a new glyph representing the given glyph index and append to 'glyphs'.
 bool AppendGlyph(FontFaceHandleFreetype face, int font_size, FontGlyphIndex glyph_index, Character character, FontGlyphMap& glyphs);
 
-// Returns the kerning between two characters given by glyph indices.
-// 'font_size' value of zero assumes the font size is already set on the face, and skips this step for performance reasons.
-int GetKerning(FontFaceHandleFreetype face, int font_size, FontGlyphIndex lhs, FontGlyphIndex rhs);
-
 // Returns the corresponding glyph index from a character code.
 FontGlyphIndex GetGlyphIndexFromCharacter(FontFaceHandleFreetype face, Character character);
 


### PR DESCRIPTION
This pull request alters the HarfBuzz sample to use the shaped advances instead of FreeTypes. The main reason to do this is because it provides more accurate kerning.

OpenType has two main ways of providing kerning information: either with a simple `kern` table or with the more modern `GPOS` feature. `GPOS` is much more sophisticated and can contain context-dependent information (such as position in a string or locale data). Some fonts might support both, and some will only support `GPOS`.

FreeType can only retrieve kerning from the `kern` table, whereäs HarfBuzz can retrieve kerning from either option (which it then adds to the advances), so it is more correct to use HarfBuzz's advances where possible.

This PR also removes all the old FreeType kerning functions from the sample (which are no longer needed).