### PR TITLE
Compute shrink-to-fit width for tables

### DIFF
--- a/Source/Core/Layout/ContainerBox.cpp
+++ b/Source/Core/Layout/ContainerBox.cpp
@@ -32,6 +32,7 @@
 #include "../../../Include/RmlUi/Core/ElementScroll.h"
 #include "../../../Include/RmlUi/Core/Profiling.h"
 #include "FlexFormattingContext.h"
+#include "TableFormattingContext.h"
 #include "FormattingContext.h"
 #include "LayoutDetails.h"
 #include <algorithm>
@@ -305,12 +306,12 @@ void TableWrapper::Close(const Vector2f content_overflow_size, const Box& box, f
 
 float TableWrapper::GetShrinkToFitWidth() const
 {
-	// We don't currently support shrink-to-fit layout of tables. However, for the trivial case of a fixed width, we
-	// simply return that.
+	// For the trivial case of a fixed width, we simply return that.
 	if (element->GetComputedValues().width().type == Style::Width::Type::Length)
 		return box.GetSize().x;
 
-	return 0.0f;
+    // Infer shrink-to-fit width from the intrinsic width of the element.
+	return TableFormattingContext::GetMaxContentSize(element).x;
 }
 
 String TableWrapper::DebugDumpTree(int depth) const

--- a/Source/Core/Layout/LayoutDetails.cpp
+++ b/Source/Core/Layout/LayoutDetails.cpp
@@ -257,13 +257,6 @@ float LayoutDetails::GetShrinkToFitWidth(Element* element, Vector2f containing_b
 		return box.GetSize().x;
 	}
 
-	// Currently we don't support shrink-to-fit width for tables. Just return a zero-sized width.
-	const Style::Display display = element->GetDisplay();
-	if (display == Style::Display::Table || display == Style::Display::InlineTable)
-	{
-		return 0.f;
-	}
-
 	// Use a large size for the box content width, so that it is practically unconstrained. This makes the formatting
 	// procedure act as if under a maximum content constraint. Children with percentage sizing values may be scaled
 	// based on this width (such as 'width' or 'margin'), if so, the layout is considered undefined like in CSS 2.
@@ -453,7 +446,7 @@ void LayoutDetails::BuildBoxWidth(Box& box, const ComputedValues& computed, floa
 		// See CSS 2.1 section 10.3.7 for when this should be applied.
 		const bool shrink_to_fit = !replaced_element &&
 			((computed.float_() != Style::Float::None) || (absolutely_positioned && inset_auto) ||
-				(computed.display() == Style::Display::InlineBlock || computed.display() == Style::Display::InlineFlex));
+				(computed.display() == Style::Display::InlineBlock || computed.display() == Style::Display::InlineFlex || computed.display() == Style::Display::InlineTable));
 
 		if (!shrink_to_fit)
 		{

--- a/Source/Core/Layout/TableFormattingContext.h
+++ b/Source/Core/Layout/TableFormattingContext.h
@@ -48,6 +48,9 @@ class TableFormattingContext final : public FormattingContext {
 public:
 	static UniquePtr<LayoutBox> Format(ContainerBox* parent_container, Element* element, const Box* override_initial_box);
 
+	/// Conputes max-content size for a table element.
+	static Vector2f GetMaxContentSize(Element* element);
+
 private:
 	TableFormattingContext() = default;
 


### PR DESCRIPTION
Close #671.

I'm mostly referencing #559 and the `TableFormattingContext::Format` implementation. Maybe there are some unnecessary calculations as I'm still not very familiar with the codebase (and C++).

In my test, the example in #671 displays correctly in a flexbox:

![image](https://github.com/user-attachments/assets/6d1f40ea-65ee-42b3-b7aa-9e728a2fcac3)
