### PR TITLE
RCSS: support hsl and hsla colors

### DIFF
--- a/Tests/Source/UnitTests/Properties.cpp
+++ b/Tests/Source/UnitTests/Properties.cpp
@@ -143,6 +143,15 @@ TEST_CASE("Properties")
 				},
 			},
 			{
+				"hsl(10000, 0%, 50%), hsl(240, 100%, 50%) 50%, hsla(-240, 100%, 50%, 0.5) 10dp",
+				"#7f7f7f, #0000ff 50%, #00ff007f 10dp",
+				{
+					ColorStop{ColourbPremultiplied(127, 127, 127), NumericValue{}},
+					ColorStop{ColourbPremultiplied(0, 0, 255), NumericValue{50.f, Unit::PERCENT}},
+					ColorStop{ColourbPremultiplied(0, 127, 0, 127), NumericValue{10.f, Unit::DP}},
+				},
+			},
+			{
 				"red 50px 20%, blue 10in",
 				"#ff0000 50px, #ff0000 20%, #0000ff 10in",
 				{


### PR DESCRIPTION
To many web developers, HSL and HSLA colors are easier to work with. Here's a test in the sandbox:

![image](https://github.com/user-attachments/assets/576185e2-f437-4aae-bb26-22fb37677ebc)
