### PR TITLE
Fix incorrect clipping due to stale viewport dimensions

### DIFF
--- a/Include/RmlUi/Core/RenderManager.h
+++ b/Include/RmlUi/Core/RenderManager.h
@@ -76,7 +76,7 @@ public:
 	RenderManager(RenderInterface* render_interface);
 	~RenderManager();
 
-	void PrepareRender();
+	void PrepareRender(Vector2i dimensions);
 	void SetViewport(Vector2i dimensions);
 	Vector2i GetViewport() const;
 

--- a/Source/Core/Context.cpp
+++ b/Source/Core/Context.cpp
@@ -216,7 +216,7 @@ bool Context::Render()
 {
 	RMLUI_ZoneScoped;
 
-	render_manager->PrepareRender();
+	render_manager->PrepareRender(dimensions);
 
 	root->Render();
 

--- a/Source/Core/RenderManager.cpp
+++ b/Source/Core/RenderManager.cpp
@@ -68,7 +68,7 @@ RenderManager::~RenderManager()
 	ReleaseAllTextures();
 }
 
-void RenderManager::PrepareRender()
+void RenderManager::PrepareRender(Vector2i dimensions)
 {
 #ifdef RMLUI_DEBUG
 	const RenderState default_state;
@@ -77,6 +77,8 @@ void RenderManager::PrepareRender()
 	RMLUI_ASSERT(state.transform == default_state.transform);
 	RMLUI_ASSERTMSG(render_stack.empty(), "Unbalanced render stack detected, ensure every PushLayer call has a corresponding call to PopLayer.");
 #endif
+
+	SetViewport(dimensions);
 }
 
 void RenderManager::SetViewport(Vector2i dimensions)


### PR DESCRIPTION
Previously, `RenderManager`'s viewport dimensions were only updated when creating or resizing a context, causing incorrect clipping when using multiple differently sized contexts:
![image](https://github.com/user-attachments/assets/f6047d39-7eef-4ffa-9bb2-ea8153db1ec8)

This PR updates them from `Context::Render`, fixing the issue.