### PR TITLE
Avoid allocations during global initialization

### DIFF
--- a/Include/RmlUi/Core/Core.h
+++ b/Include/RmlUi/Core/Core.h
@@ -180,9 +180,6 @@ RMLUICORE_API void ReleaseCompiledGeometry(RenderInterface* render_interface = n
 /// @note Invalidates all existing FontFaceHandles returned from the font engine.
 RMLUICORE_API void ReleaseFontResources();
 
-/// Forces all memory pools used by RmlUi to be released.
-RMLUICORE_API void ReleaseMemoryPools();
-
 } // namespace Rml
 
 #endif

--- a/Include/RmlUi/Core/ElementInstancer.h
+++ b/Include/RmlUi/Core/ElementInstancer.h
@@ -117,5 +117,10 @@ public:
 	}
 };
 
+namespace Detail {
+	void InitializeElementInstancerPools();
+	void ShutdownElementInstancerPools();
+} // namespace Detail
+
 } // namespace Rml
 #endif

--- a/Include/RmlUi/Core/Factory.h
+++ b/Include/RmlUi/Core/Factory.h
@@ -71,7 +71,7 @@ enum class EventId : uint16_t;
 class RMLUICORE_API Factory {
 public:
 	/// Initialise the element factory
-	static bool Initialise();
+	static void Initialise();
 	/// Cleanup and shutdown the factory
 	static void Shutdown();
 

--- a/Include/RmlUi/Core/StyleSheetSpecification.h
+++ b/Include/RmlUi/Core/StyleSheetSpecification.h
@@ -45,8 +45,7 @@ struct DefaultStyleSheetParsers;
 class RMLUICORE_API StyleSheetSpecification {
 public:
 	/// Starts up the specification structure and registers default properties and type parsers.
-	/// @return True if the specification started up successfully, false if not.
-	static bool Initialise();
+	static void Initialise();
 	/// Destroys the specification structure and releases the parsers.
 	static void Shutdown();
 

--- a/Include/RmlUi/Core/XMLParser.h
+++ b/Include/RmlUi/Core/XMLParser.h
@@ -104,15 +104,9 @@ protected:
 	void HandleData(const String& data, XMLDataType type) override;
 
 private:
-	// The header of the document being parsed.
 	UniquePtr<DocumentHeader> header;
-
-	// The active node handler.
 	XMLNodeHandler* active_handler;
-
-	// The parser stack.
-	using ParserStack = Stack<ParseFrame>;
-	ParserStack stack;
+	Stack<ParseFrame> stack;
 };
 
 } // namespace Rml

--- a/Source/Core/CMakeLists.txt
+++ b/Source/Core/CMakeLists.txt
@@ -15,6 +15,7 @@ add_library(rmlui_core
 	ContextInstancer.cpp
 	ContextInstancerDefault.cpp
 	ContextInstancerDefault.h
+	ControlledLifetimeResource.h
 	ConvolutionFilter.cpp
 	Core.cpp
 	DataController.cpp
@@ -65,6 +66,8 @@ add_library(rmlui_core
 	ElementHandle.cpp
 	ElementHandle.h
 	ElementInstancer.cpp
+	ElementMeta.cpp
+	ElementMeta.h
 	ElementScroll.cpp
 	ElementStyle.cpp
 	ElementStyle.h

--- a/Source/Core/ComputeProperty.cpp
+++ b/Source/Core/ComputeProperty.cpp
@@ -30,10 +30,29 @@
 #include "../../Include/RmlUi/Core/ComputedValues.h"
 #include "../../Include/RmlUi/Core/Property.h"
 #include "../../Include/RmlUi/Core/StringUtilities.h"
+#include "ControlledLifetimeResource.h"
 
 namespace Rml {
 
-const Style::ComputedValues DefaultComputedValues{nullptr};
+struct ComputedPropertyData {
+	const Style::ComputedValues computed{nullptr};
+};
+static ControlledLifetimeResource<ComputedPropertyData> computed_property_data;
+
+const Style::ComputedValues& DefaultComputedValues()
+{
+	return computed_property_data->computed;
+}
+
+void InitializeComputeProperty()
+{
+	computed_property_data.Initialize();
+}
+
+void ShutdownComputeProperty()
+{
+	computed_property_data.Shutdown();
+}
 
 static constexpr float PixelsPerInch = 96.0f;
 
@@ -114,7 +133,7 @@ float ComputeFontsize(NumericValue value, const Style::ComputedValues& values, c
 		case Unit::REM:
 			// If the current element is a document, the rem unit is relative to the default size.
 			if (!document_values || &values == document_values)
-				return value.number * DefaultComputedValues.font_size();
+				return value.number * DefaultComputedValues().font_size();
 
 			// Otherwise it is relative to the document font size.
 			return value.number * document_values->font_size();

--- a/Source/Core/ComputeProperty.h
+++ b/Source/Core/ComputeProperty.h
@@ -67,7 +67,10 @@ uint16_t ComputeBorderWidth(float computed_length);
 
 String GetFontFaceDescription(const String& font_family, Style::FontStyle style, Style::FontWeight weight);
 
-extern const Style::ComputedValues DefaultComputedValues;
+const Style::ComputedValues& DefaultComputedValues();
+
+void InitializeComputeProperty();
+void ShutdownComputeProperty();
 
 } // namespace Rml
 #endif

--- a/Source/Core/ControlledLifetimeResource.h
+++ b/Source/Core/ControlledLifetimeResource.h
@@ -1,0 +1,86 @@
+/*
+ * This source file is part of RmlUi, the HTML/CSS Interface Middleware
+ *
+ * For the latest information, see http://github.com/mikke89/RmlUi
+ *
+ * Copyright (c) 2019-2024 The RmlUi Team, and contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+#ifndef RMLUI_CORE_CONTROLLEDLIFETIMERESOURCE_H
+#define RMLUI_CORE_CONTROLLEDLIFETIMERESOURCE_H
+
+#include "../../Include/RmlUi/Core/Debug.h"
+#include "../../Include/RmlUi/Core/Traits.h"
+
+namespace Rml {
+
+template <typename T>
+class ControlledLifetimeResource : NonCopyMoveable {
+public:
+	ControlledLifetimeResource() = default;
+	~ControlledLifetimeResource() noexcept { RMLUI_ASSERTMSG(!pointer || intentionally_leaked, "Resource was not properly shut down."); }
+
+	explicit operator bool() const noexcept { return pointer != nullptr; }
+
+	void Initialize()
+	{
+		RMLUI_ASSERTMSG(!pointer, "Resource already initialized.");
+		pointer = new T();
+	}
+
+	void InitializeIfEmpty()
+	{
+		if (!pointer)
+			Initialize();
+		else
+			SetIntentionallyLeaked(false);
+	}
+
+	void Leak() { SetIntentionallyLeaked(true); }
+
+	void Shutdown()
+	{
+		RMLUI_ASSERTMSG(pointer, "Shutting down resource that was not initialized, or has been shut down already.");
+		RMLUI_ASSERTMSG(!intentionally_leaked, "Shutting down resource that was marked as leaked.");
+		delete pointer;
+		pointer = nullptr;
+	}
+
+	T* operator->()
+	{
+		RMLUI_ASSERTMSG(pointer, "Resource used before it was initialized, or after it was shut down.");
+		return pointer;
+	}
+
+private:
+#ifdef RMLUI_DEBUG
+	void SetIntentionallyLeaked(bool leaked) { intentionally_leaked = leaked; }
+	bool intentionally_leaked = false;
+#else
+	void SetIntentionallyLeaked(bool /*leaked*/) {}
+#endif
+
+	T* pointer = nullptr;
+};
+
+} // namespace Rml
+#endif

--- a/Source/Core/Element.cpp
+++ b/Source/Core/Element.cpp
@@ -49,6 +49,7 @@
 #include "ElementBackgroundBorder.h"
 #include "ElementDefinition.h"
 #include "ElementEffects.h"
+#include "ElementMeta.h"
 #include "ElementStyle.h"
 #include "EventDispatcher.h"
 #include "EventSpecification.h"
@@ -90,20 +91,6 @@ static float GetScrollOffsetDelta(ScrollAlignment alignment, float begin_offset,
 	return 0.f;
 }
 
-// Meta objects for element collected in a single struct to reduce memory allocations
-struct ElementMeta {
-	ElementMeta(Element* el) : event_dispatcher(el), style(el), background_border(), effects(el), scroll(el), computed_values(el) {}
-	SmallUnorderedMap<EventId, EventListener*> attribute_event_listeners;
-	EventDispatcher event_dispatcher;
-	ElementStyle style;
-	ElementBackgroundBorder background_border;
-	ElementEffects effects;
-	ElementScroll scroll;
-	Style::ComputedValues computed_values;
-};
-
-static Pool<ElementMeta> element_meta_chunk_pool(200, true);
-
 Element::Element(const String& tag) :
 	local_stacking_context(false), local_stacking_context_forced(false), stacking_context_dirty(false), computed_values_are_default_initialized(true),
 	visible(true), offset_fixed(false), absolute_offset_dirty(true), dirty_definition(false), dirty_child_definitions(false), dirty_animation(false),
@@ -125,7 +112,7 @@ Element::Element(const String& tag) :
 
 	z_index = 0;
 
-	meta = element_meta_chunk_pool.AllocateAndConstruct(this);
+	meta = ElementMetaPool::element_meta_pool->pool.AllocateAndConstruct(this);
 	data_model = nullptr;
 }
 
@@ -148,7 +135,7 @@ Element::~Element()
 	children.clear();
 	num_non_dom_children = 0;
 
-	element_meta_chunk_pool.DestroyAndDeallocate(meta);
+	ElementMetaPool::element_meta_pool->pool.DestroyAndDeallocate(meta);
 }
 
 void Element::Update(float dp_ratio, Vector2f vp_dimensions)

--- a/Source/Core/ElementMeta.cpp
+++ b/Source/Core/ElementMeta.cpp
@@ -26,42 +26,29 @@
  *
  */
 
-#ifndef RMLUI_CORE_PROPERTYPARSERCOLOUR_H
-#define RMLUI_CORE_PROPERTYPARSERCOLOUR_H
-
-#include "../../Include/RmlUi/Core/PropertyParser.h"
-#include "../../Include/RmlUi/Core/Types.h"
-#include "ControlledLifetimeResource.h"
+#include "ElementMeta.h"
 
 namespace Rml {
 
-/**
-    A property parser that parses a colour value.
+ControlledLifetimeResource<ElementMetaPool> ElementMetaPool::element_meta_pool;
 
-    @author Peter Curry
- */
+void ElementMetaPool::Initialize()
+{
+	element_meta_pool.InitializeIfEmpty();
+}
 
-class PropertyParserColour : public PropertyParser {
-public:
-	PropertyParserColour();
-	virtual ~PropertyParserColour();
-
-	/// Called to parse a RCSS colour declaration.
-	/// @param[out] property The property to set the parsed value on.
-	/// @param[in] value The raw value defined for this property.
-	/// @param[in] parameters The parameters defined for this property; not used for this parser.
-	/// @return True if the value was parsed successfully, false otherwise.
-	bool ParseValue(Property& property, const String& value, const ParameterMap& parameters) const override;
-
-	/// Parse a colour directly.
-	static bool ParseColour(Colourb& colour, const String& value);
-
-	static void Initialize();
-	static void Shutdown();
-
-private:
-	static ControlledLifetimeResource<struct PropertyParserColourData> parser_data;
-};
+void ElementMetaPool::Shutdown()
+{
+	const int num_objects = element_meta_pool->pool.GetNumAllocatedObjects();
+	if (num_objects == 0)
+	{
+		element_meta_pool.Shutdown();
+	}
+	else
+	{
+		Log::Message(Log::LT_WARNING, "Element meta pool not empty on shutdown, %d object(s) leaked.", num_objects);
+		element_meta_pool.Leak();
+	}
+}
 
 } // namespace Rml
-#endif

--- a/Source/Core/ElementMeta.h
+++ b/Source/Core/ElementMeta.h
@@ -26,41 +26,41 @@
  *
  */
 
-#ifndef RMLUI_CORE_PROPERTYPARSERCOLOUR_H
-#define RMLUI_CORE_PROPERTYPARSERCOLOUR_H
+#ifndef RMLUI_CORE_ELEMENTMETA_H
+#define RMLUI_CORE_ELEMENTMETA_H
 
-#include "../../Include/RmlUi/Core/PropertyParser.h"
+#include "../../Include/RmlUi/Core/ComputedValues.h"
+#include "../../Include/RmlUi/Core/Element.h"
+#include "../../Include/RmlUi/Core/ElementScroll.h"
+#include "../../Include/RmlUi/Core/Traits.h"
 #include "../../Include/RmlUi/Core/Types.h"
 #include "ControlledLifetimeResource.h"
+#include "ElementBackgroundBorder.h"
+#include "ElementEffects.h"
+#include "ElementStyle.h"
+#include "EventDispatcher.h"
+#include "Pool.h"
 
 namespace Rml {
 
-/**
-    A property parser that parses a colour value.
+// Meta objects for element collected in a single struct to reduce memory allocations
+struct ElementMeta {
+	explicit ElementMeta(Element* el) : event_dispatcher(el), style(el), background_border(), effects(el), scroll(el), computed_values(el) {}
+	SmallUnorderedMap<EventId, EventListener*> attribute_event_listeners;
+	EventDispatcher event_dispatcher;
+	ElementStyle style;
+	ElementBackgroundBorder background_border;
+	ElementEffects effects;
+	ElementScroll scroll;
+	Style::ComputedValues computed_values;
+};
 
-    @author Peter Curry
- */
+struct ElementMetaPool {
+	Pool<ElementMeta> pool{50, true};
 
-class PropertyParserColour : public PropertyParser {
-public:
-	PropertyParserColour();
-	virtual ~PropertyParserColour();
-
-	/// Called to parse a RCSS colour declaration.
-	/// @param[out] property The property to set the parsed value on.
-	/// @param[in] value The raw value defined for this property.
-	/// @param[in] parameters The parameters defined for this property; not used for this parser.
-	/// @return True if the value was parsed successfully, false otherwise.
-	bool ParseValue(Property& property, const String& value, const ParameterMap& parameters) const override;
-
-	/// Parse a colour directly.
-	static bool ParseColour(Colourb& colour, const String& value);
-
+	static ControlledLifetimeResource<ElementMetaPool> element_meta_pool;
 	static void Initialize();
 	static void Shutdown();
-
-private:
-	static ControlledLifetimeResource<struct PropertyParserColourData> parser_data;
 };
 
 } // namespace Rml

--- a/Source/Core/ElementStyle.cpp
+++ b/Source/Core/ElementStyle.cpp
@@ -364,7 +364,7 @@ static float ComputeLength(NumericValue value, Element* element)
 		if (ElementDocument* document = element->GetOwnerDocument())
 			doc_font_size = document->GetComputedValues().font_size();
 		else
-			doc_font_size = DefaultComputedValues.font_size();
+			doc_font_size = DefaultComputedValues().font_size();
 		break;
 	case Unit::VW:
 	case Unit::VH:
@@ -419,7 +419,7 @@ float ElementStyle::ResolveRelativeLength(NumericValue value, RelativeTarget rel
 	case RelativeTarget::ParentFontSize:
 	{
 		auto p = element->GetParentNode();
-		base_value = (p ? p->GetComputedValues().font_size() : DefaultComputedValues.font_size());
+		base_value = (p ? p->GetComputedValues().font_size() : DefaultComputedValues().font_size());
 	}
 	break;
 	case RelativeTarget::LineHeight: base_value = element->GetLineHeight(); break;
@@ -530,13 +530,13 @@ PropertyIdSet ElementStyle::ComputeValues(Style::ComputedValues& values, const S
 		// If we skipped this, the old dirty value would be unmodified, instead, now it is set to its default value.
 		// Strictly speaking, we only really need to do this for the dirty, non-inherited values. However, in most
 		// cases it seems simply assigning all non-inherited values is faster than iterating the dirty properties.
-		values.CopyNonInherited(DefaultComputedValues);
+		values.CopyNonInherited(DefaultComputedValues());
 	}
 
 	if (parent_values)
 		values.CopyInherited(*parent_values);
 	else if (!values_are_default_initialized)
-		values.CopyInherited(DefaultComputedValues);
+		values.CopyInherited(DefaultComputedValues());
 
 	bool dirty_em_properties = false;
 
@@ -560,7 +560,7 @@ PropertyIdSet ElementStyle::ComputeValues(Style::ComputedValues& values, const S
 	}
 
 	const float font_size = values.font_size();
-	const float document_font_size = (document_values ? document_values->font_size() : DefaultComputedValues.font_size());
+	const float document_font_size = (document_values ? document_values->font_size() : DefaultComputedValues().font_size());
 
 	// Since vertical-align depends on line-height we compute this before iteration
 	if (dirty_properties.Contains(PropertyId::LineHeight))

--- a/Source/Core/EventSpecification.cpp
+++ b/Source/Core/EventSpecification.cpp
@@ -28,61 +28,66 @@
 
 #include "EventSpecification.h"
 #include "../../Include/RmlUi/Core/ID.h"
+#include "ControlledLifetimeResource.h"
 
 namespace Rml {
 
-// An EventId is an index into the specifications vector.
-static Vector<EventSpecification> specifications = {{EventId::Invalid, "invalid", false, false, DefaultActionPhase::None}};
+struct EventSpecificationData {
+	// An EventId is an index into the specifications vector, must be listed in the same order as the EventId values.
+	Vector<EventSpecification> specifications = {
+		// clang-format off
+		//      id                 type      interruptible  bubbles     default_action
+		{EventId::Invalid       , "invalid"       , false , false , DefaultActionPhase::None},
+		{EventId::Mousedown     , "mousedown"     , true  , true  , DefaultActionPhase::TargetAndBubble},
+		{EventId::Mousescroll   , "mousescroll"   , true  , true  , DefaultActionPhase::None},
+		{EventId::Mouseover     , "mouseover"     , true  , true  , DefaultActionPhase::Target},
+		{EventId::Mouseout      , "mouseout"      , true  , true  , DefaultActionPhase::Target},
+		{EventId::Focus         , "focus"         , false , false , DefaultActionPhase::Target},
+		{EventId::Blur          , "blur"          , false , false , DefaultActionPhase::Target},
+		{EventId::Keydown       , "keydown"       , true  , true  , DefaultActionPhase::TargetAndBubble},
+		{EventId::Keyup         , "keyup"         , true  , true  , DefaultActionPhase::TargetAndBubble},
+		{EventId::Textinput     , "textinput"     , true  , true  , DefaultActionPhase::TargetAndBubble},
+		{EventId::Mouseup       , "mouseup"       , true  , true  , DefaultActionPhase::TargetAndBubble},
+		{EventId::Click         , "click"         , true  , true  , DefaultActionPhase::TargetAndBubble},
+		{EventId::Dblclick      , "dblclick"      , true  , true  , DefaultActionPhase::TargetAndBubble},
+		{EventId::Load          , "load"          , false , false , DefaultActionPhase::None},
+		{EventId::Unload        , "unload"        , false , false , DefaultActionPhase::None},
+		{EventId::Show          , "show"          , false , false , DefaultActionPhase::None},
+		{EventId::Hide          , "hide"          , false , false , DefaultActionPhase::None},
+		{EventId::Mousemove     , "mousemove"     , true  , true  , DefaultActionPhase::None},
+		{EventId::Dragmove      , "dragmove"      , true  , true  , DefaultActionPhase::None},
+		{EventId::Drag          , "drag"          , false , true  , DefaultActionPhase::Target},
+		{EventId::Dragstart     , "dragstart"     , false , true  , DefaultActionPhase::Target},
+		{EventId::Dragover      , "dragover"      , true  , true  , DefaultActionPhase::None},
+		{EventId::Dragdrop      , "dragdrop"      , true  , true  , DefaultActionPhase::None},
+		{EventId::Dragout       , "dragout"       , true  , true  , DefaultActionPhase::None},
+		{EventId::Dragend       , "dragend"       , true  , true  , DefaultActionPhase::None},
+		{EventId::Handledrag    , "handledrag"    , false , true  , DefaultActionPhase::None},
+		{EventId::Resize        , "resize"        , false , false , DefaultActionPhase::None},
+		{EventId::Scroll        , "scroll"        , false , true  , DefaultActionPhase::None},
+		{EventId::Animationend  , "animationend"  , false , true  , DefaultActionPhase::None},
+		{EventId::Transitionend , "transitionend" , false , true  , DefaultActionPhase::None},
+		{EventId::Change        , "change"        , false , true  , DefaultActionPhase::None},
+		{EventId::Submit        , "submit"        , true  , true  , DefaultActionPhase::None},
+		{EventId::Tabchange     , "tabchange"     , false , true  , DefaultActionPhase::None},
+		// clang-format on
+	};
 
-// Reverse lookup map from event type to id.
-static UnorderedMap<String, EventId> type_lookup;
+	// Reverse lookup map from event type to id.
+	UnorderedMap<String, EventId> type_lookup;
+};
+
+static ControlledLifetimeResource<EventSpecificationData> event_specification_data;
 
 namespace EventSpecificationInterface {
 
 	void Initialize()
 	{
-		// Must be specified in the same order as in EventId
-		specifications = {
-			//      id                 type      interruptible  bubbles     default_action
-			// clang-format off
-			{EventId::Invalid       , "invalid"       , false , false , DefaultActionPhase::None},
-			{EventId::Mousedown     , "mousedown"     , true  , true  , DefaultActionPhase::TargetAndBubble},
-			{EventId::Mousescroll   , "mousescroll"   , true  , true  , DefaultActionPhase::None},
-			{EventId::Mouseover     , "mouseover"     , true  , true  , DefaultActionPhase::Target},
-			{EventId::Mouseout      , "mouseout"      , true  , true  , DefaultActionPhase::Target},
-			{EventId::Focus         , "focus"         , false , false , DefaultActionPhase::Target},
-			{EventId::Blur          , "blur"          , false , false , DefaultActionPhase::Target},
-			{EventId::Keydown       , "keydown"       , true  , true  , DefaultActionPhase::TargetAndBubble},
-			{EventId::Keyup         , "keyup"         , true  , true  , DefaultActionPhase::TargetAndBubble},
-			{EventId::Textinput     , "textinput"     , true  , true  , DefaultActionPhase::TargetAndBubble},
-			{EventId::Mouseup       , "mouseup"       , true  , true  , DefaultActionPhase::TargetAndBubble},
-			{EventId::Click         , "click"         , true  , true  , DefaultActionPhase::TargetAndBubble},
-			{EventId::Dblclick      , "dblclick"      , true  , true  , DefaultActionPhase::TargetAndBubble},
-			{EventId::Load          , "load"          , false , false , DefaultActionPhase::None},
-			{EventId::Unload        , "unload"        , false , false , DefaultActionPhase::None},
-			{EventId::Show          , "show"          , false , false , DefaultActionPhase::None},
-			{EventId::Hide          , "hide"          , false , false , DefaultActionPhase::None},
-			{EventId::Mousemove     , "mousemove"     , true  , true  , DefaultActionPhase::None},
-			{EventId::Dragmove      , "dragmove"      , true  , true  , DefaultActionPhase::None},
-			{EventId::Drag          , "drag"          , false , true  , DefaultActionPhase::Target},
-			{EventId::Dragstart     , "dragstart"     , false , true  , DefaultActionPhase::Target},
-			{EventId::Dragover      , "dragover"      , true  , true  , DefaultActionPhase::None},
-			{EventId::Dragdrop      , "dragdrop"      , true  , true  , DefaultActionPhase::None},
-			{EventId::Dragout       , "dragout"       , true  , true  , DefaultActionPhase::None},
-			{EventId::Dragend       , "dragend"       , true  , true  , DefaultActionPhase::None},
-			{EventId::Handledrag    , "handledrag"    , false , true  , DefaultActionPhase::None},
-			{EventId::Resize        , "resize"        , false , false , DefaultActionPhase::None},
-			{EventId::Scroll        , "scroll"        , false , true  , DefaultActionPhase::None},
-			{EventId::Animationend  , "animationend"  , false , true  , DefaultActionPhase::None},
-			{EventId::Transitionend , "transitionend" , false , true  , DefaultActionPhase::None},
+		event_specification_data.Initialize();
 
-			{EventId::Change        , "change"        , false , true  , DefaultActionPhase::None},
-			{EventId::Submit        , "submit"        , true  , true  , DefaultActionPhase::None},
-			{EventId::Tabchange     , "tabchange"     , false , true  , DefaultActionPhase::None},
-			// clang-format on
-		};
+		auto& specifications = event_specification_data->specifications;
+		auto& type_lookup = event_specification_data->type_lookup;
 
-		type_lookup.clear();
 		type_lookup.reserve(specifications.size());
 		for (auto& specification : specifications)
 			type_lookup.emplace(specification.type, specification.id);
@@ -99,8 +104,14 @@ namespace EventSpecificationInterface {
 #endif
 	}
 
+	void Shutdown()
+	{
+		event_specification_data.Shutdown();
+	}
+
 	static EventSpecification& GetMutable(EventId id)
 	{
+		auto& specifications = event_specification_data->specifications;
 		size_t i = static_cast<size_t>(id);
 		if (i < specifications.size())
 			return specifications[i];
@@ -111,6 +122,9 @@ namespace EventSpecificationInterface {
 	// If not found: Inserts a new entry with given values.
 	static EventSpecification& GetOrInsert(const String& event_type, bool interruptible, bool bubbles, DefaultActionPhase default_action_phase)
 	{
+		auto& specifications = event_specification_data->specifications;
+		auto& type_lookup = event_specification_data->type_lookup;
+
 		auto it = type_lookup.find(event_type);
 
 		if (it != type_lookup.end())
@@ -148,6 +162,8 @@ namespace EventSpecificationInterface {
 
 	EventId GetIdOrInsert(const String& event_type)
 	{
+		auto& type_lookup = event_specification_data->type_lookup;
+
 		auto it = type_lookup.find(event_type);
 		if (it != type_lookup.end())
 			return it->second;
@@ -157,6 +173,8 @@ namespace EventSpecificationInterface {
 
 	EventId InsertOrReplaceCustom(const String& event_type, bool interruptible, bool bubbles, DefaultActionPhase default_action_phase)
 	{
+		auto& specifications = event_specification_data->specifications;
+
 		const size_t size_before = specifications.size();
 		EventSpecification& specification = GetOrInsert(event_type, interruptible, bubbles, default_action_phase);
 		bool got_existing_entry = (size_before == specifications.size());

--- a/Source/Core/EventSpecification.h
+++ b/Source/Core/EventSpecification.h
@@ -46,6 +46,7 @@ struct EventSpecification {
 namespace EventSpecificationInterface {
 
 	void Initialize();
+	void Shutdown();
 
 	// Get event specification for the given id.
 	// Returns the 'invalid' event type if no specification exists for id.

--- a/Source/Core/Layout/LayoutPools.h
+++ b/Source/Core/Layout/LayoutPools.h
@@ -35,6 +35,9 @@ namespace Rml {
 
 namespace LayoutPools {
 
+	void Initialize();
+	void Shutdown();
+
 	void* AllocateLayoutChunk(size_t size);
 	void DeallocateLayoutChunk(void* chunk, size_t size);
 

--- a/Source/Core/PluginRegistry.cpp
+++ b/Source/Core/PluginRegistry.cpp
@@ -28,99 +28,116 @@
 
 #include "PluginRegistry.h"
 #include "../../Include/RmlUi/Core/Plugin.h"
+#include "ControlledLifetimeResource.h"
 #include <algorithm>
 
 namespace Rml {
 
-typedef Vector<Plugin*> PluginList;
-static PluginList basic_plugins;
-static PluginList document_plugins;
-static PluginList element_plugins;
+struct PluginVectors {
+	Vector<Plugin*> basic;
+	Vector<Plugin*> document;
+	Vector<Plugin*> element;
+};
 
-PluginRegistry::PluginRegistry() {}
+static ControlledLifetimeResource<PluginVectors> plugin_vectors;
+
+static void EnsurePluginVectorsInitialized()
+{
+	if (!plugin_vectors)
+	{
+		plugin_vectors.Initialize();
+	}
+}
 
 void PluginRegistry::RegisterPlugin(Plugin* plugin)
 {
+	EnsurePluginVectorsInitialized();
+
 	int event_classes = plugin->GetEventClasses();
 
 	if (event_classes & Plugin::EVT_BASIC)
-		basic_plugins.push_back(plugin);
+		plugin_vectors->basic.push_back(plugin);
 	if (event_classes & Plugin::EVT_DOCUMENT)
-		document_plugins.push_back(plugin);
+		plugin_vectors->document.push_back(plugin);
 	if (event_classes & Plugin::EVT_ELEMENT)
-		element_plugins.push_back(plugin);
+		plugin_vectors->element.push_back(plugin);
 }
 
 void PluginRegistry::UnregisterPlugin(Plugin* plugin)
 {
-	int event_classes = plugin->GetEventClasses();
+	auto erase_value = [](Vector<Plugin*>& container, Plugin* value) {
+		container.erase(std::remove(container.begin(), container.end(), value), container.end());
+	};
 
+	int event_classes = plugin->GetEventClasses();
 	if (event_classes & Plugin::EVT_BASIC)
-		basic_plugins.erase(std::remove(basic_plugins.begin(), basic_plugins.end(), plugin), basic_plugins.end());
+		erase_value(plugin_vectors->basic, plugin);
 	if (event_classes & Plugin::EVT_DOCUMENT)
-		document_plugins.erase(std::remove(document_plugins.begin(), document_plugins.end(), plugin), document_plugins.end());
+		erase_value(plugin_vectors->document, plugin);
 	if (event_classes & Plugin::EVT_ELEMENT)
-		element_plugins.erase(std::remove(element_plugins.begin(), element_plugins.end(), plugin), element_plugins.end());
+		erase_value(plugin_vectors->element, plugin);
 }
 
 void PluginRegistry::NotifyInitialise()
 {
-	for (size_t i = 0; i < basic_plugins.size(); ++i)
-		basic_plugins[i]->OnInitialise();
+	EnsurePluginVectorsInitialized();
+
+	for (Plugin* plugin : plugin_vectors->basic)
+		plugin->OnInitialise();
 }
 
 void PluginRegistry::NotifyShutdown()
 {
-	while (!basic_plugins.empty())
+	while (!plugin_vectors->basic.empty())
 	{
-		Plugin* plugin = basic_plugins.back();
+		Plugin* plugin = plugin_vectors->basic.back();
 		PluginRegistry::UnregisterPlugin(plugin);
 		plugin->OnShutdown();
 	}
-	document_plugins.clear();
-	element_plugins.clear();
+
+	plugin_vectors.Shutdown();
 }
 
 void PluginRegistry::NotifyContextCreate(Context* context)
 {
-	for (size_t i = 0; i < basic_plugins.size(); ++i)
-		basic_plugins[i]->OnContextCreate(context);
+	for (Plugin* plugin : plugin_vectors->basic)
+		plugin->OnContextCreate(context);
 }
 
 void PluginRegistry::NotifyContextDestroy(Context* context)
 {
-	for (size_t i = 0; i < basic_plugins.size(); ++i)
-		basic_plugins[i]->OnContextDestroy(context);
+	for (Plugin* plugin : plugin_vectors->basic)
+		plugin->OnContextDestroy(context);
 }
 
 void PluginRegistry::NotifyDocumentOpen(Context* context, const String& document_path)
 {
-	for (size_t i = 0; i < document_plugins.size(); ++i)
-		document_plugins[i]->OnDocumentOpen(context, document_path);
+	for (Plugin* plugin : plugin_vectors->document)
+		plugin->OnDocumentOpen(context, document_path);
 }
 
 void PluginRegistry::NotifyDocumentLoad(ElementDocument* document)
 {
-	for (size_t i = 0; i < document_plugins.size(); ++i)
-		document_plugins[i]->OnDocumentLoad(document);
+	for (Plugin* plugin : plugin_vectors->document)
+		plugin->OnDocumentLoad(document);
 }
 
 void PluginRegistry::NotifyDocumentUnload(ElementDocument* document)
 {
-	for (size_t i = 0; i < document_plugins.size(); ++i)
-		document_plugins[i]->OnDocumentUnload(document);
+	for (Plugin* plugin : plugin_vectors->document)
+		plugin->OnDocumentUnload(document);
 }
 
 void PluginRegistry::NotifyElementCreate(Element* element)
 {
-	for (size_t i = 0; i < element_plugins.size(); ++i)
-		element_plugins[i]->OnElementCreate(element);
+	for (Plugin* plugin : plugin_vectors->element)
+		plugin->OnElementCreate(element);
 }
 
 void PluginRegistry::NotifyElementDestroy(Element* element)
 {
-	for (size_t i = 0; i < element_plugins.size(); ++i)
-		element_plugins[i]->OnElementDestroy(element);
+	for (Plugin* plugin : plugin_vectors->element)
+		plugin->OnElementDestroy(element);
 }
 
 } // namespace Rml

--- a/Source/Core/PluginRegistry.h
+++ b/Source/Core/PluginRegistry.h
@@ -70,7 +70,7 @@ public:
 	static void NotifyElementDestroy(Element* element);
 
 private:
-	PluginRegistry();
+	PluginRegistry() = delete;
 };
 
 } // namespace Rml

--- a/Source/Core/PropertyParserAnimation.cpp
+++ b/Source/Core/PropertyParserAnimation.cpp
@@ -51,61 +51,97 @@ struct Keyword {
 	}
 };
 
-static const UnorderedMap<String, Keyword> keywords = {
-	{"none", {KeywordType::None}},
-	{"all", {KeywordType::All}},
-	{"alternate", {KeywordType::Alternate}},
-	{"infinite", {KeywordType::Infinite}},
-	{"paused", {KeywordType::Paused}},
+struct PropertyParserAnimationData {
+	const UnorderedMap<String, Keyword> keywords = {
+		{"none", {KeywordType::None}},
+		{"all", {KeywordType::All}},
+		{"alternate", {KeywordType::Alternate}},
+		{"infinite", {KeywordType::Infinite}},
+		{"paused", {KeywordType::Paused}},
 
-	{"back-in", {Tween{Tween::Back, Tween::In}}},
-	{"back-out", {Tween{Tween::Back, Tween::Out}}},
-	{"back-in-out", {Tween{Tween::Back, Tween::InOut}}},
+		{"back-in", {Tween{Tween::Back, Tween::In}}},
+		{"back-out", {Tween{Tween::Back, Tween::Out}}},
+		{"back-in-out", {Tween{Tween::Back, Tween::InOut}}},
 
-	{"bounce-in", {Tween{Tween::Bounce, Tween::In}}},
-	{"bounce-out", {Tween{Tween::Bounce, Tween::Out}}},
-	{"bounce-in-out", {Tween{Tween::Bounce, Tween::InOut}}},
+		{"bounce-in", {Tween{Tween::Bounce, Tween::In}}},
+		{"bounce-out", {Tween{Tween::Bounce, Tween::Out}}},
+		{"bounce-in-out", {Tween{Tween::Bounce, Tween::InOut}}},
 
-	{"circular-in", {Tween{Tween::Circular, Tween::In}}},
-	{"circular-out", {Tween{Tween::Circular, Tween::Out}}},
-	{"circular-in-out", {Tween{Tween::Circular, Tween::InOut}}},
+		{"circular-in", {Tween{Tween::Circular, Tween::In}}},
+		{"circular-out", {Tween{Tween::Circular, Tween::Out}}},
+		{"circular-in-out", {Tween{Tween::Circular, Tween::InOut}}},
 
-	{"cubic-in", {Tween{Tween::Cubic, Tween::In}}},
-	{"cubic-out", {Tween{Tween::Cubic, Tween::Out}}},
-	{"cubic-in-out", {Tween{Tween::Cubic, Tween::InOut}}},
+		{"cubic-in", {Tween{Tween::Cubic, Tween::In}}},
+		{"cubic-out", {Tween{Tween::Cubic, Tween::Out}}},
+		{"cubic-in-out", {Tween{Tween::Cubic, Tween::InOut}}},
 
-	{"elastic-in", {Tween{Tween::Elastic, Tween::In}}},
-	{"elastic-out", {Tween{Tween::Elastic, Tween::Out}}},
-	{"elastic-in-out", {Tween{Tween::Elastic, Tween::InOut}}},
+		{"elastic-in", {Tween{Tween::Elastic, Tween::In}}},
+		{"elastic-out", {Tween{Tween::Elastic, Tween::Out}}},
+		{"elastic-in-out", {Tween{Tween::Elastic, Tween::InOut}}},
 
-	{"exponential-in", {Tween{Tween::Exponential, Tween::In}}},
-	{"exponential-out", {Tween{Tween::Exponential, Tween::Out}}},
-	{"exponential-in-out", {Tween{Tween::Exponential, Tween::InOut}}},
+		{"exponential-in", {Tween{Tween::Exponential, Tween::In}}},
+		{"exponential-out", {Tween{Tween::Exponential, Tween::Out}}},
+		{"exponential-in-out", {Tween{Tween::Exponential, Tween::InOut}}},
 
-	{"linear-in", {Tween{Tween::Linear, Tween::In}}},
-	{"linear-out", {Tween{Tween::Linear, Tween::Out}}},
-	{"linear-in-out", {Tween{Tween::Linear, Tween::InOut}}},
+		{"linear-in", {Tween{Tween::Linear, Tween::In}}},
+		{"linear-out", {Tween{Tween::Linear, Tween::Out}}},
+		{"linear-in-out", {Tween{Tween::Linear, Tween::InOut}}},
 
-	{"quadratic-in", {Tween{Tween::Quadratic, Tween::In}}},
-	{"quadratic-out", {Tween{Tween::Quadratic, Tween::Out}}},
-	{"quadratic-in-out", {Tween{Tween::Quadratic, Tween::InOut}}},
+		{"quadratic-in", {Tween{Tween::Quadratic, Tween::In}}},
+		{"quadratic-out", {Tween{Tween::Quadratic, Tween::Out}}},
+		{"quadratic-in-out", {Tween{Tween::Quadratic, Tween::InOut}}},
 
-	{"quartic-in", {Tween{Tween::Quartic, Tween::In}}},
-	{"quartic-out", {Tween{Tween::Quartic, Tween::Out}}},
-	{"quartic-in-out", {Tween{Tween::Quartic, Tween::InOut}}},
+		{"quartic-in", {Tween{Tween::Quartic, Tween::In}}},
+		{"quartic-out", {Tween{Tween::Quartic, Tween::Out}}},
+		{"quartic-in-out", {Tween{Tween::Quartic, Tween::InOut}}},
 
-	{"quintic-in", {Tween{Tween::Quintic, Tween::In}}},
-	{"quintic-out", {Tween{Tween::Quintic, Tween::Out}}},
-	{"quintic-in-out", {Tween{Tween::Quintic, Tween::InOut}}},
+		{"quintic-in", {Tween{Tween::Quintic, Tween::In}}},
+		{"quintic-out", {Tween{Tween::Quintic, Tween::Out}}},
+		{"quintic-in-out", {Tween{Tween::Quintic, Tween::InOut}}},
 
-	{"sine-in", {Tween{Tween::Sine, Tween::In}}},
-	{"sine-out", {Tween{Tween::Sine, Tween::Out}}},
-	{"sine-in-out", {Tween{Tween::Sine, Tween::InOut}}},
+		{"sine-in", {Tween{Tween::Sine, Tween::In}}},
+		{"sine-out", {Tween{Tween::Sine, Tween::Out}}},
+		{"sine-in-out", {Tween{Tween::Sine, Tween::InOut}}},
+	};
 };
+
+ControlledLifetimeResource<PropertyParserAnimationData> PropertyParserAnimation::parser_data;
+
+void PropertyParserAnimation::Initialize()
+{
+	parser_data.Initialize();
+}
+
+void PropertyParserAnimation::Shutdown()
+{
+	parser_data.Shutdown();
+}
 
 PropertyParserAnimation::PropertyParserAnimation(Type type) : type(type) {}
 
-static bool ParseAnimation(Property& property, const StringList& animation_values)
+bool PropertyParserAnimation::ParseValue(Property& property, const String& value, const ParameterMap& /*parameters*/) const
+{
+	StringList list_of_values;
+	{
+		auto lowercase_value = StringUtilities::ToLower(value);
+		StringUtilities::ExpandString(list_of_values, lowercase_value, ',');
+	}
+
+	bool result = false;
+
+	if (type == ANIMATION_PARSER)
+	{
+		result = ParseAnimation(property, list_of_values);
+	}
+	else if (type == TRANSITION_PARSER)
+	{
+		result = ParseTransition(property, list_of_values);
+	}
+
+	return result;
+}
+
+bool PropertyParserAnimation::ParseAnimation(Property& property, const StringList& animation_values)
 {
 	AnimationList animation_list;
 
@@ -126,8 +162,8 @@ static bool ParseAnimation(Property& property, const StringList& animation_value
 				continue;
 
 			// See if we have a <keyword> or <tween> specifier as defined in keywords
-			auto it = keywords.find(argument);
-			if (it != keywords.end() && it->second.ValidAnimation())
+			auto it = parser_data->keywords.find(argument);
+			if (it != parser_data->keywords.end() && it->second.ValidAnimation())
 			{
 				switch (it->second.type)
 				{
@@ -211,7 +247,7 @@ static bool ParseAnimation(Property& property, const StringList& animation_value
 	return true;
 }
 
-static bool ParseTransition(Property& property, const StringList& transition_values)
+bool PropertyParserAnimation::ParseTransition(Property& property, const StringList& transition_values)
 {
 	TransitionList transition_list{false, false, {}};
 
@@ -233,8 +269,8 @@ static bool ParseTransition(Property& property, const StringList& transition_val
 				continue;
 
 			// See if we have a <keyword> or <tween> specifier as defined in keywords
-			auto it = keywords.find(argument);
-			if (it != keywords.end() && it->second.ValidTransition())
+			auto it = parser_data->keywords.find(argument);
+			if (it != parser_data->keywords.end() && it->second.ValidTransition())
 			{
 				if (it->second.type == KeywordType::None)
 				{
@@ -343,28 +379,6 @@ static bool ParseTransition(Property& property, const StringList& transition_val
 	property.unit = Unit::TRANSITION;
 
 	return true;
-}
-
-bool PropertyParserAnimation::ParseValue(Property& property, const String& value, const ParameterMap& /*parameters*/) const
-{
-	StringList list_of_values;
-	{
-		auto lowercase_value = StringUtilities::ToLower(value);
-		StringUtilities::ExpandString(list_of_values, lowercase_value, ',');
-	}
-
-	bool result = false;
-
-	if (type == ANIMATION_PARSER)
-	{
-		result = ParseAnimation(property, list_of_values);
-	}
-	else if (type == TRANSITION_PARSER)
-	{
-		result = ParseTransition(property, list_of_values);
-	}
-
-	return result;
 }
 
 } // namespace Rml

--- a/Source/Core/PropertyParserAnimation.h
+++ b/Source/Core/PropertyParserAnimation.h
@@ -30,6 +30,7 @@
 #define RMLUI_CORE_PROPERTYPARSERANIMATION_H
 
 #include "../../Include/RmlUi/Core/PropertyParser.h"
+#include "ControlledLifetimeResource.h"
 
 namespace Rml {
 
@@ -50,6 +51,15 @@ public:
 	/// @param[in] parameters The parameters defined for this property.
 	/// @return True if the value was validated successfully, false otherwise.
 	bool ParseValue(Property& property, const String& value, const ParameterMap& parameters) const override;
+
+	static void Initialize();
+	static void Shutdown();
+
+private:
+	static bool ParseAnimation(Property& property, const StringList& animation_values);
+	static bool ParseTransition(Property& property, const StringList& transition_values);
+
+	static ControlledLifetimeResource<struct PropertyParserAnimationData> parser_data;
 };
 
 } // namespace Rml

--- a/Source/Core/PropertyParserColour.cpp
+++ b/Source/Core/PropertyParserColour.cpp
@@ -27,6 +27,7 @@
  */
 
 #include "PropertyParserColour.h"
+#include "ControlledLifetimeResource.h"
 #include <algorithm>
 #include <cmath>
 #include <string.h>
@@ -61,27 +62,40 @@ static void HSLAToRGBA(Array<float, 4>& vals)
 	}
 }
 
-const PropertyParserColour::ColourMap PropertyParserColour::html_colours = {
-	{"black", Colourb(0, 0, 0)},
-	{"silver", Colourb(192, 192, 192)},
-	{"gray", Colourb(128, 128, 128)},
-	{"grey", Colourb(128, 128, 128)},
-	{"white", Colourb(255, 255, 255)},
-	{"maroon", Colourb(128, 0, 0)},
-	{"red", Colourb(255, 0, 0)},
-	{"orange", Colourb(255, 165, 0)},
-	{"purple", Colourb(128, 0, 128)},
-	{"fuchsia", Colourb(255, 0, 255)},
-	{"green", Colourb(0, 128, 0)},
-	{"lime", Colourb(0, 255, 0)},
-	{"olive", Colourb(128, 128, 0)},
-	{"yellow", Colourb(255, 255, 0)},
-	{"navy", Colourb(0, 0, 128)},
-	{"blue", Colourb(0, 0, 255)},
-	{"teal", Colourb(0, 128, 128)},
-	{"aqua", Colourb(0, 255, 255)},
-	{"transparent", Colourb(0, 0, 0, 0)},
+struct PropertyParserColourData {
+	const UnorderedMap<String, Colourb> html_colours = {
+		{"black", Colourb(0, 0, 0)},
+		{"silver", Colourb(192, 192, 192)},
+		{"gray", Colourb(128, 128, 128)},
+		{"grey", Colourb(128, 128, 128)},
+		{"white", Colourb(255, 255, 255)},
+		{"maroon", Colourb(128, 0, 0)},
+		{"red", Colourb(255, 0, 0)},
+		{"orange", Colourb(255, 165, 0)},
+		{"purple", Colourb(128, 0, 128)},
+		{"fuchsia", Colourb(255, 0, 255)},
+		{"green", Colourb(0, 128, 0)},
+		{"lime", Colourb(0, 255, 0)},
+		{"olive", Colourb(128, 128, 0)},
+		{"yellow", Colourb(255, 255, 0)},
+		{"navy", Colourb(0, 0, 128)},
+		{"blue", Colourb(0, 0, 255)},
+		{"teal", Colourb(0, 128, 128)},
+		{"aqua", Colourb(0, 255, 255)},
+		{"transparent", Colourb(0, 0, 0, 0)},
+	};
 };
+
+ControlledLifetimeResource<PropertyParserColourData> PropertyParserColour::parser_data;
+
+void PropertyParserColour::Initialize()
+{
+	parser_data.Initialize();
+}
+void PropertyParserColour::Shutdown()
+{
+	parser_data.Shutdown();
+}
 
 PropertyParserColour::PropertyParserColour() {}
 
@@ -228,11 +242,11 @@ bool PropertyParserColour::ParseColour(Colourb& colour, const String& value)
 	else
 	{
 		// Check for the specification of an HTML colour.
-		ColourMap::const_iterator iterator = html_colours.find(StringUtilities::ToLower(value));
-		if (iterator == html_colours.end())
+		auto it = parser_data->html_colours.find(StringUtilities::ToLower(value));
+		if (it == parser_data->html_colours.end())
 			return false;
 		else
-			colour = (*iterator).second;
+			colour = it->second;
 	}
 
 	return true;

--- a/Source/Core/PropertyParserDecorator.cpp
+++ b/Source/Core/PropertyParserDecorator.cpp
@@ -35,11 +35,24 @@
 
 namespace Rml {
 
-const SmallUnorderedMap<String, BoxArea> PropertyParserDecorator::area_keywords = {
-	{"border-box", BoxArea::Border},
-	{"padding-box", BoxArea::Padding},
-	{"content-box", BoxArea::Content},
+struct PropertyParserDecoratorData {
+	const SmallUnorderedMap<String, BoxArea> area_keywords = {
+		{"border-box", BoxArea::Border},
+		{"padding-box", BoxArea::Padding},
+		{"content-box", BoxArea::Content},
+	};
 };
+
+ControlledLifetimeResource<PropertyParserDecoratorData> PropertyParserDecorator::parser_data;
+
+void PropertyParserDecorator::Initialize()
+{
+	parser_data.Initialize();
+}
+void PropertyParserDecorator::Shutdown()
+{
+	parser_data.Shutdown();
+}
 
 PropertyParserDecorator::PropertyParserDecorator() {}
 
@@ -94,8 +107,8 @@ bool PropertyParserDecorator::ParseValue(Property& property, const String& decor
 				if (keyword.empty())
 					continue;
 
-				auto it = area_keywords.find(StringUtilities::ToLower(keyword));
-				if (it == area_keywords.end())
+				auto it = parser_data->area_keywords.find(StringUtilities::ToLower(keyword));
+				if (it == parser_data->area_keywords.end())
 					return false; // Bail out if we have an invalid keyword.
 
 				paint_area = it->second;
@@ -150,7 +163,7 @@ bool PropertyParserDecorator::ParseValue(Property& property, const String& decor
 
 String PropertyParserDecorator::ConvertAreaToString(BoxArea area)
 {
-	for (const auto& it : area_keywords)
+	for (const auto& it : parser_data->area_keywords)
 	{
 		if (it.second == area)
 			return it.first;

--- a/Source/Core/PropertyParserDecorator.h
+++ b/Source/Core/PropertyParserDecorator.h
@@ -30,6 +30,7 @@
 #define RMLUI_CORE_PROPERTYPARSERDECORATOR_H
 
 #include "../../Include/RmlUi/Core/PropertyParser.h"
+#include "ControlledLifetimeResource.h"
 
 namespace Rml {
 
@@ -47,8 +48,11 @@ public:
 
 	static String ConvertAreaToString(BoxArea area);
 
+	static void Initialize();
+	static void Shutdown();
+
 private:
-	static const SmallUnorderedMap<String, BoxArea> area_keywords;
+	static ControlledLifetimeResource<struct PropertyParserDecoratorData> parser_data;
 };
 
 } // namespace Rml

--- a/Source/Core/PropertyParserNumber.cpp
+++ b/Source/Core/PropertyParserNumber.cpp
@@ -31,24 +31,38 @@
 
 namespace Rml {
 
-static const UnorderedMap<String, Unit> g_property_unit_string_map = {
-	{"", Unit::NUMBER},
-	{"%", Unit::PERCENT},
-	{"px", Unit::PX},
-	{"dp", Unit::DP},
-	{"x", Unit::X},
-	{"vw", Unit::VW},
-	{"vh", Unit::VH},
-	{"em", Unit::EM},
-	{"rem", Unit::REM},
-	{"in", Unit::INCH},
-	{"cm", Unit::CM},
-	{"mm", Unit::MM},
-	{"pt", Unit::PT},
-	{"pc", Unit::PC},
-	{"deg", Unit::DEG},
-	{"rad", Unit::RAD},
+struct PropertyParserNumberData {
+	const UnorderedMap<String, Unit> unit_string_map = {
+		{"", Unit::NUMBER},
+		{"%", Unit::PERCENT},
+		{"px", Unit::PX},
+		{"dp", Unit::DP},
+		{"x", Unit::X},
+		{"vw", Unit::VW},
+		{"vh", Unit::VH},
+		{"em", Unit::EM},
+		{"rem", Unit::REM},
+		{"in", Unit::INCH},
+		{"cm", Unit::CM},
+		{"mm", Unit::MM},
+		{"pt", Unit::PT},
+		{"pc", Unit::PC},
+		{"deg", Unit::DEG},
+		{"rad", Unit::RAD},
+	};
 };
+
+ControlledLifetimeResource<PropertyParserNumberData> PropertyParserNumber::parser_data;
+
+void PropertyParserNumber::Initialize()
+{
+	parser_data.Initialize();
+}
+
+void PropertyParserNumber::Shutdown()
+{
+	parser_data.Shutdown();
+}
 
 PropertyParserNumber::PropertyParserNumber(Units units, Unit zero_unit) : units(units), zero_unit(zero_unit) {}
 
@@ -79,8 +93,8 @@ bool PropertyParserNumber::ParseValue(Property& property, const String& value, c
 		return false;
 	}
 
-	const auto it = g_property_unit_string_map.find(str_unit);
-	if (it == g_property_unit_string_map.end())
+	const auto it = parser_data->unit_string_map.find(str_unit);
+	if (it == parser_data->unit_string_map.end())
 	{
 		// Invalid unit name
 		return false;

--- a/Source/Core/PropertyParserNumber.h
+++ b/Source/Core/PropertyParserNumber.h
@@ -30,6 +30,7 @@
 #define RMLUI_CORE_PROPERTYPARSERNUMBER_H
 
 #include "../../Include/RmlUi/Core/PropertyParser.h"
+#include "ControlledLifetimeResource.h"
 
 namespace Rml {
 
@@ -51,7 +52,12 @@ public:
 	/// @return True if the value was validated successfully, false otherwise.
 	bool ParseValue(Property& property, const String& value, const ParameterMap& parameters) const override;
 
+	static void Initialize();
+	static void Shutdown();
+
 private:
+	static ControlledLifetimeResource<struct PropertyParserNumberData> parser_data;
+
 	// Stores a bit mask of allowed units.
 	Units units;
 

--- a/Source/Core/StyleSheetContainer.cpp
+++ b/Source/Core/StyleSheetContainer.cpp
@@ -59,7 +59,7 @@ bool StyleSheetContainer::UpdateCompiledStyleSheet(const Context* context)
 
 	Vector<int> new_active_media_block_indices;
 
-	const float font_size = DefaultComputedValues.font_size();
+	const float font_size = DefaultComputedValues().font_size();
 
 	for (int media_block_index = 0; media_block_index < (int)media_blocks.size(); media_block_index++)
 	{

--- a/Source/Core/StyleSheetParser.cpp
+++ b/Source/Core/StyleSheetParser.cpp
@@ -38,6 +38,7 @@
 #include "../../Include/RmlUi/Core/StyleSheetContainer.h"
 #include "../../Include/RmlUi/Core/StyleSheetSpecification.h"
 #include "ComputeProperty.h"
+#include "ControlledLifetimeResource.h"
 #include "StyleSheetFactory.h"
 #include "StyleSheetNode.h"
 #include <algorithm>
@@ -158,8 +159,6 @@ public:
 	}
 };
 
-static UniquePtr<SpritesheetPropertyParser> spritesheet_property_parser;
-
 /*
  * Media queries need a special parser because they have unique properties that
  * aren't admissible in other property declaration contexts.
@@ -208,7 +207,13 @@ public:
 	}
 };
 
-static UniquePtr<MediaQueryPropertyParser> media_query_property_parser;
+struct StyleSheetParserData {
+	// The following parsers are reasonably heavy to initialize, so we construct them during library initialization.
+	SpritesheetPropertyParser spritesheet;
+	MediaQueryPropertyParser media_query;
+};
+
+static ControlledLifetimeResource<StyleSheetParserData> style_sheet_property_parsers;
 
 StyleSheetParser::StyleSheetParser()
 {
@@ -221,14 +226,12 @@ StyleSheetParser::~StyleSheetParser() {}
 
 void StyleSheetParser::Initialise()
 {
-	spritesheet_property_parser = MakeUnique<SpritesheetPropertyParser>();
-	media_query_property_parser = MakeUnique<MediaQueryPropertyParser>();
+	style_sheet_property_parsers.Initialize();
 }
 
 void StyleSheetParser::Shutdown()
 {
-	spritesheet_property_parser.reset();
-	media_query_property_parser.reset();
+	style_sheet_property_parsers.Shutdown();
 }
 
 static bool IsValidIdentifier(const String& str)
@@ -399,7 +402,7 @@ bool StyleSheetParser::ParseDecoratorBlock(const String& at_name, NamedDecorator
 
 bool StyleSheetParser::ParseMediaFeatureMap(const String& rules, PropertyDictionary& properties, MediaQueryModifier& modifier)
 {
-	media_query_property_parser->SetTargetProperties(&properties);
+	style_sheet_property_parsers->media_query.SetTargetProperties(&properties);
 
 	enum ParseState { Global, Name, Value };
 	ParseState state = Global;
@@ -429,7 +432,8 @@ bool StyleSheetParser::ParseMediaFeatureMap(const String& rules, PropertyDiction
 					// we can only ever see one "not" on the entire global query.
 					if (modifier != MediaQueryModifier::None)
 					{
-						Log::Message(Log::LT_WARNING, "Unexpected '%s' in @media query list at %s:%d.", current_string.c_str(), stream_file_name.c_str(), line_number);
+						Log::Message(Log::LT_WARNING, "Unexpected '%s' in @media query list at %s:%d.", current_string.c_str(),
+							stream_file_name.c_str(), line_number);
 						return false;
 					}
 
@@ -451,8 +455,7 @@ bool StyleSheetParser::ParseMediaFeatureMap(const String& rules, PropertyDiction
 			current_string = StringUtilities::StripWhitespace(StringUtilities::ToLower(std::move(current_string)));
 
 			// allow an empty string to pass through only if we had just parsed a modifier.
-			if (current_string != "and" &&
-				(properties.GetNumProperties() != 0 || !current_string.empty()))
+			if (current_string != "and" && (properties.GetNumProperties() != 0 || !current_string.empty()))
 			{
 				Log::Message(Log::LT_WARNING, "Unexpected '%s' in @media query list at %s:%d. Expected 'and'.", current_string.c_str(),
 					stream_file_name.c_str(), line_number);
@@ -473,7 +476,7 @@ bool StyleSheetParser::ParseMediaFeatureMap(const String& rules, PropertyDiction
 
 			current_string = StringUtilities::StripWhitespace(current_string);
 
-			if (!media_query_property_parser->Parse(name, current_string))
+			if (!style_sheet_property_parsers->media_query.Parse(name, current_string))
 				Log::Message(Log::LT_WARNING, "Syntax error parsing media-query property declaration '%s: %s;' in %s: %d.", name.c_str(),
 					current_string.c_str(), stream_file_name.c_str(), line_number);
 
@@ -629,12 +632,12 @@ bool StyleSheetParser::Parse(MediaBlockList& style_sheets, Stream* _stream, int 
 					}
 					else if (at_rule_identifier == "spritesheet")
 					{
-						// The spritesheet parser is reasonably heavy to initialize, so we make it a static global.
-						ReadProperties(*spritesheet_property_parser);
+						auto& spritesheet_property_parser = style_sheet_property_parsers->spritesheet;
+						ReadProperties(spritesheet_property_parser);
 
-						const String& image_source = spritesheet_property_parser->GetImageSource();
-						const SpriteDefinitionList& sprite_definitions = spritesheet_property_parser->GetSpriteDefinitions();
-						const float image_resolution_factor = spritesheet_property_parser->GetImageResolutionFactor();
+						const String& image_source = spritesheet_property_parser.GetImageSource();
+						const SpriteDefinitionList& sprite_definitions = spritesheet_property_parser.GetSpriteDefinitions();
+						const float image_resolution_factor = spritesheet_property_parser.GetImageResolutionFactor();
 
 						if (sprite_definitions.empty())
 						{
@@ -660,7 +663,7 @@ bool StyleSheetParser::Parse(MediaBlockList& style_sheets, Stream* _stream, int 
 								display_scale, sprite_definitions);
 						}
 
-						spritesheet_property_parser->Clear();
+						spritesheet_property_parser.Clear();
 						at_rule_name.clear();
 						state = State::Global;
 					}

--- a/Source/Core/StyleSheetSpecification.cpp
+++ b/Source/Core/StyleSheetSpecification.cpp
@@ -97,25 +97,31 @@ ShorthandId StyleSheetSpecification::RegisterShorthand(ShorthandId id, const Str
 	return properties.RegisterShorthand(shorthand_name, property_names, type, id);
 }
 
-bool StyleSheetSpecification::Initialise()
+void StyleSheetSpecification::Initialise()
 {
-	if (instance == nullptr)
-	{
-		new StyleSheetSpecification();
+	RMLUI_ASSERT(!instance);
 
-		instance->RegisterDefaultParsers();
-		instance->RegisterDefaultProperties();
-	}
+	PropertyParserAnimation::Initialize();
+	PropertyParserColour::Initialize();
+	PropertyParserDecorator::Initialize();
+	PropertyParserNumber::Initialize();
 
-	return true;
+	new StyleSheetSpecification();
+
+	instance->RegisterDefaultParsers();
+	instance->RegisterDefaultProperties();
 }
 
 void StyleSheetSpecification::Shutdown()
 {
-	if (instance != nullptr)
-	{
-		delete instance;
-	}
+	RMLUI_ASSERT(instance);
+
+	delete instance;
+
+	PropertyParserAnimation::Shutdown();
+	PropertyParserColour::Shutdown();
+	PropertyParserDecorator::Shutdown();
+	PropertyParserNumber::Shutdown();
 }
 
 bool StyleSheetSpecification::RegisterParser(const String& parser_name, PropertyParser* parser)
@@ -422,10 +428,10 @@ void StyleSheetSpecification::RegisterDefaultProperties()
 	RegisterProperty(PropertyId::Decorator, "decorator", "", false, false).AddParser("decorator");
 	RegisterProperty(PropertyId::MaskImage, "mask-image", "", false, false).AddParser("decorator");
 	RegisterProperty(PropertyId::FontEffect, "font-effect", "", true, false).AddParser("font_effect");
-		
+
 	RegisterProperty(PropertyId::Filter, "filter", "", false, false).AddParser("filter", "filter");
 	RegisterProperty(PropertyId::BackdropFilter, "backdrop-filter", "", false, false).AddParser("filter");
-	
+
 	RegisterProperty(PropertyId::BoxShadow, "box-shadow", "none", false, false).AddParser("box_shadow");
 
 	// Rare properties (not added to computed values)
@@ -435,7 +441,7 @@ void StyleSheetSpecification::RegisterDefaultProperties()
 	RegisterProperty(PropertyId::AlignContent, "align-content", "stretch", false, true).AddParser("keyword", "flex-start, flex-end, center, space-between, space-around, space-evenly, stretch");
 	RegisterProperty(PropertyId::AlignItems, "align-items", "stretch", false, true).AddParser("keyword", "flex-start, flex-end, center, baseline, stretch");
 	RegisterProperty(PropertyId::AlignSelf, "align-self", "auto", false, true).AddParser("keyword", "auto, flex-start, flex-end, center, baseline, stretch");
-	
+
 	RegisterProperty(PropertyId::FlexBasis, "flex-basis", "auto", false, true).AddParser("keyword", "auto").AddParser("length_percent");
 	RegisterProperty(PropertyId::FlexDirection, "flex-direction", "row", false, true).AddParser("keyword", "row, row-reverse, column, column-reverse");
 

--- a/Source/Core/SystemInterface.cpp
+++ b/Source/Core/SystemInterface.cpp
@@ -35,7 +35,11 @@
 
 namespace Rml {
 
-static String clipboard_text;
+static String& GlobalClipBoardText()
+{
+	static String clipboard_text;
+	return clipboard_text;
+}
 
 SystemInterface::SystemInterface() {}
 
@@ -59,12 +63,12 @@ void SystemInterface::SetMouseCursor(const String& /*cursor_name*/) {}
 void SystemInterface::SetClipboardText(const String& text)
 {
 	// The default implementation will only copy and paste within the application
-	clipboard_text = text;
+	GlobalClipBoardText() = text;
 }
 
 void SystemInterface::GetClipboardText(String& text)
 {
-	text = clipboard_text;
+	text = GlobalClipBoardText();
 }
 
 int SystemInterface::TranslateString(String& translated, const String& input)

--- a/Tests/Source/Common/TestsShell.cpp
+++ b/Tests/Source/Common/TestsShell.cpp
@@ -164,9 +164,9 @@ void TestsShell::ShutdownShell()
 		(void)num_documents_begin;
 	}
 
-	tests_system_interface.SetNumExpectedWarnings(0);
-
 	Rml::Shutdown();
+
+	tests_system_interface.SetNumExpectedWarnings(0);
 
 #ifdef RMLUI_TESTS_USE_SHELL
 	Backend::Shutdown();

--- a/Tests/Source/UnitTests/Core.cpp
+++ b/Tests/Source/UnitTests/Core.cpp
@@ -264,3 +264,18 @@ TEST_CASE("core.initialize")
 
 	Rml::Shutdown();
 }
+
+TEST_CASE("core.observer_ptr")
+{
+	Context* context = TestsShell::GetContext();
+	ElementDocument* document = context->LoadDocument("assets/demo.rml");
+
+	ObserverPtr<Element> observer_ptr = document->GetObserverPtr();
+	document->Close();
+
+	// We expect a warning about the observer pointer being held in user space, preventing its memory pool from shutting down.
+	TestsSystemInterface* system_interface = TestsShell::GetTestsSystemInterface();
+	system_interface->SetNumExpectedWarnings(1);
+
+	TestsShell::ShutdownShell();
+}

--- a/Tests/Source/UnitTests/ElementDocument.cpp
+++ b/Tests/Source/UnitTests/ElementDocument.cpp
@@ -260,28 +260,32 @@ TEST_CASE("Load")
 	Context* context = TestsShell::GetContext();
 	REQUIRE(context);
 
-	MockEventListener mockEventListener;
-	MockEventListenerInstancer mockEventListenerInstancer;
+	{
+		MockEventListener mockEventListener;
+		MockEventListenerInstancer mockEventListenerInstancer;
 
-	tl::sequence sequence;
-	REQUIRE_CALL(mockEventListenerInstancer, InstanceEventListener("something", tl::_))
-		.WITH(_2->GetTagName() == BODY_TAG)
-		.IN_SEQUENCE(sequence)
-		.LR_RETURN(&mockEventListener);
+		tl::sequence sequence;
+		REQUIRE_CALL(mockEventListenerInstancer, InstanceEventListener("something", tl::_))
+			.WITH(_2->GetTagName() == BODY_TAG)
+			.IN_SEQUENCE(sequence)
+			.LR_RETURN(&mockEventListener);
 
-	ALLOW_CALL(mockEventListener, OnAttach(tl::_));
-	ALLOW_CALL(mockEventListener, OnDetach(tl::_));
+		ALLOW_CALL(mockEventListener, OnAttach(tl::_));
+		ALLOW_CALL(mockEventListener, OnDetach(tl::_));
 
-	REQUIRE_CALL(mockEventListener, ProcessEvent(tl::_))
-		.WITH(_1.GetId() == EventId::Load && _1.GetTargetElement()->GetTagName() == BODY_TAG)
-		.IN_SEQUENCE(sequence);
+		REQUIRE_CALL(mockEventListener, ProcessEvent(tl::_))
+			.WITH(_1.GetId() == EventId::Load && _1.GetTargetElement()->GetTagName() == BODY_TAG)
+			.IN_SEQUENCE(sequence);
 
-	Factory::RegisterEventListenerInstancer(&mockEventListenerInstancer);
+		Factory::RegisterEventListenerInstancer(&mockEventListenerInstancer);
 
-	ElementDocument* document = context->LoadDocumentFromMemory(document_focus_rml);
-	REQUIRE(document);
+		ElementDocument* document = context->LoadDocumentFromMemory(document_focus_rml);
+		REQUIRE(document);
 
-	document->Close();
+		document->Close();
+		context->Update();
+	}
+
 	TestsShell::ShutdownShell();
 }
 

--- a/Tests/Source/UnitTests/ElementFormControlSelect.cpp
+++ b/Tests/Source/UnitTests/ElementFormControlSelect.cpp
@@ -568,6 +568,8 @@ TEST_CASE("form.select.event.change")
 	CHECK(listener->num_events_processed == 3);
 
 	document->Close();
+	context->Update();
+	listener.reset();
 
 	TestsShell::ShutdownShell();
 }


### PR DESCRIPTION
Instead, explicitly start lifetime of globals on library initialization. This is achieved by using the new ControlledLifetimeResource class. This can be used as a wrapper around globals to explicitly initialize and shutdown the objects.

This wrapper has been applied to all non-trivial global data in RmlUi. Thus, there should no longer be any memory allocations occurring before `main()` when linking in RmlUi.

We now give a warning if there are objects in user space that refer to any RmlUi resources at the end of `Rml::Shutdown`, as this prevents the library from cleaning up memory pools. Other than the warning, the behavior should be the same as previously.

Breaking change: `Rml::ReleaseMemoryPools` is no longer exposed publicly. This function is automatically called during shutdown and should not be used manually.