### PR TITLE
Allow custom getter/setter on scoped enum

### DIFF
--- a/Include/RmlUi/Core/DataModelHandle.h
+++ b/Include/RmlUi/Core/DataModelHandle.h
@@ -143,8 +143,8 @@ private:
 template <typename T>
 inline bool DataModelConstructor::RegisterScalar(DataTypeGetFunc<T> get_func, DataTypeSetFunc<T> set_func)
 {
-	// Though scoped enum is builtin scalar type, we allow custom getter/setter on it.
-	static_assert(!is_builtin_data_scalar<T>::value || is_scoped_enum<T>::value,
+	// Though enum is builtin scalar type, we allow custom getter/setter on it.
+	static_assert(!is_builtin_data_scalar<T>::value || std::is_enum<T>::value,
 		"Cannot register scalar data type function. Arithmetic types and String are handled internally and does not need to be registered.");
 	const FamilyId id = Family<T>::Id();
 

--- a/Include/RmlUi/Core/DataModelHandle.h
+++ b/Include/RmlUi/Core/DataModelHandle.h
@@ -143,7 +143,8 @@ private:
 template <typename T>
 inline bool DataModelConstructor::RegisterScalar(DataTypeGetFunc<T> get_func, DataTypeSetFunc<T> set_func)
 {
-	static_assert(!is_builtin_data_scalar<T>::value,
+	// Though scoped enum is builtin scalar type, we allow custom getter/setter on it.
+	static_assert(!is_builtin_data_scalar<T>::value || is_scoped_enum<T>::value,
 		"Cannot register scalar data type function. Arithmetic types and String are handled internally and does not need to be registered.");
 	const FamilyId id = Family<T>::Id();
 

--- a/Include/RmlUi/Core/DataTypeRegister.h
+++ b/Include/RmlUi/Core/DataTypeRegister.h
@@ -37,16 +37,6 @@
 
 namespace Rml {
 
-template <typename T, bool = std::is_enum<T>::value>
-struct is_scoped_enum {
-	static constexpr bool value = false;
-};
-
-template <typename T>
-struct is_scoped_enum<T, true> {
-	static constexpr bool value = !std::is_convertible<T, int>::value;
-};
-
 template <typename T>
 struct is_builtin_data_scalar {
 	static constexpr bool value =

--- a/Include/RmlUi/Core/DataTypeRegister.h
+++ b/Include/RmlUi/Core/DataTypeRegister.h
@@ -37,6 +37,16 @@
 
 namespace Rml {
 
+template <typename T, bool = std::is_enum<T>::value>
+struct is_scoped_enum {
+	static constexpr bool value = false;
+};
+
+template <typename T>
+struct is_scoped_enum<T, true> {
+	static constexpr bool value = !std::is_convertible<T, int>::value;
+};
+
 template <typename T>
 struct is_builtin_data_scalar {
 	static constexpr bool value =


### PR DESCRIPTION
Close #693.

*Edit:* During experiment, I found that even for plain enums, we can have both default and custom getter/setter in one data model. So I pushed a second commit to allow custom getter/setter for all enums.