### PR TITLE
Allow selecting fonts from collections

### DIFF
--- a/Include/RmlUi/Core/Core.h
+++ b/Include/RmlUi/Core/Core.h
@@ -134,8 +134,9 @@ RMLUICORE_API int GetNumContexts();
 /// @param[in] fallback_face True to use this font face for unknown characters in other font faces.
 /// @param[in] weight The weight to load when the font face contains multiple weights, otherwise the weight to register the font as. By default, it
 /// loads all found font weights.
+/// @param[in] face_index The index of the font face within a font collection.
 /// @return True if the face was loaded successfully, false otherwise.
-RMLUICORE_API bool LoadFontFace(const String& file_path, bool fallback_face = false, Style::FontWeight weight = Style::FontWeight::Auto);
+RMLUICORE_API bool LoadFontFace(const String& file_path, bool fallback_face = false, Style::FontWeight weight = Style::FontWeight::Auto, int face_index = 0);
 /// Adds a new font face from memory to the font engine. The face's family, style and weight is given by the parameters.
 /// @param[in] data The font data.
 /// @param[in] family The family to register the font as.
@@ -143,10 +144,11 @@ RMLUICORE_API bool LoadFontFace(const String& file_path, bool fallback_face = fa
 /// @param[in] weight The weight to load when the font face contains multiple weights, otherwise the weight to register the font as. By default, it
 /// loads all found font weights.
 /// @param[in] fallback_face True to use this font face for unknown characters in other font faces.
+/// @param[in] face_index The index of the font face within a font collection.
 /// @return True if the face was loaded successfully, false otherwise.
 /// @lifetime The pointed to 'data' must remain available until after the call to Rml::Shutdown.
 RMLUICORE_API bool LoadFontFace(Span<const byte> data, const String& family, Style::FontStyle style,
-	Style::FontWeight weight = Style::FontWeight::Auto, bool fallback_face = false);
+	Style::FontWeight weight = Style::FontWeight::Auto, bool fallback_face = false, int face_index = 0);
 
 /// Registers a generic RmlUi plugin.
 RMLUICORE_API void RegisterPlugin(Plugin* plugin);

--- a/Include/RmlUi/Core/FontEngineInterface.h
+++ b/Include/RmlUi/Core/FontEngineInterface.h
@@ -57,20 +57,22 @@ public:
 
 	/// Called by RmlUi when it wants to load a font face from file.
 	/// @param[in] file_name The file to load the face from.
+	/// @param[in] face_index The index of the font face within a font collection.
 	/// @param[in] fallback_face True to use this font face for unknown characters in other font faces.
 	/// @param[in] weight The weight to load when the font face contains multiple weights, otherwise the weight to register the font as.
 	/// @return True if the face was loaded successfully, false otherwise.
-	virtual bool LoadFontFace(const String& file_name, bool fallback_face, Style::FontWeight weight);
+	virtual bool LoadFontFace(const String& file_name, int face_index, bool fallback_face, Style::FontWeight weight);
 
 	/// Called by RmlUi when it wants to load a font face from memory, registered using the provided family, style, and weight.
 	/// @param[in] data The font data.
+	/// @param[in] face_index The index of the font face within a font collection.
 	/// @param[in] family The family to register the font as.
 	/// @param[in] style The style to register the font as.
 	/// @param[in] weight The weight to load when the font face contains multiple weights, otherwise the weight to register the font as.
 	/// @param[in] fallback_face True to use this font face for unknown characters in other font faces.
 	/// @return True if the face was loaded successfully, false otherwise.
 	/// @note The debugger plugin will load its embedded font faces through this method using the family name 'rmlui-debugger-font'.
-	virtual bool LoadFontFace(Span<const byte> data, const String& family, Style::FontStyle style, Style::FontWeight weight, bool fallback_face);
+	virtual bool LoadFontFace(Span<const byte> data, int face_index, const String& family, Style::FontStyle style, Style::FontWeight weight, bool fallback_face);
 
 	/// Called by RmlUi when a font configuration is resolved for an element. Should return a handle that
 	/// can later be used to resolve properties of the face, and generate string geometry to be rendered.
@@ -118,7 +120,7 @@ public:
 
 	/// Called by RmlUi to determine if the text geometry is required to be re-generated. Whenever the returned version
 	/// is changed, all geometry belonging to the given face handle will be re-generated.
-	/// @param[in] handle The font handle.
+	/// @param[in] face_handle The font handle.
 	/// @return The version required for using any geometry generated with the face handle.
 	virtual int GetVersion(FontFaceHandle handle);
 

--- a/Samples/basic/bitmap_font/src/FontEngineInterfaceBitmap.cpp
+++ b/Samples/basic/bitmap_font/src/FontEngineInterfaceBitmap.cpp
@@ -40,12 +40,12 @@ void FontEngineInterfaceBitmap::Shutdown()
 	FontProviderBitmap::Shutdown();
 }
 
-bool FontEngineInterfaceBitmap::LoadFontFace(const String& file_name, bool /*fallback_face*/, FontWeight /*weight*/)
+bool FontEngineInterfaceBitmap::LoadFontFace(const String& file_name, int /*face_index*/, bool /*fallback_face*/, FontWeight /*weight*/)
 {
 	return FontProviderBitmap::LoadFontFace(file_name);
 }
 
-bool FontEngineInterfaceBitmap::LoadFontFace(Span<const byte> /*data*/, const String& font_family, FontStyle /*style*/, FontWeight /*weight*/,
+bool FontEngineInterfaceBitmap::LoadFontFace(Span<const byte> /*data*/, int /*face_index*/, const String& font_family, FontStyle /*style*/, FontWeight /*weight*/,
 	bool /*fallback_face*/)
 {
 	// We return 'true' here to allow the debugger to continue loading, but we will use our own fonts when it asks for a handle.

--- a/Samples/basic/bitmap_font/src/FontEngineInterfaceBitmap.h
+++ b/Samples/basic/bitmap_font/src/FontEngineInterfaceBitmap.h
@@ -63,11 +63,11 @@ public:
 	void Shutdown() override;
 
 	/// Called by RmlUi when it wants to load a font face from file.
-	bool LoadFontFace(const String& file_name, bool fallback_face, FontWeight weight) override;
+	bool LoadFontFace(const String& file_name, int face_index, bool fallback_face, FontWeight weight) override;
 
 	/// Called by RmlUi when it wants to load a font face from memory, registered using the provided family, style, and weight.
 	/// @param[in] data A pointer to the data.
-	bool LoadFontFace(Span<const byte> data, const String& family, FontStyle style, FontWeight weight, bool fallback_face) override;
+	bool LoadFontFace(Span<const byte> data, int face_index, const String& family, FontStyle style, FontWeight weight, bool fallback_face) override;
 
 	/// Called by RmlUi when a font configuration is resolved for an element. Should return a handle that
 	/// can later be used to resolve properties of the face, and generate string geometry to be rendered.

--- a/Samples/basic/harfbuzz/src/FontEngineInterfaceHarfBuzz.cpp
+++ b/Samples/basic/harfbuzz/src/FontEngineInterfaceHarfBuzz.cpp
@@ -40,15 +40,15 @@ void FontEngineInterfaceHarfBuzz::Shutdown()
 	FontProvider::Shutdown();
 }
 
-bool FontEngineInterfaceHarfBuzz::LoadFontFace(const String& file_name, bool fallback_face, Style::FontWeight weight)
+bool FontEngineInterfaceHarfBuzz::LoadFontFace(const String& file_name, int face_index, bool fallback_face, Style::FontWeight weight)
 {
-	return FontProvider::LoadFontFace(file_name, fallback_face, weight);
+	return FontProvider::LoadFontFace(file_name, face_index, fallback_face, weight);
 }
 
-bool FontEngineInterfaceHarfBuzz::LoadFontFace(Span<const byte> data, const String& font_family, Style::FontStyle style, Style::FontWeight weight,
+bool FontEngineInterfaceHarfBuzz::LoadFontFace(Span<const byte> data, int face_index, const String& font_family, Style::FontStyle style, Style::FontWeight weight,
 	bool fallback_face)
 {
-	return FontProvider::LoadFontFace(data, font_family, style, weight, fallback_face);
+	return FontProvider::LoadFontFace(data, face_index, font_family, style, weight, fallback_face);
 }
 
 FontFaceHandle FontEngineInterfaceHarfBuzz::GetFontFaceHandle(const String& family, Style::FontStyle style, Style::FontWeight weight, int size)

--- a/Samples/basic/harfbuzz/src/FontEngineInterfaceHarfBuzz.h
+++ b/Samples/basic/harfbuzz/src/FontEngineInterfaceHarfBuzz.h
@@ -54,10 +54,10 @@ public:
 	void Shutdown() override;
 
 	/// Adds a new font face to the database. The face's family, style and weight will be determined from the face itself.
-	bool LoadFontFace(const String& file_name, bool fallback_face, Style::FontWeight weight) override;
+	bool LoadFontFace(const String& file_name, int face_index, bool fallback_face, Style::FontWeight weight) override;
 
 	/// Adds a new font face to the database using the provided family, style and weight.
-	bool LoadFontFace(Span<const byte> data, const String& font_family, Style::FontStyle style, Style::FontWeight weight,
+	bool LoadFontFace(Span<const byte> data, int face_index, const String& font_family, Style::FontStyle style, Style::FontWeight weight,
 		bool fallback_face) override;
 
 	/// Returns a handle to a font face that can be used to position and render text. This will return the closest match

--- a/Samples/basic/harfbuzz/src/FontProvider.h
+++ b/Samples/basic/harfbuzz/src/FontProvider.h
@@ -67,10 +67,10 @@ public:
 	static FontFaceHandleHarfBuzz* GetFontFaceHandle(const String& family, Style::FontStyle style, Style::FontWeight weight, int size);
 
 	/// Adds a new font face to the database. The face's family, style and weight will be determined from the face itself.
-	static bool LoadFontFace(const String& file_name, bool fallback_face, Style::FontWeight weight = Style::FontWeight::Auto);
+	static bool LoadFontFace(const String& file_name, int face_index, bool fallback_face, Style::FontWeight weight = Style::FontWeight::Auto);
 
 	/// Adds a new font face from memory.
-	static bool LoadFontFace(Span<const byte> data, const String& font_family, Style::FontStyle style, Style::FontWeight weight, bool fallback_face);
+	static bool LoadFontFace(Span<const byte> data, int face_index, const String& font_family, Style::FontStyle style, Style::FontWeight weight, bool fallback_face);
 
 	/// Return the number of fallback font faces.
 	static int CountFallbackFontFaces();
@@ -87,7 +87,7 @@ private:
 
 	static FontProvider& Get();
 
-	bool LoadFontFace(Span<const byte> data, bool fallback_face, UniquePtr<byte[]> face_memory, const String& source, String font_family,
+	bool LoadFontFace(Span<const byte> data, int face_index, bool fallback_face, UniquePtr<byte[]> face_memory, const String& source, String font_family,
 		Style::FontStyle style,
 		Style::FontWeight weight);
 

--- a/Source/Core/Core.cpp
+++ b/Source/Core/Core.cpp
@@ -356,14 +356,14 @@ int GetNumContexts()
 	return (int)core_data->contexts.size();
 }
 
-bool LoadFontFace(const String& file_path, bool fallback_face, Style::FontWeight weight)
+bool LoadFontFace(const String& file_path, bool fallback_face, Style::FontWeight weight, int face_index)
 {
-	return font_interface->LoadFontFace(file_path, fallback_face, weight);
+	return font_interface->LoadFontFace(file_path, face_index, fallback_face, weight);
 }
 
-bool LoadFontFace(Span<const byte> data, const String& family, Style::FontStyle style, Style::FontWeight weight, bool fallback_face)
+bool LoadFontFace(Span<const byte> data, const String& family, Style::FontStyle style, Style::FontWeight weight, bool fallback_face, int face_index)
 {
-	return font_interface->LoadFontFace(data, family, style, weight, fallback_face);
+	return font_interface->LoadFontFace(data, face_index, family, style, weight, fallback_face);
 }
 
 void RegisterPlugin(Plugin* plugin)

--- a/Source/Core/FontEngineDefault/FontEngineInterfaceDefault.cpp
+++ b/Source/Core/FontEngineDefault/FontEngineInterfaceDefault.cpp
@@ -43,15 +43,15 @@ void FontEngineInterfaceDefault::Shutdown()
 	FontProvider::Shutdown();
 }
 
-bool FontEngineInterfaceDefault::LoadFontFace(const String& file_name, bool fallback_face, Style::FontWeight weight)
+bool FontEngineInterfaceDefault::LoadFontFace(const String& file_name, int face_index, bool fallback_face, Style::FontWeight weight)
 {
-	return FontProvider::LoadFontFace(file_name, fallback_face, weight);
+	return FontProvider::LoadFontFace(file_name, face_index, fallback_face, weight);
 }
 
-bool FontEngineInterfaceDefault::LoadFontFace(Span<const byte> data, const String& font_family, Style::FontStyle style, Style::FontWeight weight,
+bool FontEngineInterfaceDefault::LoadFontFace(Span<const byte> data, int face_index, const String& font_family, Style::FontStyle style, Style::FontWeight weight,
 	bool fallback_face)
 {
-	return FontProvider::LoadFontFace(data, font_family, style, weight, fallback_face);
+	return FontProvider::LoadFontFace(data, face_index, font_family, style, weight, fallback_face);
 }
 
 FontFaceHandle FontEngineInterfaceDefault::GetFontFaceHandle(const String& family, Style::FontStyle style, Style::FontWeight weight, int size)

--- a/Source/Core/FontEngineDefault/FontEngineInterfaceDefault.h
+++ b/Source/Core/FontEngineDefault/FontEngineInterfaceDefault.h
@@ -41,10 +41,10 @@ public:
 	void Shutdown() override;
 
 	/// Adds a new font face to the database. The face's family, style and weight will be determined from the face itself.
-	bool LoadFontFace(const String& file_name, bool fallback_face, Style::FontWeight weight) override;
+	bool LoadFontFace(const String& file_name, int face_index, bool fallback_face, Style::FontWeight weight) override;
 
 	/// Adds a new font face to the database using the provided family, style and weight.
-	bool LoadFontFace(Span<const byte> data, const String& font_family, Style::FontStyle style, Style::FontWeight weight,
+	bool LoadFontFace(Span<const byte> data, int face_index, const String& font_family, Style::FontStyle style, Style::FontWeight weight,
 		bool fallback_face) override;
 
 	/// Returns a handle to a font face that can be used to position and render text. This will return the closest match

--- a/Source/Core/FontEngineDefault/FontProvider.cpp
+++ b/Source/Core/FontEngineDefault/FontProvider.cpp
@@ -110,7 +110,7 @@ void FontProvider::ReleaseFontResources()
 		name_family.second->ReleaseFontResources();
 }
 
-bool FontProvider::LoadFontFace(const String& file_name, bool fallback_face, Style::FontWeight weight)
+bool FontProvider::LoadFontFace(const String& file_name, int face_index, bool fallback_face, Style::FontWeight weight)
 {
 	FileInterface* file_interface = GetFileInterface();
 	FileHandle handle = file_interface->Open(file_name);
@@ -128,28 +128,28 @@ bool FontProvider::LoadFontFace(const String& file_name, bool fallback_face, Sty
 	file_interface->Read(buffer, length, handle);
 	file_interface->Close(handle);
 
-	bool result = Get().LoadFontFace({buffer, length}, fallback_face, std::move(buffer_ptr), file_name, {}, Style::FontStyle::Normal, weight);
+	bool result = Get().LoadFontFace({buffer, length}, face_index, fallback_face, std::move(buffer_ptr), file_name, {}, Style::FontStyle::Normal, weight);
 
 	return result;
 }
 
-bool FontProvider::LoadFontFace(Span<const byte> data, const String& font_family, Style::FontStyle style, Style::FontWeight weight,
+bool FontProvider::LoadFontFace(Span<const byte> data, int face_index, const String& font_family, Style::FontStyle style, Style::FontWeight weight,
 	bool fallback_face)
 {
 	const String source = "memory";
 
-	bool result = Get().LoadFontFace(data, fallback_face, nullptr, source, font_family, style, weight);
+	bool result = Get().LoadFontFace(data, face_index, fallback_face, nullptr, source, font_family, style, weight);
 
 	return result;
 }
 
-bool FontProvider::LoadFontFace(Span<const byte> data, bool fallback_face, UniquePtr<byte[]> face_memory, const String& source, String font_family,
+bool FontProvider::LoadFontFace(Span<const byte> data, int face_index, bool fallback_face, UniquePtr<byte[]> face_memory, const String& source, String font_family,
 	Style::FontStyle style, Style::FontWeight weight)
 {
 	using Style::FontWeight;
 
 	Vector<FaceVariation> face_variations;
-	if (!FreeType::GetFaceVariations(data, face_variations))
+	if (!FreeType::GetFaceVariations(data, face_variations, face_index))
 	{
 		Log::Message(Log::LT_ERROR, "Failed to load font face from '%s': Invalid or unsupported font face file format.", source.c_str());
 		return false;
@@ -205,7 +205,7 @@ bool FontProvider::LoadFontFace(Span<const byte> data, bool fallback_face, Uniqu
 
 	for (const FaceVariation& variation : load_variations)
 	{
-		FontFaceHandleFreetype ft_face = FreeType::LoadFace(data, source, variation.named_instance_index);
+		FontFaceHandleFreetype ft_face = FreeType::LoadFace(data, source, face_index, variation.named_instance_index);
 		if (!ft_face)
 			return false;
 

--- a/Source/Core/FontEngineDefault/FontProvider.h
+++ b/Source/Core/FontEngineDefault/FontProvider.h
@@ -60,10 +60,10 @@ public:
 	static FontFaceHandleDefault* GetFontFaceHandle(const String& family, Style::FontStyle style, Style::FontWeight weight, int size);
 
 	/// Adds a new font face to the database. The face's family, style and weight will be determined from the face itself.
-	static bool LoadFontFace(const String& file_name, bool fallback_face, Style::FontWeight weight = Style::FontWeight::Auto);
+	static bool LoadFontFace(const String& file_name, int face_index, bool fallback_face, Style::FontWeight weight = Style::FontWeight::Auto);
 
 	/// Adds a new font face from memory.
-	static bool LoadFontFace(Span<const byte> data, const String& font_family, Style::FontStyle style, Style::FontWeight weight, bool fallback_face);
+	static bool LoadFontFace(Span<const byte> data, int face_index, const String& font_family, Style::FontStyle style, Style::FontWeight weight, bool fallback_face);
 
 	/// Return the number of fallback font faces.
 	static int CountFallbackFontFaces();
@@ -80,7 +80,7 @@ private:
 
 	static FontProvider& Get();
 
-	bool LoadFontFace(Span<const byte> data, bool fallback_face, UniquePtr<byte[]> face_memory, const String& source, String font_family,
+	bool LoadFontFace(Span<const byte> data, int face_index, bool fallback_face, UniquePtr<byte[]> face_memory, const String& source, String font_family,
 		Style::FontStyle style, Style::FontWeight weight);
 
 	bool AddFace(FontFaceHandleFreetype face, const String& family, Style::FontStyle style, Style::FontWeight weight, bool fallback_face,

--- a/Source/Core/FontEngineDefault/FreeTypeInterface.cpp
+++ b/Source/Core/FontEngineDefault/FreeTypeInterface.cpp
@@ -78,12 +78,12 @@ void FreeType::Shutdown()
 	}
 }
 
-bool FreeType::GetFaceVariations(Span<const byte> data, Vector<FaceVariation>& out_face_variations)
+bool FreeType::GetFaceVariations(Span<const byte> data, Vector<FaceVariation>& out_face_variations, int face_index)
 {
 	RMLUI_ASSERT(ft_library);
 
 	FT_Face face = nullptr;
-	FT_Error error = FT_New_Memory_Face(ft_library, static_cast<const FT_Byte*>(data.data()), static_cast<FT_Long>(data.size()), 0, &face);
+	FT_Error error = FT_New_Memory_Face(ft_library, static_cast<const FT_Byte*>(data.data()), static_cast<FT_Long>(data.size()), face_index, &face);
 	if (error)
 		return false;
 
@@ -133,13 +133,13 @@ bool FreeType::GetFaceVariations(Span<const byte> data, Vector<FaceVariation>& o
 	return true;
 }
 
-FontFaceHandleFreetype FreeType::LoadFace(Span<const byte> data, const String& source, int named_style_index)
+FontFaceHandleFreetype FreeType::LoadFace(Span<const byte> data, const String& source, int face_index, int named_style_index)
 {
 	RMLUI_ASSERT(ft_library);
 
 	FT_Face face = nullptr;
 	FT_Error error =
-		FT_New_Memory_Face(ft_library, static_cast<const FT_Byte*>(data.data()), static_cast<FT_Long>(data.size()), (named_style_index << 16), &face);
+		FT_New_Memory_Face(ft_library, static_cast<const FT_Byte*>(data.data()), static_cast<FT_Long>(data.size()), (named_style_index << 16) | face_index, &face);
 
 	if (error)
 	{

--- a/Source/Core/FontEngineDefault/FreeTypeInterface.h
+++ b/Source/Core/FontEngineDefault/FreeTypeInterface.h
@@ -42,10 +42,10 @@ namespace FreeType {
 	void Shutdown();
 
 	// Returns a sorted list of available font variations for the font face located in memory.
-	bool GetFaceVariations(Span<const byte> data, Vector<FaceVariation>& out_face_variations);
+	bool GetFaceVariations(Span<const byte> data, Vector<FaceVariation>& out_face_variations, int face_index);
 
 	// Loads a FreeType face from memory, 'source' is only used for logging.
-	FontFaceHandleFreetype LoadFace(Span<const byte> data, const String& source, int named_instance_index = 0);
+	FontFaceHandleFreetype LoadFace(Span<const byte> data, const String& source, int face_index, int named_instance_index = 0);
 
 	// Releases the FreeType face.
 	bool ReleaseFace(FontFaceHandleFreetype face);

--- a/Source/Core/FontEngineInterface.cpp
+++ b/Source/Core/FontEngineInterface.cpp
@@ -39,12 +39,12 @@ void FontEngineInterface::Initialize() {}
 
 void FontEngineInterface::Shutdown() {}
 
-bool FontEngineInterface::LoadFontFace(const String& /*file_path*/, bool /*fallback_face*/, Style::FontWeight /*weight*/)
+bool FontEngineInterface::LoadFontFace(const String& /*file_path*/, int /*face_index*/, bool /*fallback_face*/, Style::FontWeight /*weight*/)
 {
 	return false;
 }
 
-bool FontEngineInterface::LoadFontFace(Span<const byte> /*data*/, const String& /*family*/, Style::FontStyle /*style*/, Style::FontWeight /*weight*/,
+bool FontEngineInterface::LoadFontFace(Span<const byte> /*data*/, int /*face_index*/, const String& /*family*/, Style::FontStyle /*style*/, Style::FontWeight /*weight*/,
 	bool /*fallback_face*/)
 {
 	return false;

--- a/Source/Lua/RmlUi.cpp
+++ b/Source/Lua/RmlUi.cpp
@@ -82,7 +82,8 @@ int LuaRmlUiCreateContext(lua_State* L, LuaRmlUi* /*obj*/)
 int LuaRmlUiLoadFontFace(lua_State* L, LuaRmlUi* /*obj*/)
 {
 	const char* file = luaL_checkstring(L, 1);
-	lua_pushboolean(L, LoadFontFace(file));
+	int face_index = lua_gettop(L) == 1 ? 0 : static_cast<int>(luaL_checkinteger(L, 2));
+	lua_pushboolean(L, LoadFontFace(file, face_index));
 	return 1;
 }
 


### PR DESCRIPTION
This pull request adds a `face_index` parameter to the `LoadFontFace` function to allow selection of font faces within font collections.

User impact: no impact when `LoadFontFace` is called with just a single path argument as the `face_index` argument is defaulted to `0`, however `face_index` will need to be specified if further arguments are used like `fallback_font`.