### PR TITLE
Update dependency check in RmlUiConfig

### DIFF
--- a/CMake/RmlUiConfig.cmake.in
+++ b/CMake/RmlUiConfig.cmake.in
@@ -6,20 +6,21 @@ set(RMLUI_LUA_BINDINGS @RMLUI_LUA_BINDINGS@)
 set(RMLUI_LUA_BINDINGS_LIBRARY "@RMLUI_LUA_BINDINGS_LIBRARY@")
 set(RMLUI_TRACY_PROFILING "@RMLUI_TRACY_PROFILING@")
 
-macro(report_dependency_not_found friendly_name target_name)
+macro(report_dependency_not_found friendly_name package_name target_name)
 	if(RmlUi_FIND_REQUIRED)
 		message(FATAL_ERROR
 				"${friendly_name} could not be found.\n"
 				"Please ensure that ${friendly_name} can be found by CMake, or linked to using \"${target_name}\" as its "
-				"target name. If you are consuming RmlUi from another CMake project, you can create an ALIAS target to "
-				"offer an alternative name for a CMake target."
+				"target name. The location of the build directory of the dependency can be provided by setting the "
+				"\"${package_name}_ROOT\" CMake variable. If you are consuming RmlUi from another CMake project, you can "
+				"create an ALIAS target to offer an alternative name for a CMake target."
 			)
 	endif()
 	return()
 endmacro()
-macro(report_dependency_found_or_error friendly_name target_name)
+macro(report_dependency_found_or_error friendly_name package_name target_name)
 	if(NOT TARGET ${target_name})
-		report_dependency_not_found(${friendly_name} ${target_name})
+		report_dependency_not_found(${friendly_name} ${package_name} ${target_name})
 	endif()
 	if(ARGC GREATER "2" AND ARGV2)
 		set(success_message " - ${ARGV2}")


### PR DESCRIPTION
An extra parameter was added to the report_dependency_found_or_error macro in Utilities.cmake, but RmlUiConfig wasn't updated.

As a result, find_package(RmlUi) fails because it can't find Freetype (since it looks for the Freetype target, not Freetype::Freetype).