### PR TITLE
Add ability to provide an offset the viewport

### DIFF
--- a/Backends/RmlUi_Renderer_GL3.cpp
+++ b/Backends/RmlUi_Renderer_GL3.cpp
@@ -805,10 +805,12 @@ RenderInterface_GL3::~RenderInterface_GL3()
 	}
 }
 
-void RenderInterface_GL3::SetViewport(int width, int height)
+void RenderInterface_GL3::SetViewport(int width, int height, int offset_x, int offset_y)
 {
 	viewport_width = Rml::Math::Max(width, 1);
 	viewport_height = Rml::Math::Max(height, 1);
+	viewport_offset_x = offset_x;
+	viewport_offset_y = offset_y;
 	projection = Rml::Matrix4f::ProjectOrtho(0, (float)viewport_width, (float)viewport_height, 0, -10000, 10000);
 }
 
@@ -909,6 +911,7 @@ void RenderInterface_GL3::EndFrame()
 
 	// Draw to backbuffer
 	glBindFramebuffer(GL_FRAMEBUFFER, 0);
+	glViewport(viewport_offset_x, viewport_offset_y, viewport_width, viewport_height);
 
 	// Assuming we have an opaque background, we can just write to it with the premultiplied alpha blend mode and we'll get the correct result.
 	// Instead, if we had a transparent destination that didn't use premultiplied alpha, we would need to perform a manual un-premultiplication step.

--- a/Backends/RmlUi_Renderer_GL3.h
+++ b/Backends/RmlUi_Renderer_GL3.h
@@ -50,7 +50,7 @@ public:
 	explicit operator bool() const { return static_cast<bool>(program_data); }
 
 	// The viewport should be updated whenever the window size changes.
-	void SetViewport(int viewport_width, int viewport_height);
+	void SetViewport(int viewport_width, int viewport_height, int viewport_offset_x = 0, int viewport_offset_y = 0);
 
 	// Sets up OpenGL states for taking rendering commands from RmlUi.
 	void BeginFrame();
@@ -131,6 +131,8 @@ private:
 
 	int viewport_width = 0;
 	int viewport_height = 0;
+	int viewport_offset_x = 0;
+	int viewport_offset_y = 0;
 
 	Rml::CompiledGeometryHandle fullscreen_quad_geometry = {};
 


### PR DESCRIPTION
When displaying content like fullscreen games with a very wide or tall aspect ratio it's useful to add a black border to the sides of the screen.

Currently the viewport is hardcoded to always be aligned to the left. These changes allow a custom offset to be provided to the viewport (GL3 Backend).

For actual interaction like hover events etc, the user will need to ensure they're providing the offset the `ProcessMouseMove()` coords.