### PR TITLE
Implement ability to style progress of a range input

### DIFF
--- a/Samples/assets/invader.rcss
+++ b/Samples/assets/invader.rcss
@@ -529,12 +529,19 @@ input.range slidertrack {
 input.range:focus-visible slidertrack {
 	decorator: ninepatch( range-track-focus, range-track-focus-inner, 1.0 );
 }
+input.range sliderprogress {
+	background: rgba(100, 0, 0, 80);
+	height: 7dp;
+	position: relative;
+	top: 8dp;
+}
 input.range sliderbar {
 	margin-left: -8dp;
 	margin-right: -7dp;
 	margin-top: -3dp;
 	width: 34dp;
 	height: 23dp;
+	z-index: 1;
 	decorator: image( range-bar );
 }
 input.range sliderbar:hover, input.range slidertrack:hover + sliderbar  {

--- a/Samples/assets/invader.rcss
+++ b/Samples/assets/invader.rcss
@@ -531,9 +531,8 @@ input.range:focus-visible slidertrack {
 }
 input.range sliderprogress {
 	background: rgba(100, 0, 0, 80);
+	margin-top: 8dp;
 	height: 7dp;
-	position: relative;
-	top: 8dp;
 }
 input.range sliderbar {
 	margin-left: -8dp;
@@ -541,7 +540,6 @@ input.range sliderbar {
 	margin-top: -3dp;
 	width: 34dp;
 	height: 23dp;
-	z-index: 1;
 	decorator: image( range-bar );
 }
 input.range sliderbar:hover, input.range slidertrack:hover + sliderbar  {

--- a/Source/Core/Elements/WidgetSlider.cpp
+++ b/Source/Core/Elements/WidgetSlider.cpp
@@ -70,10 +70,10 @@ WidgetSlider::~WidgetSlider()
 {
 	if (bar)
 		parent->RemoveChild(bar);
+	if (track && progress)
+		track->RemoveChild(progress);
 	if (track)
 		parent->RemoveChild(track);
-	if (progress)
-		parent->RemoveChild(progress);
 
 	parent->RemoveEventListener(EventId::Blur, this);
 	parent->RemoveEventListener(EventId::Focus, this);
@@ -106,7 +106,7 @@ bool WidgetSlider::Initialise()
 
 	// Add them as non-DOM elements.
 	track = parent->AppendChild(std::move(track_element), false);
-	progress = parent->AppendChild(std::move(progress_element), false);
+	progress = track->AppendChild(std::move(progress_element), false);
 	bar = parent->AppendChild(std::move(bar_element), false);
 	arrows[0] = parent->AppendChild(std::move(arrow0_element), false);
 	arrows[1] = parent->AppendChild(std::move(arrow1_element), false);

--- a/Source/Core/Elements/WidgetSlider.cpp
+++ b/Source/Core/Elements/WidgetSlider.cpp
@@ -106,8 +106,8 @@ bool WidgetSlider::Initialise()
 
 	// Add them as non-DOM elements.
 	track = parent->AppendChild(std::move(track_element), false);
-	bar = parent->AppendChild(std::move(bar_element), false);
 	progress = parent->AppendChild(std::move(progress_element), false);
+	bar = parent->AppendChild(std::move(bar_element), false);
 	arrows[0] = parent->AppendChild(std::move(arrow0_element), false);
 	arrows[1] = parent->AppendChild(std::move(arrow1_element), false);
 
@@ -297,7 +297,6 @@ void WidgetSlider::FormatElements(const Vector2f containing_block, float slider_
 		offset.y += arrows[0]->GetBox().GetSize(BoxArea::Border).y + arrows[0]->GetBox().GetEdge(BoxArea::Margin, BoxEdge::Bottom) +
 			track->GetBox().GetEdge(BoxArea::Margin, BoxEdge::Top);
 		track->SetOffset(offset, parent);
-		progress->SetOffset(offset, parent);
 
 		offset.x = arrows[1]->GetBox().GetEdge(BoxArea::Margin, BoxEdge::Left);
 		offset.y += track->GetBox().GetSize(BoxArea::Border).y + track->GetBox().GetEdge(BoxArea::Margin, BoxEdge::Bottom) +
@@ -313,7 +312,6 @@ void WidgetSlider::FormatElements(const Vector2f containing_block, float slider_
 			track->GetBox().GetEdge(BoxArea::Margin, BoxEdge::Left);
 		offset.y = track->GetBox().GetEdge(BoxArea::Margin, BoxEdge::Top);
 		track->SetOffset(offset, parent);
-		progress->SetOffset(offset, parent);
 
 		offset.x += track->GetBox().GetSize(BoxArea::Border).x + track->GetBox().GetEdge(BoxArea::Margin, BoxEdge::Right) +
 			arrows[1]->GetBox().GetEdge(BoxArea::Margin, BoxEdge::Left);
@@ -363,6 +361,7 @@ void WidgetSlider::FormatProgress()
 	auto& computed = progress->GetComputedValues();
 
 	Vector2f progress_box_content = progress_box.GetSize();
+
 	if (orientation == HORIZONTAL)
 	{
 		if (computed.height().type == Style::Height::Auto)
@@ -372,6 +371,12 @@ void WidgetSlider::FormatProgress()
 	// Set the new dimensions on the progress element to re-decorate it.
 	progress_box.SetContent(progress_box_content);
 	progress->SetBox(progress_box);
+
+        Vector2f offset = track->GetRelativeOffset();
+        offset.x += progress->GetBox().GetEdge(BoxArea::Margin, BoxEdge::Left);
+        offset.y += progress->GetBox().GetEdge(BoxArea::Margin, BoxEdge::Top);
+
+        progress->SetOffset(offset, parent);
 
 	ResizeProgress();
 }

--- a/Source/Core/Elements/WidgetSlider.cpp
+++ b/Source/Core/Elements/WidgetSlider.cpp
@@ -113,6 +113,7 @@ bool WidgetSlider::Initialise()
 
 	const Property drag_property = Property(Style::Drag::Drag);
 	track->SetProperty(PropertyId::Drag, drag_property);
+	progress->SetProperty(PropertyId::Drag, drag_property);
 	bar->SetProperty(PropertyId::Drag, drag_property);
 
 	// Attach the listeners
@@ -444,7 +445,7 @@ void WidgetSlider::ProcessEvent(Event& event)
 
 	case EventId::Dragstart:
 	{
-		if (event.GetTargetElement() == bar || event.GetTargetElement() == track)
+		if (event.GetTargetElement() == bar || event.GetTargetElement() == track || event.GetTargetElement() == progress)
 		{
 			bar->SetPseudoClass("active", true);
 
@@ -457,7 +458,7 @@ void WidgetSlider::ProcessEvent(Event& event)
 	break;
 	case EventId::Drag:
 	{
-		if (event.GetTargetElement() == bar || event.GetTargetElement() == track)
+		if (event.GetTargetElement() == bar || event.GetTargetElement() == track || event.GetTargetElement() == progress)
 		{
 			float new_bar_offset = event.GetParameter<float>((orientation == HORIZONTAL ? "mouse_x" : "mouse_y"), 0) - bar_drag_anchor;
 			float new_bar_position = AbsolutePositionToBarPosition(new_bar_offset);
@@ -468,7 +469,7 @@ void WidgetSlider::ProcessEvent(Event& event)
 	break;
 	case EventId::Dragend:
 	{
-		if (event.GetTargetElement() == bar || event.GetTargetElement() == track)
+		if (event.GetTargetElement() == bar || event.GetTargetElement() == track || event.GetTargetElement() == progress)
 		{
 			bar->SetPseudoClass("active", false);
 		}

--- a/Source/Core/Elements/WidgetSlider.h
+++ b/Source/Core/Elements/WidgetSlider.h
@@ -92,6 +92,9 @@ private:
 	/// Lays out and positions the bar element.
 	void FormatBar();
 
+	/// Lays out and positions the progress element.
+	void FormatProgress();
+
 	/// Returns the widget's parent element.
 	Element* GetParent() const;
 
@@ -117,6 +120,7 @@ private:
 	float AbsolutePositionToBarPosition(float absolute_position) const;
 
 	void PositionBar();
+	void ResizeProgress();
 
 	// Clamps the new value, sets it on the slider and returns it as a normalized number from 0 to 1.
 	float SetValueInternal(float new_value, bool force_submit_change_event = true);
@@ -129,6 +133,8 @@ private:
 	Element* track;
 	// The bar element. This is the element that is dragged across the trough.
 	Element* bar;
+	// Element that renders the progress area of the slider.
+	Element* progress;
 	// The two (optional) buttons for incrementing and decrementing the slider.
 	Element* arrows[2];
 


### PR DESCRIPTION
This adds the ability to style the current progress of a range input, similar to `::-moz-range-progress`, `:-webkit-slider-runnable-track`.

![Peek 2025-03-06 01-12](https://github.com/user-attachments/assets/4d7c3054-32ef-491e-a899-485b2f1009f6)
