### PR TITLE
Fix word break when the first character of token is multibyte

### DIFF
--- a/Source/Core/ElementText.cpp
+++ b/Source/Core/ElementText.cpp
@@ -258,6 +258,15 @@ bool ElementText::GenerateLine(String& line, int& line_length, float& line_width
 						token.clear();
 						next_token_begin = token_begin;
 						const char* partial_string_end = StringUtilities::SeekBackwardUTF8(token_begin + i, token_begin);
+                        // When the char is multibyte it may happen that token_begin + i is the second byte of the same character as token_begin
+                        // then BuildToken() fails. I think this happens when first character of the token is a multibyte character and StringUtilities::SeekBackwardUTF8
+						// returns the same char.
+						if (partial_string_end == token_begin)
+						{
+							i += 2;
+							force_loop_break_after_next = true;
+							continue;
+						}
 						BuildToken(token, next_token_begin, partial_string_end, line.empty() && trim_whitespace_prefix, collapse_white_space,
 							break_at_endline, text_transform_property, decode_escape_characters);
 						token_width = font_engine_interface->GetStringWidth(font_face_handle, token, text_shaping_context, previous_codepoint);


### PR DESCRIPTION
Hello, This is my first PR for RmlUi so I wanted to say thanks for a great library :)

I use RmlUi to display "HTML-like" documents and I noticed instability in some documents with multi byte chars. In release mode there was an infinite loop and in debug a message appeared:

![rmlui_bug](https://github.com/user-attachments/assets/dc8b25cd-69ba-4977-b568-797e32af71a1)

The error occurs when word break is enabled and the first character in the processed token is a multi-byte character, e.g. Polish characters such as "ś" or "ć".  
In this case, the character returned for `token_begin` and  `token_begin + i` by `StringUtilities::SeekBackwardUTF8()` may be the same char. I fixed that by stopping iteration when `partial_string_end == token_begin`. I don't know this is the best solution but it works (no inifinite loop/assertion fail) and text is appropriately divided into lines.

## Example document that shows the bug

It is quite easy to cause the issue by creating a table filled with the characters ść :

Screen from rmlui fixed by this PR:
![obraz](https://github.com/user-attachments/assets/d369229c-f1a9-47ec-940a-2a0ed415164b)

Simplified rml doc:

```
<!DOCTYPE html>
<rml lang="pl">
	<head>
		<meta charset="UTF-8"/>
		<meta http-equiv="X-UA-Compatible" content="IE=edge"/>
		<meta name="viewport" content="width=device-width, initial-scale=1.0"/>
		<title>Instalacje sanitarne i sieci zewnętrzne</title>
		<style>

.txt-centered {
		text-align: center;
		vertical-align: middle;
}

body {
    display: block;
    font-family: Roboto;
    font-size: 14dp;
    text-align: left;
    color:rgb(246, 252, 255);
    background:rgb(46, 48, 49);
    position: relative;
    top: 0dp;
    left: 0dp;
    overflow: scroll;
    height: 100vh;
}

div {
    display: block;
    position: relative;
}

/*
    Default styles for all the basic elements.
*/

em
{
    font-style: italic;
}

p {
    display: block;
    padding: 2dp;
{

strong
{
    font-weight: bold;
}

select
{
    text-align: left;
}

tabset tabs
{
    display: block;
}

table
{
    box-sizing: border-box;
    display: table;
    border: 0px rgb(113, 121, 121);
    border-collapse: collapse;
    border-width: 0px 0px 1dp 1dp;
}
tr
{
    box-sizing: border-box;
    display: table-row;
}
td
{
    box-sizing: border-box;
    display: table-cell;
    border: 0px rgb(113, 121, 121);
    border-width: 1dp 1dp 0 0;
    padding: 2dp;
    min-width: 10dp;
    word-break: break-word;
}
col
{
    box-sizing: border-box;
    display: table-column;
    min-width: 10dp;
}
colgroup
{
    display: table-column-group;
}
thead, tbody, tfoot
{
    display: table-row-group;
}


</style>
	</head>
	<body>
		<div id="content">
			<h5 id="IT_10_05">Tablica 0001</h5>
			<table>
				<tr>
					<td class="txt-centered">Lp.</td>
					<td class="txt-centered">title1</td>
					<td colspan="15" class="txt-centered">title2</td>
				</tr>
				<tr>
					<td class="txt-centered">01</td>
					<td class="txt-centered">02</td>
					<td class="txt-centered">03</td>
					<td class="txt-centered">04</td>
					<td class="txt-centered">05</td>
					<td class="txt-centered">06</td>
					<td class="txt-centered">07</td>
					<td class="txt-centered">08</td>
					<td class="txt-centered">09</td>
					<td class="txt-centered">10</td>
					<td class="txt-centered">11</td>
					<td class="txt-centered">12</td>
					<td class="txt-centered">13</td>
					<td class="txt-centered">14</td>
					<td class="txt-centered">15</td>
					<td class="txt-centered">16</td>
					<td class="txt-centered">17</td>
				</tr>
				<tr>
					<td class="txt-centered">1</td>
					<td>śśśśćśśśśśććść</td>
					<td class="txt-centered">28</td>
					<td class="txt-centered">32</td>
					<td class="txt-centered">36</td>
					<td class="txt-centered">41</td>
					<td class="txt-centered">48</td>
					<td class="txt-centered">55</td>
					<td class="txt-centered">64</td>
					<td class="txt-centered">78</td>
					<td class="txt-centered">91</td>
					<td class="txt-centered">111</td>
					<td class="txt-centered">129</td>
					<td class="txt-centered">160</td>
					<td class="txt-centered">198</td>
					<td class="txt-centered">242</td>
					<td class="txt-centered">295</td>
				</tr>
			</table>
			<p/>
		</div>
	</body>
</rml>
```
