### PR TITLE
Fix LogDefault output on mingw

### DIFF
--- a/Backends/RmlUi_BackwardCompatible/RmlUi_Renderer_BackwardCompatible_GL3.cpp
+++ b/Backends/RmlUi_BackwardCompatible/RmlUi_Renderer_BackwardCompatible_GL3.cpp
@@ -33,7 +33,7 @@
 #include <RmlUi/Core/Platform.h>
 #include <string.h>
 
-#if defined(RMLUI_PLATFORM_WIN32) && !defined(__MINGW32__)
+#if defined RMLUI_PLATFORM_WIN32_NATIVE
 	// function call missing argument list
 	#pragma warning(disable : 4551)
 	// unreferenced local function has been removed

--- a/Backends/RmlUi_Renderer_GL3.cpp
+++ b/Backends/RmlUi_Renderer_GL3.cpp
@@ -38,7 +38,7 @@
 #include <algorithm>
 #include <string.h>
 
-#if defined(RMLUI_PLATFORM_WIN32) && !defined(__MINGW32__)
+#if defined RMLUI_PLATFORM_WIN32_NATIVE
 	// function call missing argument list
 	#pragma warning(disable : 4551)
 	// unreferenced local function has been removed

--- a/Include/RmlUi/Core/Platform.h
+++ b/Include/RmlUi/Core/Platform.h
@@ -57,6 +57,8 @@
 #endif
 
 #if defined(RMLUI_PLATFORM_WIN32) && !defined(__MINGW32__)
+	#define RMLUI_PLATFORM_WIN32_NATIVE
+
 	// declaration of 'identifier' hides class member
 	#pragma warning(disable : 4458)
 

--- a/Source/Core/LogDefault.cpp
+++ b/Source/Core/LogDefault.cpp
@@ -29,7 +29,7 @@
 #include "LogDefault.h"
 #include "../../Include/RmlUi/Core/StringUtilities.h"
 
-#ifdef RMLUI_PLATFORM_WIN32
+#ifdef RMLUI_PLATFORM_WIN32_NATIVE
 	#include <windows.h>
 #else
 	#include <stdio.h>
@@ -37,7 +37,7 @@
 
 namespace Rml {
 
-#if defined(RMLUI_PLATFORM_WIN32) && !defined(__MINGW32__)
+#if defined RMLUI_PLATFORM_WIN32_NATIVE
 bool LogDefault::LogMessage(Log::Type type, const String& message)
 {
 	#if !defined(WINAPI_FAMILY) || (WINAPI_FAMILY == WINAPI_FAMILY_DESKTOP_APP)

--- a/Source/Core/LogDefault.cpp
+++ b/Source/Core/LogDefault.cpp
@@ -37,7 +37,7 @@
 
 namespace Rml {
 
-#ifdef RMLUI_PLATFORM_WIN32
+#if defined(RMLUI_PLATFORM_WIN32) && !defined(__MINGW32__)
 bool LogDefault::LogMessage(Log::Type type, const String& message)
 {
 	#if !defined(WINAPI_FAMILY) || (WINAPI_FAMILY == WINAPI_FAMILY_DESKTOP_APP)

--- a/Tests/Source/VisualTests/CaptureScreen.cpp
+++ b/Tests/Source/VisualTests/CaptureScreen.cpp
@@ -233,7 +233,7 @@ void ReleaseTextureGeometry(Rml::RenderInterface* render_interface, TextureGeome
 }
 
 // Suppress warnings emitted by lodepng
-#if defined(RMLUI_PLATFORM_WIN32) && !defined(__MINGW32__)
+#if defined RMLUI_PLATFORM_WIN32_NATIVE
 	#pragma warning(disable : 4334)
 	#pragma warning(disable : 4267)
 #endif


### PR DESCRIPTION
Current implementation for win32 won't produce any console output on mingw. `fprintf` works fine.