### PR TITLE
Lua plugin: Fix loading font faces

### DIFF
--- a/Source/Lua/RmlUi.cpp
+++ b/Source/Lua/RmlUi.cpp
@@ -82,8 +82,9 @@ int LuaRmlUiCreateContext(lua_State* L, LuaRmlUi* /*obj*/)
 int LuaRmlUiLoadFontFace(lua_State* L, LuaRmlUi* /*obj*/)
 {
 	const char* file = luaL_checkstring(L, 1);
-	int face_index = lua_gettop(L) == 1 ? 0 : static_cast<int>(luaL_checkinteger(L, 2));
-	lua_pushboolean(L, LoadFontFace(file, face_index));
+	bool fallback_face = lua_gettop(L) <= 1 ? false : RMLUI_CHECK_BOOL(L, 2);
+	int face_index = lua_gettop(L) <= 2 ? 0 : static_cast<int>(luaL_checkinteger(L, 3));
+	lua_pushboolean(L, LoadFontFace(file, fallback_face, Style::FontWeight::Auto, face_index));
 	return 1;
 }
 


### PR DESCRIPTION
When the font face index was first proposed (#720), it was added as a second parameter. It was later refactored to be the last parameter. However, when this change was made, it was not reflected in the Lua plugin.

I took this opportunity to introduce an additional parameter for the Lua function: the fallback face flag. Keeping it as the second parameter does not break anything, as that is what the face index argument actually was for Lua before.