### PR TITLE
Fix to maintain image aspect ratio if height or width attribute set on image element

### DIFF
--- a/Source/Core/Elements/ElementImage.cpp
+++ b/Source/Core/Elements/ElementImage.cpp
@@ -52,28 +52,45 @@ bool ElementImage::GetIntrinsicDimensions(Vector2f& _dimensions, float& _ratio)
 {
 	EnsureSourceLoaded();
 
-	// Calculate the x dimension.
-	if (HasAttribute("width"))
-		dimensions.x = GetAttribute<float>("width", -1);
-	else if (rect_source == RectSource::None)
+	if (rect_source == RectSource::None)
+	{
 		dimensions.x = (float)texture.GetDimensions().x;
-	else
-		dimensions.x = rect.Width();
-
-	// Calculate the y dimension.
-	if (HasAttribute("height"))
-		dimensions.y = GetAttribute<float>("height", -1);
-	else if (rect_source == RectSource::None)
 		dimensions.y = (float)texture.GetDimensions().y;
-	else
+	} else
+	{
+		dimensions.x = rect.Width();
 		dimensions.y = rect.Height();
+	}
+
+	//Calculate the source ratio
+	_ratio = dimensions.x / dimensions.y;
+
+	//Scale based on attributes (this only appears to be done by LayoutDetails for CSS set height/width)
+	auto requested_width = GetAttribute<float>("width", -1);
+	auto requested_height = GetAttribute<float>("height", -1);
+	if (requested_height>0 && requested_width>0)
+	{
+		//If both a height and width are set update the ratio to match
+		_ratio = requested_width / requested_height;
+		dimensions.x = requested_width;
+		dimensions.y = requested_height;
+	}
+	else if (requested_height>0)
+	{
+		dimensions.x = requested_height * _ratio;
+		dimensions.y = requested_height;
+	}
+	else if (requested_width>0)
+	{
+		dimensions.x = requested_width;
+		dimensions.y = requested_width / _ratio;
+	}
 
 	dimensions *= dimensions_scale;
 
 	// Return the calculated dimensions. If this changes the size of the element, it will result in
 	// a call to 'onresize' below which will regenerate the geometry.
 	_dimensions = dimensions;
-	_ratio = dimensions.x / dimensions.y;
 
 	return true;
 }

--- a/Source/Core/Elements/ElementImage.cpp
+++ b/Source/Core/Elements/ElementImage.cpp
@@ -54,33 +54,32 @@ bool ElementImage::GetIntrinsicDimensions(Vector2f& _dimensions, float& _ratio)
 
 	if (rect_source == RectSource::None)
 	{
-		dimensions.x = (float)texture.GetDimensions().x;
-		dimensions.y = (float)texture.GetDimensions().y;
-	} else
+		dimensions = Vector2f(texture.GetDimensions());
+	}
+	else
 	{
-		dimensions.x = rect.Width();
-		dimensions.y = rect.Height();
+		dimensions = rect.Size();
 	}
 
-	//Calculate the source ratio
+	// Calculate the source ratio
 	_ratio = dimensions.x / dimensions.y;
 
-	//Scale based on attributes (this only appears to be done by LayoutDetails for CSS set height/width)
+	// Scale based on attributes (this only appears to be done by LayoutDetails for CSS set height/width)
 	auto requested_width = GetAttribute<float>("width", -1);
 	auto requested_height = GetAttribute<float>("height", -1);
-	if (requested_height>0 && requested_width>0)
+	if (requested_height > 0 && requested_width > 0)
 	{
-		//If both a height and width are set update the ratio to match
+		// If both a height and width are set update the ratio to match
 		_ratio = requested_width / requested_height;
 		dimensions.x = requested_width;
 		dimensions.y = requested_height;
 	}
-	else if (requested_height>0)
+	else if (requested_height > 0)
 	{
 		dimensions.x = requested_height * _ratio;
 		dimensions.y = requested_height;
 	}
-	else if (requested_width>0)
+	else if (requested_width > 0)
 	{
 		dimensions.x = requested_width;
 		dimensions.y = requested_width / _ratio;

--- a/Tests/Data/VisualTests/image_ratio.rml
+++ b/Tests/Data/VisualTests/image_ratio.rml
@@ -1,0 +1,40 @@
+<rml>
+	<head>
+		<title>Image Ratio Sizing - Attribute</title>
+		<link type="text/rcss" href="../style.rcss"/>
+		<meta name="Description" content="When a width or height is set the image should be scaled keeping its aspect ratio. All but the last example should be a square." />
+		<style>
+			.width-50 { width: 50px; }
+			.height-50 { height: 50px; }
+			.height-100 { height: 100px; }
+		</style>
+	</head>
+
+	<body>
+	    <table>
+	        <tr><td>Attribute</td><td>CSS</td></tr>
+	        <tr><td colspan="2">Original size (square 100x100):</td></tr>
+	        <tr>
+	            <td colspan="2"><img src="/assets/present.tga" alt="no width/height set" /></td>
+            </tr>
+
+	        <tr><td colspan="2">Set height to 50, width auto, expect half sized square:</td></tr>
+	        <tr>
+	            <td><img src="/assets/present.tga" height="50" alt="height 50 only, attribute" /></td>
+	            <td><img src="/assets/present.tga" class="height-50" /></td>
+            </tr>
+
+	        <tr><td colspan="2">Set width to 50, height auto, expect half sized square:</td></tr>
+	        <tr>
+	            <td><img src="/assets/present.tga" width="50" alt="width 50 only, attribute" /></td>
+	            <td><img src="/assets/present.tga" class="width-50" /></td>
+            </tr>
+
+	        <tr><td colspan="2">Set width to 50 and height to 100 (via attributes), expect rectangular:</td></tr>
+	        <tr>
+	            <td><img src="/assets/present.tga" width="50" height="100" alt="height 100, width 50, attribute" /></td>
+	            <td><img src="/assets/present.tga" class="height-100 width-50" /></td>
+            </tr>
+        </table>
+	</body>
+</rml>

--- a/Tests/Source/UnitTests/ElementImage.cpp
+++ b/Tests/Source/UnitTests/ElementImage.cpp
@@ -106,3 +106,83 @@ TEST_CASE("elementimage.dp_ratio")
 	document->Close();
 	TestsShell::ShutdownShell();
 }
+
+
+
+static const String document_wrapped_image_rml_ratio_test = R"(
+<rml>
+<head>
+	<title>Test</title>
+	<style>
+		.width-50 { width: 50px; }
+		.height-50 { height: 50px; }
+		.height-100 { height: 100px; }
+	</style>
+</head>
+<body>
+	<img src="/test_not_loaded/test_512_256.tga" id="test1" alt="Original size" />
+	<img src="/test_not_loaded/test_512_256.tga" id="test2" height="50" alt="Set height to 50, width auto, attribute set" />
+	<img src="/test_not_loaded/test_512_256.tga" id="test3" class="height-50" alt="Set height to 50, width auto, css set" />
+	<img src="/test_not_loaded/test_512_256.tga" id="test4" width="50" alt="Set width to 50, height auto, attribute set" />
+	<img src="/test_not_loaded/test_512_256.tga" id="test5" class="width-50" alt="Set width to 50, height auto, css set" />
+	<img src="/test_not_loaded/test_512_256.tga" id="test6" width="50" height="100" alt="Set width to 50 and height to 100, attribute set" />
+	<img src="/test_not_loaded/test_512_256.tga" id="test7" class="height-100 width-50" alt="Set width to 50 and height to 100, css set" />
+</body>
+</rml>
+)";
+
+TEST_CASE("elementimage.preserve_ratio")
+{
+	Context* context = TestsShell::GetContext();
+	ElementDocument* document = context->LoadDocumentFromMemory(document_wrapped_image_rml_ratio_test, "assets/");
+	document->Show();
+
+	//Texture size is hardcoded in test render interface to 512x256
+	SUBCASE("baseline")
+	{
+		Element* img_test1 = document->GetElementById("test1");
+		CHECK(img_test1->GetClientWidth() == 512);
+		CHECK(img_test1->GetClientHeight() == 256);
+	}
+	SUBCASE("height only - attribute set")
+	{
+		Element* img_test2 = document->GetElementById("test2");
+		CHECK(img_test2->GetClientWidth() == 100);
+		CHECK(img_test2->GetClientHeight() == 50);
+	}
+	SUBCASE("height only - css set")
+	{
+		Element* img_test3 = document->GetElementById("test3");
+		CHECK(img_test3->GetClientWidth() == 100);
+		CHECK(img_test3->GetClientHeight() == 50);
+	}
+	SUBCASE("width only - attribute set")
+	{
+		Element* img_test4 = document->GetElementById("test4");
+		CHECK(img_test4->GetClientWidth() == 50);
+		CHECK(img_test4->GetClientHeight() == 25);
+	}
+	SUBCASE("width only - attribute set")
+	{
+		Element* img_test5 = document->GetElementById("test5");
+		CHECK(img_test5->GetClientWidth() == 50);
+		CHECK(img_test5->GetClientHeight() == 25);
+	}
+	SUBCASE("height and width - attribute set")
+	{
+		Element* img_test6 = document->GetElementById("test6");
+		CHECK(img_test6->GetClientWidth() == 50);
+		CHECK(img_test6->GetClientHeight() == 100);
+	}
+	SUBCASE("height and width - css set")
+	{
+		Element* img_test7 = document->GetElementById("test7");
+		CHECK(img_test7->GetClientWidth() == 50);
+		CHECK(img_test7->GetClientHeight() == 100);
+	}
+
+	TestsShell::RenderLoop();
+
+	document->Close();
+	TestsShell::ShutdownShell();
+}

--- a/Tests/Source/UnitTests/ElementImage.cpp
+++ b/Tests/Source/UnitTests/ElementImage.cpp
@@ -136,40 +136,55 @@ TEST_CASE("elementimage.preserve_ratio")
 	document->Show();
 
 	// Texture size is hardcoded in test render interface to 512x256
-	INFO("original image size");
-	Element* img_test1 = document->GetElementById("test1");
-	CHECK(img_test1->GetClientWidth() == 512);
-	CHECK(img_test1->GetClientHeight() == 256);
+	{
+		INFO("original image size");
+		Element* img_test1 = document->GetElementById("test1");
+		CHECK(img_test1->GetClientWidth() == 512);
+		CHECK(img_test1->GetClientHeight() == 256);
+	}
 
-	INFO("height only - attribute set");
-	Element* img_test2 = document->GetElementById("test2");
-	CHECK(img_test2->GetClientWidth() == 100);
-	CHECK(img_test2->GetClientHeight() == 50);
+	{
+		INFO("height only - attribute set");
+		Element* img_test2 = document->GetElementById("test2");
+		CHECK(img_test2->GetClientWidth() == 100);
+		CHECK(img_test2->GetClientHeight() == 50);
+	}
 
-	INFO("height only - css set");
-	Element* img_test3 = document->GetElementById("test3");
-	CHECK(img_test3->GetClientWidth() == 100);
-	CHECK(img_test3->GetClientHeight() == 50);
+	{
+		INFO("height only - css set");
+		Element* img_test3 = document->GetElementById("test3");
+		CHECK(img_test3->GetClientWidth() == 100);
+		CHECK(img_test3->GetClientHeight() == 50);
+	}
 
-	INFO("width only - attribute set");
-	Element* img_test4 = document->GetElementById("test4");
-	CHECK(img_test4->GetClientWidth() == 50);
-	CHECK(img_test4->GetClientHeight() == 25);
+	{
+		INFO("width only - attribute set");
+		Element* img_test4 = document->GetElementById("test4");
+		CHECK(img_test4->GetClientWidth() == 50);
+		CHECK(img_test4->GetClientHeight() == 25);
+	}
 
-	INFO("width only - attribute set");
-	Element* img_test5 = document->GetElementById("test5");
-	CHECK(img_test5->GetClientWidth() == 50);
-	CHECK(img_test5->GetClientHeight() == 25);
+	{
+		INFO("width only - css set");
+		Element* img_test5 = document->GetElementById("test5");
+		CHECK(img_test5->GetClientWidth() == 50);
+		CHECK(img_test5->GetClientHeight() == 25);
+		FAIL("test");
+	}
 
-	INFO("height and width - attribute set");
-	Element* img_test6 = document->GetElementById("test6");
-	CHECK(img_test6->GetClientWidth() == 50);
-	CHECK(img_test6->GetClientHeight() == 100);
+	{
+		INFO("height and width - attribute set");
+		Element* img_test6 = document->GetElementById("test6");
+		CHECK(img_test6->GetClientWidth() == 50);
+		CHECK(img_test6->GetClientHeight() == 100);
+	}
 
-	INFO("height and width - css set");
-	Element* img_test7 = document->GetElementById("test7");
-	CHECK(img_test7->GetClientWidth() == 50);
-	CHECK(img_test7->GetClientHeight() == 100);
+	{
+		INFO("height and width - css set");
+		Element* img_test7 = document->GetElementById("test7");
+		CHECK(img_test7->GetClientWidth() == 50);
+		CHECK(img_test7->GetClientHeight() == 100);
+	}
 
 	TestsShell::RenderLoop();
 

--- a/Tests/Source/UnitTests/ElementImage.cpp
+++ b/Tests/Source/UnitTests/ElementImage.cpp
@@ -169,7 +169,6 @@ TEST_CASE("elementimage.preserve_ratio")
 		Element* img_test5 = document->GetElementById("test5");
 		CHECK(img_test5->GetClientWidth() == 50);
 		CHECK(img_test5->GetClientHeight() == 25);
-		FAIL("test");
 	}
 
 	{

--- a/Tests/Source/UnitTests/ElementImage.cpp
+++ b/Tests/Source/UnitTests/ElementImage.cpp
@@ -107,8 +107,6 @@ TEST_CASE("elementimage.dp_ratio")
 	TestsShell::ShutdownShell();
 }
 
-
-
 static const String document_wrapped_image_rml_ratio_test = R"(
 <rml>
 <head>
@@ -137,49 +135,41 @@ TEST_CASE("elementimage.preserve_ratio")
 	ElementDocument* document = context->LoadDocumentFromMemory(document_wrapped_image_rml_ratio_test, "assets/");
 	document->Show();
 
-	//Texture size is hardcoded in test render interface to 512x256
-	SUBCASE("baseline")
-	{
-		Element* img_test1 = document->GetElementById("test1");
-		CHECK(img_test1->GetClientWidth() == 512);
-		CHECK(img_test1->GetClientHeight() == 256);
-	}
-	SUBCASE("height only - attribute set")
-	{
-		Element* img_test2 = document->GetElementById("test2");
-		CHECK(img_test2->GetClientWidth() == 100);
-		CHECK(img_test2->GetClientHeight() == 50);
-	}
-	SUBCASE("height only - css set")
-	{
-		Element* img_test3 = document->GetElementById("test3");
-		CHECK(img_test3->GetClientWidth() == 100);
-		CHECK(img_test3->GetClientHeight() == 50);
-	}
-	SUBCASE("width only - attribute set")
-	{
-		Element* img_test4 = document->GetElementById("test4");
-		CHECK(img_test4->GetClientWidth() == 50);
-		CHECK(img_test4->GetClientHeight() == 25);
-	}
-	SUBCASE("width only - attribute set")
-	{
-		Element* img_test5 = document->GetElementById("test5");
-		CHECK(img_test5->GetClientWidth() == 50);
-		CHECK(img_test5->GetClientHeight() == 25);
-	}
-	SUBCASE("height and width - attribute set")
-	{
-		Element* img_test6 = document->GetElementById("test6");
-		CHECK(img_test6->GetClientWidth() == 50);
-		CHECK(img_test6->GetClientHeight() == 100);
-	}
-	SUBCASE("height and width - css set")
-	{
-		Element* img_test7 = document->GetElementById("test7");
-		CHECK(img_test7->GetClientWidth() == 50);
-		CHECK(img_test7->GetClientHeight() == 100);
-	}
+	// Texture size is hardcoded in test render interface to 512x256
+	INFO("original image size");
+	Element* img_test1 = document->GetElementById("test1");
+	CHECK(img_test1->GetClientWidth() == 512);
+	CHECK(img_test1->GetClientHeight() == 256);
+
+	INFO("height only - attribute set");
+	Element* img_test2 = document->GetElementById("test2");
+	CHECK(img_test2->GetClientWidth() == 100);
+	CHECK(img_test2->GetClientHeight() == 50);
+
+	INFO("height only - css set");
+	Element* img_test3 = document->GetElementById("test3");
+	CHECK(img_test3->GetClientWidth() == 100);
+	CHECK(img_test3->GetClientHeight() == 50);
+
+	INFO("width only - attribute set");
+	Element* img_test4 = document->GetElementById("test4");
+	CHECK(img_test4->GetClientWidth() == 50);
+	CHECK(img_test4->GetClientHeight() == 25);
+
+	INFO("width only - attribute set");
+	Element* img_test5 = document->GetElementById("test5");
+	CHECK(img_test5->GetClientWidth() == 50);
+	CHECK(img_test5->GetClientHeight() == 25);
+
+	INFO("height and width - attribute set");
+	Element* img_test6 = document->GetElementById("test6");
+	CHECK(img_test6->GetClientWidth() == 50);
+	CHECK(img_test6->GetClientHeight() == 100);
+
+	INFO("height and width - css set");
+	Element* img_test7 = document->GetElementById("test7");
+	CHECK(img_test7->GetClientWidth() == 50);
+	CHECK(img_test7->GetClientHeight() == 100);
 
 	TestsShell::RenderLoop();
 


### PR DESCRIPTION
Fix for an issue where setting an image element height or width via its attributes doesn't preserve the aspect ratio of the source image. This only relates to the intrinsic size, if the height/width attributes aren't set and it is sized via css the aspect ratio is currently preserved.

This change moves the ratio calculation earlier on before the source image dimensions are overwritten and also handles aspect ratio sizing where one of height or width attributes are set. If height and width attributes are set it will use the resulting aspect ratio rather than that of the source.

I haven't seen any unintended consequences of this change in any of the visual tests, sprites / rect attributes all still seem to behave as expected.

This includes a unit test and visual test. For comparison below is the before and after.
| current master | PR code |
| ---------------- | --------- |
| ![image_ratio_prefix](https://github.com/user-attachments/assets/9045be33-cd9e-4258-9473-ce53d5880dfa) | ![image_ratio_fixed](https://github.com/user-attachments/assets/f72f9dc9-32a6-4cf4-b55b-ee6e4e6c5996) |

