### PR TITLE
Fix text content disappearing when Ctrl + Alt + A key combination is used

### DIFF
--- a/Source/Core/Elements/WidgetTextInput.cpp
+++ b/Source/Core/Elements/WidgetTextInput.cpp
@@ -593,7 +593,7 @@ void WidgetTextInput::ProcessEvent(Event& event)
 
 		case Input::KI_A:
 		{
-			if (ctrl)
+			if (ctrl && !alt)
 				Select();
 		}
 		break;


### PR DESCRIPTION
This is quite a follow-up to #465. The problem is that if you use the Polish keyboard layout, you must use <kbd>Ctrl</kbd> + <kbd>Alt</kbd> + <kbd>A</kbd> key combination to type Latin A with ogonek (ą). However, right now, RmlUi also selects all text as it thinks that only <kbd>Ctrl</kbd> + <kbd>A</kbd> was pressed, which is followed by inputting the letter, effectively purging the entire text.

If selecting the text is "ignored" when the <kbd>Alt</kbd> key is pressed, we match the behavior of other (system) programs.