### PR TITLE
Add IsFontFamilyLoaded()

### DIFF
--- a/Include/RmlUi/Core/Core.h
+++ b/Include/RmlUi/Core/Core.h
@@ -150,6 +150,10 @@ RMLUICORE_API bool LoadFontFace(const String& file_path, bool fallback_face = fa
 /// @lifetime The pointed to 'data' must remain available until after the call to Rml::Shutdown.
 RMLUICORE_API bool LoadFontFace(Span<const byte> data, const String& family, Style::FontStyle style,
 	Style::FontWeight weight = Style::FontWeight::Auto, bool fallback_face = false, int face_index = 0);
+/// Return if any face of the font family is loaded.
+/// @param[in] family The desired font family.
+/// @return True if any face of the font family is loaded, false otherwise.
+RMLUICORE_API bool IsFontFamilyLoaded(const String& family);
 
 /// Registers a generic RmlUi plugin.
 RMLUICORE_API void RegisterPlugin(Plugin* plugin);

--- a/Include/RmlUi/Core/FontEngineInterface.h
+++ b/Include/RmlUi/Core/FontEngineInterface.h
@@ -74,6 +74,11 @@ public:
 	/// @note The debugger plugin will load its embedded font faces through this method using the family name 'rmlui-debugger-font'.
 	virtual bool LoadFontFace(Span<const byte> data, int face_index, const String& family, Style::FontStyle style, Style::FontWeight weight, bool fallback_face);
 
+	/// Return if any face of the font family is loaded.
+	/// @param[in] family The desired font family.
+	/// @return True if any face of the font family is loaded, false otherwise.
+	virtual bool IsFontFamilyLoaded(const String& family);
+
 	/// Called by RmlUi when a font configuration is resolved for an element. Should return a handle that
 	/// can later be used to resolve properties of the face, and generate string geometry to be rendered.
 	/// @param[in] family The family of the desired font handle.

--- a/Source/Core/Core.cpp
+++ b/Source/Core/Core.cpp
@@ -366,6 +366,11 @@ bool LoadFontFace(Span<const byte> data, const String& family, Style::FontStyle 
 	return font_interface->LoadFontFace(data, face_index, family, style, weight, fallback_face);
 }
 
+bool IsFontFamilyLoaded(const String& family)
+{
+	return font_interface->IsFontFamilyLoaded(family);
+}
+
 void RegisterPlugin(Plugin* plugin)
 {
 	if (initialised)

--- a/Source/Core/FontEngineDefault/FontEngineInterfaceDefault.cpp
+++ b/Source/Core/FontEngineDefault/FontEngineInterfaceDefault.cpp
@@ -54,6 +54,11 @@ bool FontEngineInterfaceDefault::LoadFontFace(Span<const byte> data, int face_in
 	return FontProvider::LoadFontFace(data, face_index, font_family, style, weight, fallback_face);
 }
 
+bool FontEngineInterfaceDefault::IsFontFamilyLoaded(const String& family)
+{
+	return FontProvider::IsFontFamilyLoaded(family);
+}
+
 FontFaceHandle FontEngineInterfaceDefault::GetFontFaceHandle(const String& family, Style::FontStyle style, Style::FontWeight weight, int size)
 {
 	auto handle = FontProvider::GetFontFaceHandle(family, style, weight, size);

--- a/Source/Core/FontEngineDefault/FontEngineInterfaceDefault.h
+++ b/Source/Core/FontEngineDefault/FontEngineInterfaceDefault.h
@@ -47,6 +47,9 @@ public:
 	bool LoadFontFace(Span<const byte> data, int face_index, const String& font_family, Style::FontStyle style, Style::FontWeight weight,
 		bool fallback_face) override;
 
+	/// Return if any face of the font family is loaded.
+	bool IsFontFamilyLoaded(const String& family) override;
+
 	/// Returns a handle to a font face that can be used to position and render text. This will return the closest match
 	/// it can find, but in the event a font family is requested that does not exist, NULL will be returned instead of a
 	/// valid handle.

--- a/Source/Core/FontEngineDefault/FontProvider.cpp
+++ b/Source/Core/FontEngineDefault/FontProvider.cpp
@@ -229,6 +229,14 @@ bool FontProvider::LoadFontFace(Span<const byte> data, int face_index, bool fall
 	return true;
 }
 
+bool FontProvider::IsFontFamilyLoaded(const String& family)
+{
+	RMLUI_ASSERTMSG(family == StringUtilities::ToLower(family), "Font family name must be converted to lowercase before entering here.");
+
+	FontFamilyMap& families = Get().font_families;
+	return (families.find(family) != families.end());
+}
+
 bool FontProvider::AddFace(FontFaceHandleFreetype face, const String& family, Style::FontStyle style, Style::FontWeight weight, bool fallback_face,
 	UniquePtr<byte[]> face_memory)
 {

--- a/Source/Core/FontEngineDefault/FontProvider.h
+++ b/Source/Core/FontEngineDefault/FontProvider.h
@@ -65,6 +65,9 @@ public:
 	/// Adds a new font face from memory.
 	static bool LoadFontFace(Span<const byte> data, int face_index, const String& font_family, Style::FontStyle style, Style::FontWeight weight, bool fallback_face);
 
+	/// Return if any face of the font family is loaded.
+	static bool IsFontFamilyLoaded(const String& family);
+
 	/// Return the number of fallback font faces.
 	static int CountFallbackFontFaces();
 

--- a/Source/Core/FontEngineInterface.cpp
+++ b/Source/Core/FontEngineInterface.cpp
@@ -50,6 +50,11 @@ bool FontEngineInterface::LoadFontFace(Span<const byte> /*data*/, int /*face_ind
 	return false;
 }
 
+bool FontEngineInterface::IsFontFamilyLoaded(const String& /*family*/)
+{
+	return false;
+}
+
 FontFaceHandle FontEngineInterface::GetFontFaceHandle(const String& /*family*/, Style::FontStyle /*style*/, Style::FontWeight /*weight*/,
 	int /*size*/)
 {


### PR DESCRIPTION
A function/interface to determine if the font family exists in `FontFamilyMap`. Basically the same as `GetFontFaceHandle()`, but without match calculations for style/weight/size, and exposed to the user.