### PR TITLE
Limit the number of times a texture is unsuccessfully loaded

### DIFF
--- a/Source/Core/TextureDatabase.cpp
+++ b/Source/Core/TextureDatabase.cpp
@@ -75,10 +75,11 @@ auto CallbackTextureDatabase::EnsureLoaded(RenderManager* render_manager, Render
 	-> CallbackTextureEntry&
 {
 	CallbackTextureEntry& data = texture_list[callback_index];
-	if (!data.texture_handle)
+	if (!data.texture_handle && data.failed_load_count < MAX_TEXTURE_LOAD_ATTEMPTS)
 	{
 		if (!data.callback(CallbackTextureInterface(*render_manager, *render_interface, data.texture_handle, data.dimensions)))
 		{
+			data.failed_load_count++;
 			data.texture_handle = {};
 			data.dimensions = {};
 		}

--- a/Source/Core/TextureDatabase.cpp
+++ b/Source/Core/TextureDatabase.cpp
@@ -75,11 +75,11 @@ auto CallbackTextureDatabase::EnsureLoaded(RenderManager* render_manager, Render
 	-> CallbackTextureEntry&
 {
 	CallbackTextureEntry& data = texture_list[callback_index];
-	if (!data.texture_handle && data.failed_load_count < MAX_TEXTURE_LOAD_ATTEMPTS)
+	if (!data.texture_handle && !data.load_failed)
 	{
 		if (!data.callback(CallbackTextureInterface(*render_manager, *render_interface, data.texture_handle, data.dimensions)))
 		{
-			data.failed_load_count++;
+			data.load_failed = true;
 			data.texture_handle = {};
 			data.dimensions = {};
 		}

--- a/Source/Core/TextureDatabase.h
+++ b/Source/Core/TextureDatabase.h
@@ -38,7 +38,6 @@ namespace Rml {
 class RenderInterface;
 
 class CallbackTextureDatabase : NonCopyMoveable {
-
 public:
 	CallbackTextureDatabase();
 	~CallbackTextureDatabase();

--- a/Source/Core/TextureDatabase.h
+++ b/Source/Core/TextureDatabase.h
@@ -38,7 +38,6 @@ namespace Rml {
 class RenderInterface;
 
 class CallbackTextureDatabase : NonCopyMoveable {
-	const uint8_t MAX_TEXTURE_LOAD_ATTEMPTS = 3; // Maximum number of attempts to load a texture before giving up.
 
 public:
 	CallbackTextureDatabase();
@@ -59,7 +58,7 @@ private:
 		CallbackTextureFunction callback;
 		TextureHandle texture_handle = {};
 		Vector2i dimensions;
-		uint8_t failed_load_count = 0; // Number of times the callback failed to load the texture.
+		bool load_failed = false;
 	};
 
 	CallbackTextureEntry& EnsureLoaded(RenderManager* render_manager, RenderInterface* render_interface, StableVectorIndex callback_index);

--- a/Source/Core/TextureDatabase.h
+++ b/Source/Core/TextureDatabase.h
@@ -38,6 +38,8 @@ namespace Rml {
 class RenderInterface;
 
 class CallbackTextureDatabase : NonCopyMoveable {
+	const uint8_t MAX_TEXTURE_LOAD_ATTEMPTS = 3; // Maximum number of attempts to load a texture before giving up.
+
 public:
 	CallbackTextureDatabase();
 	~CallbackTextureDatabase();
@@ -57,6 +59,7 @@ private:
 		CallbackTextureFunction callback;
 		TextureHandle texture_handle = {};
 		Vector2i dimensions;
+		uint8_t failed_load_count = 0; // Number of times the callback failed to load the texture.
 	};
 
 	CallbackTextureEntry& EnsureLoaded(RenderManager* render_manager, RenderInterface* render_interface, StableVectorIndex callback_index);


### PR DESCRIPTION
During the SVG changes, with an SVG which didn't render anything the texture db would constantly try to reload the texture as it wasn't producing a bitmap and so was failing (this was noticed in the sandbox of the demo sample, entering ```<svg><circle /></svg>``` in the rml text box). Presumably this happens in other cases as well. 

This change sets a limit on how many times it will attempt to reload a texture and fail, currently defaulted to 3.

I'm not sure if the constant reloading was desirable in some situations, specifically in terms of the SVG change, if LUA were to set invalid SVG via innerRML it would effectively disable that element rendering correct SVG data subsequently past to it. This may perhaps be seen as being less fault tolerant, though i'm not sure that is a bad thing.