### PR TITLE
Radio grouping fix

### DIFF
--- a/Include/RmlUi/Core/ElementUtilities.h
+++ b/Include/RmlUi/Core/ElementUtilities.h
@@ -69,7 +69,8 @@ public:
 	/// @param[out] elements Resulting elements.
 	/// @param[in] root_element First element to check.
 	/// @param[in] tag Tag to search for.
-	static void GetElementsByTagName(ElementList& elements, Element* root_element, const String& tag);
+	/// @param[in] stop_tag Optional, tag to stop searching at i.e. won't look for other elements within this tag.
+	static void GetElementsByTagName(ElementList& elements, Element* root_element, const String& tag, const String& stop_tag = "");
 	/// Get all elements with the given class set on them.
 	/// @param[out] elements Resulting elements.
 	/// @param[in] root_element First element to check.

--- a/Source/Core/ElementUtilities.cpp
+++ b/Source/Core/ElementUtilities.cpp
@@ -74,7 +74,7 @@ Element* ElementUtilities::GetElementById(Element* root_element, const String& i
 	return nullptr;
 }
 
-void ElementUtilities::GetElementsByTagName(ElementList& elements, Element* root_element, const String& tag)
+void ElementUtilities::GetElementsByTagName(ElementList& elements, Element* root_element, const String& tag, const String& stop_tag)
 {
 	// Breadth first search on elements for the corresponding id
 	typedef Queue<Element*> SearchQueue;
@@ -90,9 +90,12 @@ void ElementUtilities::GetElementsByTagName(ElementList& elements, Element* root
 		if (element->GetTagName() == tag)
 			elements.push_back(element);
 
-		// Add all children to search.
-		for (int i = 0; i < element->GetNumChildren(); i++)
-			search_queue.push(element->GetChild(i));
+		if (stop_tag.empty() || element->GetTagName() != stop_tag)
+		{
+			// Add all children to search.
+			for (int i = 0; i < element->GetNumChildren(); i++)
+				search_queue.push(element->GetChild(i));
+		}
 	}
 }
 

--- a/Source/Core/Elements/InputTypeRadio.cpp
+++ b/Source/Core/Elements/InputTypeRadio.cpp
@@ -104,7 +104,7 @@ void InputTypeRadio::PopRadioSet()
 	//If no containing form was found, use the containing document as the parent
 	if (parent == nullptr)
 	{
-		parent = element->GetOwnerDocument();
+		parent = static_cast<Element*>(element->GetOwnerDocument());
 		stop_tag = "form"; // Don't include any radios that are inside form elements
 	}
 

--- a/Source/Core/Elements/InputTypeRadio.cpp
+++ b/Source/Core/Elements/InputTypeRadio.cpp
@@ -104,7 +104,7 @@ void InputTypeRadio::PopRadioSet()
 	//If no containing form was found, use the containing document as the parent
 	if (parent == nullptr)
 	{
-		parent = static_cast<Element*>(element->GetOwnerDocument());
+		parent = rmlui_dynamic_cast<Element*>(element->GetOwnerDocument());
 		stop_tag = "form"; // Don't include any radios that are inside form elements
 	}
 

--- a/Source/Core/Elements/InputTypeRadio.cpp
+++ b/Source/Core/Elements/InputTypeRadio.cpp
@@ -96,17 +96,15 @@ void InputTypeRadio::PopRadioSet()
 	// Uncheck all other radio buttons with our name in the form.
 	String stop_tag;
 	Element* parent = element->GetParentNode();
-	Element* prevParent = element->GetParentNode();
 	while (parent != nullptr && rmlui_dynamic_cast<ElementForm*>(parent) == nullptr)
 	{
-		prevParent = parent;
 		parent = parent->GetParentNode();
 	}
 
-	//If no containing form was found, use top-most parent
-	if (parent == nullptr && prevParent != nullptr)
+	//If no containing form was found, use the containing document as the parent
+	if (parent == nullptr)
 	{
-		parent = prevParent;
+		parent = element->GetOwnerDocument();
 		stop_tag = "form"; // Don't include any radios that are inside form elements
 	}
 

--- a/Source/Core/Elements/InputTypeRadio.cpp
+++ b/Source/Core/Elements/InputTypeRadio.cpp
@@ -27,6 +27,7 @@
  */
 
 #include "InputTypeRadio.h"
+#include "../../../Include/RmlUi/Core/ElementDocument.h"
 #include "../../../Include/RmlUi/Core/ElementUtilities.h"
 #include "../../../Include/RmlUi/Core/Elements/ElementForm.h"
 #include "../../../Include/RmlUi/Core/Elements/ElementFormControlInput.h"
@@ -104,7 +105,7 @@ void InputTypeRadio::PopRadioSet()
 	//If no containing form was found, use the containing document as the parent
 	if (parent == nullptr)
 	{
-		parent = rmlui_dynamic_cast<Element*>(element->GetOwnerDocument());
+		parent = element->GetOwnerDocument();
 		stop_tag = "form"; // Don't include any radios that are inside form elements
 	}
 

--- a/Source/Core/Elements/InputTypeRadio.cpp
+++ b/Source/Core/Elements/InputTypeRadio.cpp
@@ -98,9 +98,7 @@ void InputTypeRadio::PopRadioSet()
 	String stop_tag;
 	Element* parent = element->GetParentNode();
 	while (parent != nullptr && rmlui_dynamic_cast<ElementForm*>(parent) == nullptr)
-	{
 		parent = parent->GetParentNode();
-	}
 
 	//If no containing form was found, use the containing document as the parent
 	if (parent == nullptr)

--- a/Source/Core/Elements/InputTypeRadio.cpp
+++ b/Source/Core/Elements/InputTypeRadio.cpp
@@ -108,7 +108,7 @@ void InputTypeRadio::PopRadioSet()
 	if (parent != nullptr)
 	{
 		ElementList form_controls;
-		ElementUtilities::GetElementsByTagName(form_controls, parent, "input");
+		ElementUtilities::GetElementsByTagName(form_controls, parent, "input", "form");
 
 		for (size_t i = 0; i < form_controls.size(); ++i)
 		{

--- a/Source/Core/Elements/InputTypeRadio.cpp
+++ b/Source/Core/Elements/InputTypeRadio.cpp
@@ -94,15 +94,21 @@ bool InputTypeRadio::GetIntrinsicDimensions(Vector2f& dimensions, float& ratio)
 void InputTypeRadio::PopRadioSet()
 {
 	// Uncheck all other radio buttons with our name in the form.
-	ElementForm* form = nullptr;
 	Element* parent = element->GetParentNode();
-	while (parent != nullptr && (form = rmlui_dynamic_cast<ElementForm*>(parent)) == nullptr)
+	Element* prevParent = element->GetParentNode();
+	while (parent != nullptr && rmlui_dynamic_cast<ElementForm*>(parent) == nullptr)
+	{
+		prevParent = parent;
 		parent = parent->GetParentNode();
+	}
 
-	if (form != nullptr)
+	if (parent == nullptr && prevParent != nullptr)
+		parent = prevParent;
+
+	if (parent != nullptr)
 	{
 		ElementList form_controls;
-		ElementUtilities::GetElementsByTagName(form_controls, form, "input");
+		ElementUtilities::GetElementsByTagName(form_controls, parent, "input");
 
 		for (size_t i = 0; i < form_controls.size(); ++i)
 		{

--- a/Source/Core/Elements/InputTypeRadio.cpp
+++ b/Source/Core/Elements/InputTypeRadio.cpp
@@ -94,6 +94,7 @@ bool InputTypeRadio::GetIntrinsicDimensions(Vector2f& dimensions, float& ratio)
 void InputTypeRadio::PopRadioSet()
 {
 	// Uncheck all other radio buttons with our name in the form.
+	String stop_tag;
 	Element* parent = element->GetParentNode();
 	Element* prevParent = element->GetParentNode();
 	while (parent != nullptr && rmlui_dynamic_cast<ElementForm*>(parent) == nullptr)
@@ -102,13 +103,17 @@ void InputTypeRadio::PopRadioSet()
 		parent = parent->GetParentNode();
 	}
 
+	//If no containing form was found, use top-most parent
 	if (parent == nullptr && prevParent != nullptr)
+	{
 		parent = prevParent;
+		stop_tag = "form"; // Don't include any radios that are inside form elements
+	}
 
 	if (parent != nullptr)
 	{
 		ElementList form_controls;
-		ElementUtilities::GetElementsByTagName(form_controls, parent, "input", "form");
+		ElementUtilities::GetElementsByTagName(form_controls, parent, "input", stop_tag);
 
 		for (size_t i = 0; i < form_controls.size(); ++i)
 		{


### PR DESCRIPTION
Currently radio input elements are grouped by name (you can only select a single radio in the group) but **only** when they are within a form parent element. If there isn't a form element they act individually so you could have both radios checked with the same name at the same time.

I don't believe this is expected behaviour, and they should behave the same without a form element containing them.

This PR maintains current functionality of radios acting mutually exclusively in their name group within context of their own form. It extends this by grouping radio buttons by name that are outside of any form element, these will act as a separate grouping to any others that may be within form elements.

Test RML/HTML used for checking this:
```
<p>Expected behaviour is radios should be mutually exclusive on each line, and should not interact between lines</p>
<div>
<input type="radio" name="testradio" value="1" />
<input type="radio" name="testradio" value="2" />
</div>
<div>
<form>
<input type="radio" name="testradio" value="1" />
<input type="radio" name="testradio" value="2" />
</form>
</div>
<div>
<form>
<input type="radio" name="testradio" value="1" />
<input type="radio" name="testradio" value="2" />
</form>
</div>
```

I appreciate you may not be keen on the optional parameter added to GetElementsByTagName but this seemed like the most efficient way of preventing non form contained radios interacting with those contained within a form.
