### PR TITLE
Remove duplicate "Equal" table from VisualTest comparsion log

### DIFF
--- a/Tests/Source/VisualTests/TestNavigator.cpp
+++ b/Tests/Source/VisualTests/TestNavigator.cpp
@@ -566,12 +566,6 @@ void TestNavigator::StopTestSuiteIteration()
 			suite.SetIndex(i);
 			log += Rml::CreateString("%5d   %s\n", i + 1, suite.GetFilename().c_str());
 		}
-		log += "\nEqual:\n";
-		for (int i : equal)
-		{
-			suite.SetIndex(i);
-			log += Rml::CreateString("%5d   %s\n", i + 1, suite.GetFilename().c_str());
-		}
 
 		const Rml::String log_path = GetCaptureOutputDirectory() + "/comparison.log";
 		bool save_result = SaveFile(log_path, log);


### PR DESCRIPTION
Comparsion log of VisualTest has mistakenly duplicated "Equal" table that was introduced with merge of effects branch in 8559aaf59649a39e7b9e4ac6bbafcedbad5e369f (if I understand correctly)
![image](https://github.com/user-attachments/assets/ac28431d-fac2-4d2f-a3fa-025a1404bde2)
This PR removes it