### PR TITLE
HTML Conformance: Change button and submit input element types to show text from value attribute not child text node

### DIFF
--- a/Source/Core/Elements/InputTypeButton.cpp
+++ b/Source/Core/Elements/InputTypeButton.cpp
@@ -29,6 +29,8 @@
 #include "InputTypeButton.h"
 #include "../../../Include/RmlUi/Core/Elements/ElementForm.h"
 #include "../../../Include/RmlUi/Core/Elements/ElementFormControlInput.h"
+#include "../Include/RmlUi/Core/Factory.h"
+#include "../Include/RmlUi/Core/ElementText.h"
 
 namespace Rml {
 

--- a/Source/Core/Elements/InputTypeButton.cpp
+++ b/Source/Core/Elements/InputTypeButton.cpp
@@ -29,8 +29,8 @@
 #include "InputTypeButton.h"
 #include "../../../Include/RmlUi/Core/Elements/ElementForm.h"
 #include "../../../Include/RmlUi/Core/Elements/ElementFormControlInput.h"
-#include "../Include/RmlUi/Core/Factory.h"
 #include "../Include/RmlUi/Core/ElementText.h"
+#include "../Include/RmlUi/Core/Factory.h"
 
 namespace Rml {
 

--- a/Source/Core/Elements/InputTypeButton.cpp
+++ b/Source/Core/Elements/InputTypeButton.cpp
@@ -29,7 +29,6 @@
 #include "InputTypeButton.h"
 #include "../../../Include/RmlUi/Core/Elements/ElementForm.h"
 #include "../../../Include/RmlUi/Core/Elements/ElementFormControlInput.h"
-#include "../Include/RmlUi/Core/ElementText.h"
 #include "../Include/RmlUi/Core/Factory.h"
 
 namespace Rml {

--- a/Source/Core/Elements/InputTypeButton.cpp
+++ b/Source/Core/Elements/InputTypeButton.cpp
@@ -34,11 +34,7 @@
 
 namespace Rml {
 
-InputTypeButton::InputTypeButton(ElementFormControlInput* element) : InputType(element)
-{
-	value_element = element->AppendChild(Factory::InstanceElement(element, "#text", "", XMLAttributes()), true);
-	rmlui_static_cast<ElementText*>(value_element)->SetText(element->GetAttribute<String>("value", ""));
-}
+InputTypeButton::InputTypeButton(ElementFormControlInput* element) : InputType(element) {}
 
 InputTypeButton::~InputTypeButton() {}
 
@@ -52,7 +48,14 @@ bool InputTypeButton::OnAttributeChange(const ElementAttributes& changed_attribu
 {
 	if (changed_attributes.find("value") != changed_attributes.end())
 	{
-		rmlui_static_cast<ElementText*>(value_element)->SetText(element->GetAttribute<String>("value", ""));
+		auto value = element->GetAttribute<String>("value", "");
+		if (!value.empty() && !value_element)
+			value_element =
+				rmlui_static_cast<ElementText*>(element->AppendChild(Factory::InstanceElement(element, "#text", "", XMLAttributes()), true));
+
+		if (value_element)
+			value_element->SetText(value);
+
 		return false;
 	}
 	return true;

--- a/Source/Core/Elements/InputTypeButton.cpp
+++ b/Source/Core/Elements/InputTypeButton.cpp
@@ -32,7 +32,11 @@
 
 namespace Rml {
 
-InputTypeButton::InputTypeButton(ElementFormControlInput* element) : InputType(element) {}
+InputTypeButton::InputTypeButton(ElementFormControlInput* element) : InputType(element)
+{
+	value_element = element->AppendChild(Factory::InstanceElement(element, "#text", "", XMLAttributes()), true);
+	rmlui_static_cast<ElementText*>(value_element)->SetText(element->GetAttribute<String>("value", ""));
+}
 
 InputTypeButton::~InputTypeButton() {}
 
@@ -40,6 +44,16 @@ bool InputTypeButton::IsSubmitted()
 {
 	// Buttons are never submitted.
 	return false;
+}
+
+bool InputTypeButton::OnAttributeChange(const ElementAttributes& changed_attributes)
+{
+	if (changed_attributes.find("value") != changed_attributes.end())
+	{
+		rmlui_static_cast<ElementText*>(value_element)->SetText(element->GetAttribute<String>("value", ""));
+		return false;
+	}
+	return true;
 }
 
 void InputTypeButton::ProcessDefaultAction(Event& /*event*/) {}

--- a/Source/Core/Elements/InputTypeButton.cpp
+++ b/Source/Core/Elements/InputTypeButton.cpp
@@ -29,7 +29,7 @@
 #include "InputTypeButton.h"
 #include "../../../Include/RmlUi/Core/Elements/ElementForm.h"
 #include "../../../Include/RmlUi/Core/Elements/ElementFormControlInput.h"
-#include "../Include/RmlUi/Core/Factory.h"
+#include "../../../Include/RmlUi/Core/Factory.h"
 
 namespace Rml {
 

--- a/Source/Core/Elements/InputTypeButton.h
+++ b/Source/Core/Elements/InputTypeButton.h
@@ -30,8 +30,8 @@
 #define RMLUI_CORE_ELEMENTS_INPUTTYPEBUTTON_H
 
 #include "../../../Include/RmlUi/Core/ElementDocument.h"
+#include "../../../Include/RmlUi/Core/ElementText.h"
 #include "../../../Include/RmlUi/Core/EventListener.h"
-#include "../Include/RmlUi/Core/ElementText.h"
 #include "InputType.h"
 
 namespace Rml {

--- a/Source/Core/Elements/InputTypeButton.h
+++ b/Source/Core/Elements/InputTypeButton.h
@@ -31,6 +31,7 @@
 
 #include "../../../Include/RmlUi/Core/ElementDocument.h"
 #include "../../../Include/RmlUi/Core/EventListener.h"
+#include "../Include/RmlUi/Core/ElementText.h"
 #include "InputType.h"
 
 namespace Rml {

--- a/Source/Core/Elements/InputTypeButton.h
+++ b/Source/Core/Elements/InputTypeButton.h
@@ -65,7 +65,7 @@ public:
 	bool GetIntrinsicDimensions(Vector2f& dimensions, float& ratio) override;
 
 private:
-	Element* value_element = nullptr;
+	ElementText* value_element = nullptr;
 };
 
 } // namespace Rml

--- a/Source/Core/Elements/InputTypeButton.h
+++ b/Source/Core/Elements/InputTypeButton.h
@@ -51,6 +51,11 @@ public:
 	/// @return True if the form control is to be submitted, false otherwise.
 	bool IsSubmitted() override;
 
+	/// Called when an attribute of the element has changed.
+	/// @param[in] changed_attributes The attributes that have changed.
+	/// @return True if no layout is required, false if the layout needs to be dirtied.
+	bool OnAttributeChange(const ElementAttributes& changed_attributes) override;
+
 	/// Checks for necessary functional changes in the control as a result of the event.
 	/// @param[in] event The event to process.
 	void ProcessDefaultAction(Event& event) override;
@@ -58,6 +63,9 @@ public:
 	/// Sizes the dimensions to the element's inherent size.
 	/// @return False.
 	bool GetIntrinsicDimensions(Vector2f& dimensions, float& ratio) override;
+
+private:
+	Element* value_element = nullptr;
 };
 
 } // namespace Rml

--- a/Source/Core/Elements/InputTypeSubmit.cpp
+++ b/Source/Core/Elements/InputTypeSubmit.cpp
@@ -34,11 +34,7 @@
 
 namespace Rml {
 
-InputTypeSubmit::InputTypeSubmit(ElementFormControlInput* element) : InputType(element)
-{
-	value_element = element->AppendChild(Factory::InstanceElement(element, "#text", "", XMLAttributes()), true);
-	rmlui_static_cast<ElementText*>(value_element)->SetText(element->GetAttribute<String>("value", ""));
-}
+InputTypeSubmit::InputTypeSubmit(ElementFormControlInput* element) : InputType(element) {}
 
 InputTypeSubmit::~InputTypeSubmit() {}
 bool InputTypeSubmit::IsSubmitted()
@@ -51,7 +47,14 @@ bool InputTypeSubmit::OnAttributeChange(const ElementAttributes& changed_attribu
 {
 	if (changed_attributes.find("value") != changed_attributes.end())
 	{
-		rmlui_static_cast<ElementText*>(value_element)->SetText(element->GetAttribute<String>("value", ""));
+		auto value = element->GetAttribute<String>("value", "");
+		if (!value.empty() && !value_element)
+			value_element =
+				rmlui_static_cast<ElementText*>(element->AppendChild(Factory::InstanceElement(element, "#text", "", XMLAttributes()), true));
+
+		if (value_element)
+			value_element->SetText(value);
+
 		return false;
 	}
 	return true;

--- a/Source/Core/Elements/InputTypeSubmit.cpp
+++ b/Source/Core/Elements/InputTypeSubmit.cpp
@@ -29,6 +29,8 @@
 #include "InputTypeSubmit.h"
 #include "../../../Include/RmlUi/Core/Elements/ElementForm.h"
 #include "../../../Include/RmlUi/Core/Elements/ElementFormControlInput.h"
+#include "../Include/RmlUi/Core/Factory.h"
+#include "../Include/RmlUi/Core/ElementText.h"
 
 namespace Rml {
 

--- a/Source/Core/Elements/InputTypeSubmit.cpp
+++ b/Source/Core/Elements/InputTypeSubmit.cpp
@@ -29,7 +29,7 @@
 #include "InputTypeSubmit.h"
 #include "../../../Include/RmlUi/Core/Elements/ElementForm.h"
 #include "../../../Include/RmlUi/Core/Elements/ElementFormControlInput.h"
-#include "../Include/RmlUi/Core/Factory.h"
+#include "../../../Include/RmlUi/Core/Factory.h"
 
 namespace Rml {
 

--- a/Source/Core/Elements/InputTypeSubmit.cpp
+++ b/Source/Core/Elements/InputTypeSubmit.cpp
@@ -32,14 +32,27 @@
 
 namespace Rml {
 
-InputTypeSubmit::InputTypeSubmit(ElementFormControlInput* element) : InputType(element) {}
+InputTypeSubmit::InputTypeSubmit(ElementFormControlInput* element) : InputType(element)
+{
+	value_element = element->AppendChild(Factory::InstanceElement(element, "#text", "", XMLAttributes()), true);
+	rmlui_static_cast<ElementText*>(value_element)->SetText(element->GetAttribute<String>("value", ""));
+}
 
 InputTypeSubmit::~InputTypeSubmit() {}
-
 bool InputTypeSubmit::IsSubmitted()
 {
 	// Submit buttons are never submitted; they submit themselves if appropriate.
 	return false;
+}
+
+bool InputTypeSubmit::OnAttributeChange(const ElementAttributes& changed_attributes)
+{
+	if (changed_attributes.find("value") != changed_attributes.end())
+	{
+		rmlui_static_cast<ElementText*>(value_element)->SetText(element->GetAttribute<String>("value", ""));
+		return false;
+	}
+	return true;
 }
 
 void InputTypeSubmit::ProcessDefaultAction(Event& event)

--- a/Source/Core/Elements/InputTypeSubmit.cpp
+++ b/Source/Core/Elements/InputTypeSubmit.cpp
@@ -29,8 +29,8 @@
 #include "InputTypeSubmit.h"
 #include "../../../Include/RmlUi/Core/Elements/ElementForm.h"
 #include "../../../Include/RmlUi/Core/Elements/ElementFormControlInput.h"
-#include "../Include/RmlUi/Core/Factory.h"
 #include "../Include/RmlUi/Core/ElementText.h"
+#include "../Include/RmlUi/Core/Factory.h"
 
 namespace Rml {
 

--- a/Source/Core/Elements/InputTypeSubmit.cpp
+++ b/Source/Core/Elements/InputTypeSubmit.cpp
@@ -29,7 +29,6 @@
 #include "InputTypeSubmit.h"
 #include "../../../Include/RmlUi/Core/Elements/ElementForm.h"
 #include "../../../Include/RmlUi/Core/Elements/ElementFormControlInput.h"
-#include "../Include/RmlUi/Core/ElementText.h"
 #include "../Include/RmlUi/Core/Factory.h"
 
 namespace Rml {

--- a/Source/Core/Elements/InputTypeSubmit.h
+++ b/Source/Core/Elements/InputTypeSubmit.h
@@ -29,6 +29,7 @@
 #ifndef RMLUI_CORE_ELEMENTS_INPUTTYPESUBMIT_H
 #define RMLUI_CORE_ELEMENTS_INPUTTYPESUBMIT_H
 
+#include "../Include/RmlUi/Core/ElementText.h"
 #include "InputType.h"
 
 namespace Rml {

--- a/Source/Core/Elements/InputTypeSubmit.h
+++ b/Source/Core/Elements/InputTypeSubmit.h
@@ -48,6 +48,11 @@ public:
 	/// @return True if the form control is to be submitted, false otherwise.
 	bool IsSubmitted() override;
 
+	/// Called when an attribute of the element has changed.
+	/// @param[in] changed_attributes The attributes that have changed.
+	/// @return True if no layout is required, false if the layout needs to be dirtied.
+	bool OnAttributeChange(const ElementAttributes& changed_attributes) override;
+
 	/// Checks for necessary functional changes in the control as a result of the event.
 	/// @param[in] event The event to process.
 	void ProcessDefaultAction(Event& event) override;
@@ -55,6 +60,9 @@ public:
 	/// Sizes the dimensions to the element's inherent size.
 	/// @return False.
 	bool GetIntrinsicDimensions(Vector2f& dimensions, float& ratio) override;
+
+private:
+	Element* value_element = nullptr;
 };
 
 } // namespace Rml

--- a/Source/Core/Elements/InputTypeSubmit.h
+++ b/Source/Core/Elements/InputTypeSubmit.h
@@ -62,7 +62,7 @@ public:
 	bool GetIntrinsicDimensions(Vector2f& dimensions, float& ratio) override;
 
 private:
-	Element* value_element = nullptr;
+	ElementText* value_element = nullptr;
 };
 
 } // namespace Rml

--- a/Source/Core/Elements/InputTypeSubmit.h
+++ b/Source/Core/Elements/InputTypeSubmit.h
@@ -29,7 +29,7 @@
 #ifndef RMLUI_CORE_ELEMENTS_INPUTTYPESUBMIT_H
 #define RMLUI_CORE_ELEMENTS_INPUTTYPESUBMIT_H
 
-#include "../Include/RmlUi/Core/ElementText.h"
+#include "../../../Include/RmlUi/Core/ElementText.h"
 #include "InputType.h"
 
 namespace Rml {


### PR DESCRIPTION
Current behaviour uses the child text node as the source of the button text however this is not how HTML spec/browsers work, instead the value attribute should be the source of the button text. Unless I'm missing something this deviation from HTML behaviour also isn't documented anywhere.

This change uses the value attribute as the text to show on the button, but will still show the child text node if set. This should prevent breakage of any existing markup relying on this behaviour, but if they have both a value attribute and child text node both of these will show after this change.

To show a input button/submit button currently with button text of "Test Button" would require:
```
<input type="submit">Test Button</input>
<input type="button">Test Button</input>
```

With this change the following works:
```
<input type="submit" value="Test Button" />
<input type="button" value="Test Button" />
```

I'm not too happy with instancing the text node as a DOM element but it seemed like the lesser of two evils, as having it as a non-DOM would the require more code to render it.