### PR TITLE
Fix compile issues with the SVG plugin when using a custom `String` type

### DIFF
--- a/Source/SVG/ElementSVG.cpp
+++ b/Source/SVG/ElementSVG.cpp
@@ -117,7 +117,7 @@ void ElementSVG::UpdateCachedData()
 
 	svg_dirty = false;
 
-	const std::string source = GetAttribute<String>("src", "");
+	const String source = GetAttribute<String>("src", "");
 	if (source.empty())
 	{
 		handle.reset();

--- a/Source/SVG/SVGCache.cpp
+++ b/Source/SVG/SVGCache.cpp
@@ -142,7 +142,7 @@ namespace SVG {
 			[&](const SVGGeometry& data) { return data.colour == colour; });
 	}
 
-	static const std::string& GetSourceOr(const lunasvg::Document* svg_document, const std::string& default_value)
+	static const String& GetSourceOr(const lunasvg::Document* svg_document, const String& default_value)
 	{
 		const auto& documents = svg_cache_data->documents;
 		auto it = std::find_if(documents.begin(), documents.end(),

--- a/Source/SVG/SVGCache.cpp
+++ b/Source/SVG/SVGCache.cpp
@@ -188,7 +188,7 @@ namespace SVG {
 			}
 
 			// We use a reset-release approach here in case clients use a non-std unique_ptr (lunasvg uses std::unique_ptr)
-			doc.svg_document.reset(lunasvg::Document::loadFromData(svg_data).release());
+			doc.svg_document.reset(lunasvg::Document::loadFromData(svg_data.data(), svg_data.size()).release());
 
 			if (!doc.svg_document)
 			{


### PR DESCRIPTION
This PR fixes compilation issues with the SVG plugin when `Rml::String` is defined to something other than `std::string`.

They were a few places where `std::string` was used instead of `String`. Also, replacing `lunasvg::Document::loadFromData(svg_data)` with `loadFromData(svg_data.data(), svg_data.size())` allows it to work with other string types. I don't know what minimum version of lunasvg RmlUi supports, but the `loadFromData(const char*, size_t)` overload is present since v2.0.0, and it is called by the `loadFromData(std::string)` overload, so it shouldn't make a difference.