### PR TITLE
add support for focusin/focusout

### DIFF
--- a/Include/RmlUi/Core/ID.h
+++ b/Include/RmlUi/Core/ID.h
@@ -221,6 +221,8 @@ enum class EventId : uint16_t {
 	Mouseout,
 	Focus,
 	Blur,
+	FocusIn,
+	FocusOut,
 	Keydown,
 	Keyup,
 	Textinput,

--- a/Source/Core/Context.cpp
+++ b/Source/Core/Context.cpp
@@ -1047,10 +1047,16 @@ bool Context::OnFocusChange(Element* new_focus, bool focus_visible)
 	Dictionary parameters;
 	SendEvents(old_chain, new_chain, EventId::Blur, parameters);
 
+	if (old_focus)
+		old_focus->DispatchEvent(Rml::EventId::FocusOut, parameters);
+
 	if (focus_visible)
 		parameters["focus_visible"] = true;
 
 	SendEvents(new_chain, old_chain, EventId::Focus, parameters);
+
+	if (new_focus)
+		new_focus->DispatchEvent(Rml::EventId::FocusIn, parameters);
 
 	focus = new_focus;
 

--- a/Source/Core/EventSpecification.cpp
+++ b/Source/Core/EventSpecification.cpp
@@ -44,6 +44,8 @@ struct EventSpecificationData {
 		{EventId::Mouseout      , "mouseout"      , true  , true  , DefaultActionPhase::Target},
 		{EventId::Focus         , "focus"         , false , false , DefaultActionPhase::Target},
 		{EventId::Blur          , "blur"          , false , false , DefaultActionPhase::Target},
+		{EventId::FocusIn       , "focusin"       , false , true  , DefaultActionPhase::TargetAndBubble},
+		{EventId::FocusOut      , "focusout"      , false , true  , DefaultActionPhase::TargetAndBubble},
 		{EventId::Keydown       , "keydown"       , true  , true  , DefaultActionPhase::TargetAndBubble},
 		{EventId::Keyup         , "keyup"         , true  , true  , DefaultActionPhase::TargetAndBubble},
 		{EventId::Textinput     , "textinput"     , true  , true  , DefaultActionPhase::TargetAndBubble},


### PR DESCRIPTION
Simple patch to add support for `focusin` and `focusout`, which are bubble-able versions of `focus` and `blur`. For weird historical reasons, focus and blur don't bubble which makes certain features difficult to implement without them (like for parent elements to detect when deep children have been unfocused).

See https://javascript.info/focus-blur#delegation-focusin-focusout and https://w3c.github.io/uievents/#event-type-focusin