### PR TITLE
Overload element animation functions, using PropertyId.

### DIFF
--- a/Include/RmlUi/Core/Element.h
+++ b/Include/RmlUi/Core/Element.h
@@ -70,9 +70,9 @@ struct ElementMeta;
 struct StackingContextChild;
 
 /**
-    A generic element in the DOM tree.
+	A generic element in the DOM tree.
 
-    @author Peter Curry
+	@author Peter Curry
  */
 
 class RMLUICORE_API Element : public ScriptInterface, public EnableObserverPtr<Element> {
@@ -270,11 +270,14 @@ public:
 	/// @return True if a new animation was added.
 	bool Animate(const String& property_name, const Property& target_value, float duration, Tween tween = Tween{}, int num_iterations = 1,
 		bool alternate_direction = true, float delay = 0.0f, const Property* start_value = nullptr);
+	bool Animate(PropertyId id, const Property& target_value, float duration, Tween tween = Tween{}, int num_iterations = 1,
+		bool alternate_direction = true, float delay = 0.0f, const Property* start_value = nullptr);
 
 	/// Add a key to an animation, extending its duration.
 	/// If no animation exists for the given property name, the call will be ignored.
 	/// @return True if a new animation key was added.
 	bool AddAnimationKey(const String& property_name, const Property& target_value, float duration, Tween tween = Tween{});
+	bool AddAnimationKey(PropertyId id, const Property& target_value, float duration, Tween tween = Tween{});
 
 	/// Iterator for the local (non-inherited) properties defined on this element.
 	/// @warning Modifying the element's properties or classes invalidates the iterator.
@@ -584,7 +587,7 @@ public:
 	//@}
 
 	/**
-	    @name Internal Functions
+		@name Internal Functions
 	 */
 	//@{
 	/// Access the event dispatcher for this element.

--- a/Source/Core/Element.cpp
+++ b/Source/Core/Element.cpp
@@ -2498,10 +2498,15 @@ void Element::UpdateDefinition()
 bool Element::Animate(const String& property_name, const Property& target_value, float duration, Tween tween, int num_iterations,
 	bool alternate_direction, float delay, const Property* start_value)
 {
-	bool result = false;
-	PropertyId property_id = StyleSheetSpecification::GetPropertyId(property_name);
+	return Animate(StyleSheetSpecification::GetPropertyId(property_name), target_value, duration, tween,
+		num_iterations, alternate_direction, delay, start_value);
+}
 
-	auto it_animation = StartAnimation(property_id, start_value, num_iterations, alternate_direction, delay, false);
+bool Element::Animate(PropertyId id, const Property& target_value, float duration, Tween tween, int num_iterations,
+	bool alternate_direction, float delay, const Property* start_value)
+{
+	bool result = false;
+	auto it_animation = StartAnimation(id, start_value, num_iterations, alternate_direction, delay, false);
 	if (it_animation != animations.end())
 	{
 		result = it_animation->AddKey(duration, target_value, *this, tween, true);
@@ -2514,13 +2519,15 @@ bool Element::Animate(const String& property_name, const Property& target_value,
 
 bool Element::AddAnimationKey(const String& property_name, const Property& target_value, float duration, Tween tween)
 {
+	return AddAnimationKey(StyleSheetSpecification::GetPropertyId(property_name), target_value, duration, tween);
+}
+
+bool Element::AddAnimationKey(PropertyId id, const Property& target_value, float duration, Tween tween)
+{
 	ElementAnimation* animation = nullptr;
-
-	PropertyId property_id = StyleSheetSpecification::GetPropertyId(property_name);
-
 	for (auto& existing_animation : animations)
 	{
-		if (existing_animation.GetPropertyId() == property_id)
+		if (existing_animation.GetPropertyId() == id)
 		{
 			animation = &existing_animation;
 			break;


### PR DESCRIPTION
Small commit to overload `Element::Animate()` and `Element::AddAnimationKey()` taking PropertyId as parameter.