### PR TITLE
Fix unsupported glyph cluster rendering

### DIFF
--- a/Samples/basic/harfbuzz/src/FontFaceHandleHarfBuzz.h
+++ b/Samples/basic/harfbuzz/src/FontFaceHandleHarfBuzz.h
@@ -71,6 +71,7 @@ public:
 
 	const FontGlyphMap& GetGlyphs() const;
 	const FallbackFontGlyphMap& GetFallbackGlyphs() const;
+	const FallbackFontClusterGlyphMap& GetFallbackClusterGlyphs() const;
 
 	/// Returns the width a string will take up if rendered with this handle.
 	/// @param[in] string The string to measure.
@@ -131,6 +132,19 @@ private:
 	/// @return The fallback font glyph for character.
 	const FontGlyph* GetOrAppendFallbackGlyph(Character character);
 
+	// Build and append fallback cluster glyph to 'fallback_cluster_glyphs'.
+	bool AppendFallbackClusterGlyph(StringView cluster, const TextShapingContext& text_shaping_context,
+		const LanguageDataMap& registered_languages);
+
+	/// Retrieve a fallback cluster glyph from the given cluster and text-shaping/language data, building and appending a new fallback cluster glyph if not already built.
+	/// @param[in] cluster  The cluster.
+	/// @param[in] text_shaping_context  Extra parameters that provide context for text shaping.
+	/// @param[in] registered_languages  A list of languages registered in the font engine interface.
+	/// @param[out] glyph_index  The glyph index of the cluster.
+	/// @return The fallback font glyph for cluster.
+	const FontGlyph* GetOrAppendFallbackClusterGlyph(const String& cluster, const TextShapingContext& text_shaping_context,
+		const LanguageDataMap& registered_languages, FontGlyphIndex& glyph_index);
+
 	// Regenerate layers if dirty, such as after adding new glyphs.
 	bool UpdateLayersOnDirty();
 
@@ -140,12 +154,28 @@ private:
 	// (Re-)generate a layer in this font face handle.
 	bool GenerateLayer(FontFaceLayer* layer);
 
-	// Configure internal text shaping buffer values with context.
+	/// Configure internal text shaping buffer values with context.
+	/// @param[in] shaping_buffer  The shaping buffer to be configured.
+	/// @param[in] string  The string currently being measured/rendered.
+	/// @param[in] text_shaping_context  Extra parameters that provide context for text shaping.
+	/// @param[in] registered_languages  A list of languages registered in the font engine interface.
 	void ConfigureTextShapingBuffer(struct hb_buffer_t* shaping_buffer, StringView string, const TextShapingContext& text_shaping_context,
-		const LanguageDataMap& registered_languages);
+		const LanguageDataMap& registered_languages) const;
+
+	/// Creates a cluster string from shaped glyph info and index.
+	/// @param[in] glyph_info  The shaped glyph info list (supplied by HarfBuzz).
+	/// @param[in] glyph_count  The number of shaped glyphs in glyph_info.
+	/// @param[in] glyph_index  The current glyph index.
+	/// @param[in] first_character  The first character of the cluster.
+	/// @param[in] string  The string currently being measured/rendered.
+	/// @param[out] cluster_codepoint_count  The number of codepoints in the cluster (which may differ from the length of the returned string).
+	/// @return A UTF8 string built from all codepoints in the current glyph cluster.
+	String GetCurrentClusterString(const struct hb_glyph_info_t* glyph_info, int glyph_count, int glyph_index, Character first_character,
+		StringView string, int& cluster_codepoint_count) const;
 
 	FontGlyphMap glyphs;
 	FallbackFontGlyphMap fallback_glyphs;
+	FallbackFontClusterGlyphMap fallback_cluster_glyphs;
 
 	struct EffectLayerPair {
 		const FontEffect* font_effect;

--- a/Samples/basic/harfbuzz/src/FontFaceLayer.h
+++ b/Samples/basic/harfbuzz/src/FontFaceLayer.h
@@ -82,8 +82,8 @@ public:
 	/// @param[out] texture_data The generated texture data.
 	/// @param[out] texture_dimensions The dimensions of the texture.
 	/// @param[in] texture_id The index of the texture within the layer to generate.
-	/// @param[in] glyphs The glyphs required by the font face handle.
-	bool GenerateTexture(Vector<byte>& texture_data, Vector2i& texture_dimensions, int texture_id, const FontGlyphMap& glyphs, const FallbackFontGlyphMap& fallback_glyphs);
+	/// @param[in] glyph_maps The glyph maps required by the font face handle.
+	bool GenerateTexture(Vector<byte>& texture_data, Vector2i& texture_dimensions, int texture_id, const FontGlyphMaps& glyph_maps);
 
 	/// Generates the geometry required to render a single character.
 	/// @param[out] mesh_list An array of meshes this layer will write to. It must be at least as big as the number of textures in this layer.

--- a/Samples/basic/harfbuzz/src/FontGlyph.h
+++ b/Samples/basic/harfbuzz/src/FontGlyph.h
@@ -31,14 +31,29 @@
 
 #include <RmlUi/Core.h>
 
+using FontGlyphIndex = uint32_t;
+
 struct FontGlyphData
 {
 	Rml::FontGlyph bitmap;
 	Rml::Character character;
 };
 
-using FontGlyphIndex = uint32_t;
+struct FontClusterGlyphData
+{
+	FontGlyphIndex glyph_index;
+	FontGlyphData glyph_data;
+};
+
 using FontGlyphMap = Rml::UnorderedMap<FontGlyphIndex, FontGlyphData>;
 using FallbackFontGlyphMap = Rml::UnorderedMap<Rml::Character, Rml::FontGlyph>;
+using FallbackFontClusterGlyphMap = Rml::UnorderedMap<Rml::String, FontClusterGlyphData>;
+
+struct FontGlyphMaps
+{
+	const FontGlyphMap* glyphs;
+	const FallbackFontGlyphMap* fallback_glyphs;
+	const FallbackFontClusterGlyphMap* fallback_cluster_glyphs;
+};
 
 #endif


### PR DESCRIPTION
This pull-request fixes issues regarding fallback font cluster rendering (such as Emoji ZWJ sequences), which was brought up as an aside in #818.

The initial solution mentioned in the issue was to properly segment text. However, upon thinking about this more, I realised that doing this wouldn't actually fix the underlying issue (for example, it would be possible for an unsupported cluster to appear in the middle of a text segment). In the end, I managed to implement proper glyph cluster rendering if a fallback font supports it.

<img width="576" height="199" alt="image" src="https://github.com/user-attachments/assets/b99546d2-1b42-4eb8-ad54-62e0a09e69e0" />

In the middle of a paragraph:
<img width="555" height="109" alt="image" src="https://github.com/user-attachments/assets/c73fd54e-cbb6-472d-aa40-a82efb513176" />

The basic logic works as follows:
* The font interface encounters a glyph that the current font doesn't support.
* It will then check if the glyph is part of a compound (more than one character) cluster.
* If so, then it will see if any fallback fonts support this cluster as a single glyph, and will use it for measuring/rendering.
* Otherwise, if the glyph is not part of a compound cluster, it will look for the glyph in the fallback fonts like always, and will render the default replacement character if none are found.

It also works properly in right-to-left text (which should be a given since HarfBuzz will preserve the clusters, direction notwithstanding, but it's always good to see it in action):
<img width="340" height="148" alt="image" src="https://github.com/user-attachments/assets/f696bc52-a013-4645-aeae-e1dfcec2ccfe" />

It will also render only a single replacement character for each cluster if no glyph could be found for it, instead of rendering one for each component of a cluster:
<img width="362" height="192" alt="image" src="https://github.com/user-attachments/assets/2d30db1d-847d-4b25-adc8-f9b3d999b23f" />
