### PR TITLE
Support multiple font families in font handling

### DIFF
--- a/Include/RmlUi/Core/ComputedValues.h
+++ b/Include/RmlUi/Core/ComputedValues.h
@@ -254,7 +254,7 @@ namespace Style {
 		bool                 has_decorator()       const { return common.has_decorator; }
 
 		// -- Inherited --
-		String         font_family()      const;
+		StringList     font_family()      const;
 		String         cursor()           const;
 		FontFaceHandle font_face_handle() const { return inherited.font_face_handle; }
 		float          font_size()        const { return inherited.font_size; }

--- a/Include/RmlUi/Core/FontEngineInterface.h
+++ b/Include/RmlUi/Core/FontEngineInterface.h
@@ -82,6 +82,15 @@ public:
 	/// @param[in] size The size of desired handle, in points.
 	/// @return A valid handle if a matching (or closely matching) font face was found, NULL otherwise.
 	virtual FontFaceHandle GetFontFaceHandle(const String& family, Style::FontStyle style, Style::FontWeight weight, int size);
+	
+	/// Attempts to find a valid font handle from a list of font families.
+	/// Iterates through each family until a matching (or close) font face is found.
+	/// @param[in] families Ordered list of font family names to try.
+	/// @param[in] style Desired font style.
+	/// @param[in] weight Desired font weight.
+	/// @param[in] size Font size in points.
+	/// @return The first valid font handle found, or NULL if none match.
+	FontFaceHandle GetFontFaceHandle(const StringList& families, Style::FontStyle style, Style::FontWeight weight, int size);
 
 	/// Called by RmlUi when a list of font effects is resolved for an element with a given font face.
 	/// @param[in] handle The font handle.

--- a/Source/Core/ComputeProperty.cpp
+++ b/Source/Core/ComputeProperty.cpp
@@ -145,9 +145,13 @@ float ComputeFontsize(NumericValue value, const Style::ComputedValues& values, c
 	return ComputeLength(value, 0.f, 0.f, dp_ratio, vp_dimensions);
 }
 
-String ComputeFontFamily(String font_family)
+StringList ComputeFontFamily(String font_family)
 {
-	return StringUtilities::ToLower(std::move(font_family));
+	StringList font_families{};
+	StringUtilities::ExpandString(
+		font_families,
+		StringUtilities::ToLower(std::move(font_family)));
+	return font_families;
 }
 
 Style::Clip ComputeClip(const Property* property)

--- a/Source/Core/ComputeProperty.h
+++ b/Source/Core/ComputeProperty.h
@@ -44,7 +44,7 @@ float ComputeAngle(NumericValue value);
 float ComputeFontsize(NumericValue value, const Style::ComputedValues& values, const Style::ComputedValues* parent_values,
 	const Style::ComputedValues* document_values, float dp_ratio, Vector2f vp_dimensions);
 
-String ComputeFontFamily(String font_family);
+StringList ComputeFontFamily(String font_family);
 
 Style::Clip ComputeClip(const Property* property);
 

--- a/Source/Core/ComputedValues.cpp
+++ b/Source/Core/ComputedValues.cpp
@@ -52,12 +52,12 @@ const TransitionList* Style::ComputedValues::transition() const
 	return nullptr;
 }
 
-String Style::ComputedValues::font_family() const
+StringList Style::ComputedValues::font_family() const
 {
 	if (auto p = element->GetProperty(PropertyId::FontFamily))
 		return ComputeFontFamily(p->Get<String>());
 
-	return String();
+	return StringList();
 }
 
 String Style::ComputedValues::cursor() const

--- a/Source/Core/FontEngineInterface.cpp
+++ b/Source/Core/FontEngineInterface.cpp
@@ -56,6 +56,14 @@ FontFaceHandle FontEngineInterface::GetFontFaceHandle(const String& /*family*/, 
 	return 0;
 }
 
+FontFaceHandle FontEngineInterface::GetFontFaceHandle(const StringList& families, Style::FontStyle style, Style::FontWeight weight, int size)
+{
+	for (const auto& family : families)
+		if (FontFaceHandle handle = GetFontFaceHandle(family, style, weight, size))
+			return handle;
+	return reinterpret_cast<FontFaceHandle>(nullptr);
+}
+
 FontEffectsHandle FontEngineInterface::PrepareFontEffects(FontFaceHandle /*handle*/, const FontEffectList& /*font_effects*/)
 {
 	return 0;

--- a/Tests/Data/style.rcss
+++ b/Tests/Data/style.rcss
@@ -13,7 +13,7 @@ hr {
 }
 
 body {
-	font-family: LatoLatin;
+	font-family: TestFamily, LatoLatin;
 	font-weight: normal;
 	font-style: normal;
 	font-size: 14dp;


### PR DESCRIPTION
Refactored font-family property to use a list of font families instead of a single string. Updated related interfaces and logic to iterate through font families and select the first available font. Adjusted tests to use multiple font families in style definitions.