### PR TITLE
Don't assert in `~ControlledLifetimeResource` for dll

### DIFF
--- a/Source/Core/ControlledLifetimeResource.h
+++ b/Source/Core/ControlledLifetimeResource.h
@@ -37,7 +37,12 @@ template <typename T>
 class ControlledLifetimeResource : NonCopyMoveable {
 public:
 	ControlledLifetimeResource() = default;
-	~ControlledLifetimeResource() noexcept { RMLUI_ASSERTMSG(!pointer || intentionally_leaked, "Resource was not properly shut down."); }
+	~ControlledLifetimeResource() noexcept
+	{
+#if defined(RMLUI_PLATFORM_WIN32) && !defined(RMLUI_STATIC_LIB)
+		RMLUI_ASSERTMSG(!pointer || intentionally_leaked, "Resource was not properly shut down.");
+#endif
+	}
 
 	explicit operator bool() const noexcept { return pointer != nullptr; }
 


### PR DESCRIPTION
Remove assert from `~ControlledLifetimeResource` when built as a shared library on Windows (DLL) to improve developer experience.
See https://github.com/mikke89/RmlUi/issues/864 for discussion