### PR TITLE
Handle nullptr clipboard data in GLFW clipboard getter

### DIFF
--- a/Backends/RmlUi_Platform_GLFW.cpp
+++ b/Backends/RmlUi_Platform_GLFW.cpp
@@ -107,7 +107,18 @@ void SystemInterface_GLFW::SetClipboardText(const Rml::String& text_utf8)
 void SystemInterface_GLFW::GetClipboardText(Rml::String& text)
 {
 	if (window)
-		text = Rml::String(glfwGetClipboardString(window));
+	{
+		const char* clipboard = glfwGetClipboardString(window);
+
+		if (clipboard != nullptr)
+		{
+			text = Rml::String(clipboard);
+		}
+		else
+		{
+			text.clear();
+		}
+	}
 }
 
 bool RmlGLFW::ProcessKeyCallback(Rml::Context* context, int key, int action, int mods)


### PR DESCRIPTION
glfwGetClipboardString can return nullptr if clipboard doesn't contain text (e.g., when image is copied). Passing nullptr to std::string constructor would cause crash on strlen.