### PR TITLE
Fix compile issues in the SVG plugin when using a non-std `string` type

### DIFF
--- a/Source/SVG/ElementSVG.cpp
+++ b/Source/SVG/ElementSVG.cpp
@@ -120,8 +120,10 @@ void ElementSVG::SetInnerRML(const String& content)
 	if (!source.empty())
 		return;
 
+	// We use CreateString instead of std::to_string to avoid having to create an extra std::string and convert it to Rml::String in case clients use
+	// a non-std string.
 	if (!HasAttribute("rmlui-svgdata-id"))
-		SetAttribute("rmlui-svgdata-id", "svgdata:" + std::to_string(internal_id_counter++));
+		SetAttribute("rmlui-svgdata-id", "svgdata:" + CreateString("%lu", internal_id_counter++));
 
 	svg_data = "" + content;
 	svg_dirty = true;

--- a/Source/SVG/SVGCache.cpp
+++ b/Source/SVG/SVGCache.cpp
@@ -189,14 +189,16 @@ namespace SVG {
 					return {};
 				}
 
-				// We use a reset-release approach here in case clients use a non-std unique_ptr (lunasvg uses std::unique_ptr)
-				doc.svg_document.reset(lunasvg::Document::loadFromData(svg_data).release());
+				// We use a reset-release approach here in case clients use a non-std unique_ptr (lunasvg uses std::unique_ptr). We also use
+				// loadFromData(char*, size_t) instead of loadFromData(std::string) in case clients use a non-std string.
+				doc.svg_document.reset(lunasvg::Document::loadFromData(svg_data.data(), svg_data.size()).release());
 			}
 			else
 			{
 				RMLUI_SVG_DEBUG_LOG("Loading SVG document from element %s contents", source_id.c_str());
-				// We use a reset-release approach here in case clients use a non-std unique_ptr (lunasvg uses std::unique_ptr)
-				doc.svg_document.reset(lunasvg::Document::loadFromData(source).release());
+				// We use a reset-release approach here in case clients use a non-std unique_ptr (lunasvg uses std::unique_ptr). We also use
+				// loadFromData(char*, size_t) instead of loadFromData(std::string) in case clients use a non-std string.
+				doc.svg_document.reset(lunasvg::Document::loadFromData(source.data(), source.size()).release());
 			}
 
 			if (!doc.svg_document)


### PR DESCRIPTION
This PR fixes a few compile issues related to the use of `std::string` where a `Rml::String` is expected (or the opposite).

In SVGCache.cpp, I applied the same changes as in #820, since they got overwritten by #777. I also added an explanatory comment.

Also note that the samples and benchmarks don't compile when `Rml::String` is not `std::string`. I can add the fix for the samples in this PR if needed, I put the patch below.
For the benchmarks I don't know if it's necessary to fix them, as I wouldn't expect people to run them with a non-std string type. Afaict it's just that the `bench.run(name, ...)` function expects a `std::string` but is passed an `Rml::String`.

<details>

<summary>Patch for the samples</summary>

```diff
diff --git a/Samples/basic/svg/src/main.cpp b/Samples/basic/svg/src/main.cpp
index c0f5a797..7ad37699 100644
--- a/Samples/basic/svg/src/main.cpp
+++ b/Samples/basic/svg/src/main.cpp
@@ -115,7 +115,7 @@ int main(int /*argc*/, char** /*argv*/)
        Shell::LoadFonts();
 
        // Load and show the documents.
-       std::vector<std::string> rml_docs = {"basic/svg/data/svg_element.rml", "basic/svg/data/svg_decorator.rml", "basic/svg/data/svg_inline.rml"};
+       std::vector<Rml::String> rml_docs = {"basic/svg/data/svg_element.rml", "basic/svg/data/svg_decorator.rml", "basic/svg/data/svg_inline.rml"};
        for (const auto& rml_doc : rml_docs)
        {
                if (Rml::ElementDocument* document = context->LoadDocument(rml_doc))
diff --git a/Samples/basic/transform/src/main.cpp b/Samples/basic/transform/src/main.cpp
index e7eb7d7c..97445805 100644
--- a/Samples/basic/transform/src/main.cpp
+++ b/Samples/basic/transform/src/main.cpp
@@ -61,9 +61,7 @@ public:
 
                if (document && perspective > 0)
                {
-                       std::stringstream s;
-                       s << "perspective(" << perspective << "dp) ";
-                       document->SetProperty("transform", s.str());
+                       document->SetProperty("transform", Rml::CreateString("perspective(%fdp) ", perspective));
                }
        }
 
@@ -71,11 +69,11 @@ public:
        {
                if (document)
                {
-                       std::stringstream s;
+                       Rml::String s;
                        if (perspective > 0)
-                               s << "perspective(" << perspective << "dp) ";
-                       s << "rotate3d(0.0, 1.0, 0.0, " << degrees << "deg)";
-                       document->SetProperty("transform", s.str());
+                               s += Rml::CreateString("perspective(%fdp) ", perspective);
+                       s += Rml::CreateString("rotate3d(0.0, 1.0, 0.0, %fdeg)", degrees);
+                       document->SetProperty("transform", s);
                }
        }
```

</details>