### PR TITLE
Fix synchronization bug in Vulkan backend (#861)

### DIFF
--- a/Backends/RmlUi_Renderer_VK.cpp
+++ b/Backends/RmlUi_Renderer_VK.cpp
@@ -2646,7 +2646,7 @@ void RenderInterface_VK::Update_PendingForDeletion_Geometries() noexcept
 
 void RenderInterface_VK::Submit() noexcept
 {
-	const VkSemaphore p_semaphores_wait[] = {m_semaphores_image_available[m_semaphore_index]};
+	const VkSemaphore p_semaphores_wait[] = {m_semaphores_image_available[m_semaphore_index_previous]};
 	const VkSemaphore p_semaphores_signal[] = {m_semaphores_finished_render[m_semaphore_index]};
 
 	VkFence p_fence = m_executed_fences[m_semaphore_index];


### PR DESCRIPTION
## Description

This PR fixes a semaphore synchronization issue in the Vulkan renderer that causes the application to freeze on startup.

### Problem

When running samples with the Vulkan backend (`GLFW_VK`), the window freezes immediately. The OpenGL backend (`GLFW_GL3`) works correctly.

### Root Cause

In `RenderInterface_VK::Submit()`, the code was waiting on the wrong semaphore index:

1. `Wait()` acquires the next swapchain image and signals `m_semaphores_image_available[m_semaphore_index]`
2. `Wait()` then increments `m_semaphore_index` to prepare for the next frame
3. `Submit()` was incorrectly waiting on `m_semaphores_image_available[m_semaphore_index]` (the **new** index)
4. This semaphore was never signaled, causing `vkQueueSubmit` to block indefinitely

### Fix

Changed `Submit()` to wait on `m_semaphores_image_available[m_semaphore_index_previous]`, which correctly references the semaphore that was signaled during `vkAcquireNextImageKHR`.

```cpp
// Before
const VkSemaphore p_semaphores_wait[] = {m_semaphores_image_available[m_semaphore_index]};

// After
const VkSemaphore p_semaphores_wait[] = {m_semaphores_image_available[m_semaphore_index_previous]};
```

### Testing

Verified that the Vulkan backend no longer freezes and renders correctly.

Fixes #861

cc: @wh1t3lord 
