### PR TITLE
Move function-local static containers to translation unit scope to avoid static initialization crashes

### DIFF
--- a/Source/Core/ElementText.cpp
+++ b/Source/Core/ElementText.cpp
@@ -445,6 +445,7 @@ void ElementText::GetRML(String& content)
 	content += StringUtilities::EncodeRml(text);
 }
 
+static const FontEffectList empty_font_effects;
 bool ElementText::UpdateFontEffects()
 {
 	RMLUI_ZoneScoped;
@@ -453,8 +454,6 @@ bool ElementText::UpdateFontEffects()
 		return false;
 
 	font_effects_dirty = false;
-
-	static const FontEffectList empty_font_effects;
 
 	// Fetch the font-effect for this text element
 	const FontEffectList* font_effects = &empty_font_effects;

--- a/Source/Core/Layout/BlockFormattingContext.cpp
+++ b/Source/Core/Layout/BlockFormattingContext.cpp
@@ -24,6 +24,7 @@ static void LogUnexpectedFlowElement(Element* element, Style::Display display)
 
 #ifdef RMLUI_DEBUG
 static bool g_debug_dumping_layout_tree = false;
+static const String debug_trigger_id = "rmlui-debug-layout";
 struct DebugDumpLayoutTree {
 	Element* element;
 	BlockContainer* block_box;
@@ -32,7 +33,6 @@ struct DebugDumpLayoutTree {
 	DebugDumpLayoutTree(Element* element, BlockContainer* block_box) : element(element), block_box(block_box)
 	{
 		// When an element with this ID is encountered, dump the formatted layout tree (including for all descendant formatting contexts).
-		static const String debug_trigger_id = "rmlui-debug-layout";
 		is_printing_tree_root = element->HasAttribute(debug_trigger_id);
 		if (is_printing_tree_root)
 			g_debug_dumping_layout_tree = true;

--- a/Source/Core/StyleSheet.cpp
+++ b/Source/Core/StyleSheet.cpp
@@ -85,11 +85,12 @@ const Keyframes* StyleSheet::GetKeyframes(const String& name) const
 	return nullptr;
 }
 
+// Since we may return a reference to the below static variable.
+static DecoratorPtrList non_cached_decorator_list;
 const DecoratorPtrList& StyleSheet::InstanceDecorators(RenderManager& render_manager, const DecoratorDeclarationList& declaration_list,
 	const PropertySource* source) const
 {
-	RMLUI_ASSERT_NONRECURSIVE; // Since we may return a reference to the below static variable.
-	static DecoratorPtrList non_cached_decorator_list;
+	RMLUI_ASSERT_NONRECURSIVE;
 
 	// Empty declaration values are used for interpolated values which we don't want to cache.
 	const bool enable_cache = !declaration_list.value.empty();
@@ -162,12 +163,12 @@ const Sprite* StyleSheet::GetSprite(const String& name) const
 	return spritesheet_list.GetSprite(name);
 }
 
+// Using static to avoid allocations. Make sure we don't call this function recursively.
+static Vector<const StyleSheetNode*> applicable_nodes;
 SharedPtr<const ElementDefinition> StyleSheet::GetElementDefinition(const Element* element) const
 {
 	RMLUI_ASSERT_NONRECURSIVE;
 
-	// Using static to avoid allocations. Make sure we don't call this function recursively.
-	static Vector<const StyleSheetNode*> applicable_nodes;
 	applicable_nodes.clear();
 
 	auto AddApplicableNodes = [element](const StyleSheetIndex::NodeIndex& node_index, const String& key) {

--- a/Source/Core/StyleSheetParser.cpp
+++ b/Source/Core/StyleSheetParser.cpp
@@ -18,6 +18,10 @@
 
 namespace Rml {
 
+static const String identifiers = "#.:[ >+~";
+static const String combinators = " >+~";
+static const String attribute_operators = "=~|^$*]";
+
 class AbstractPropertyParser : NonCopyMoveable {
 protected:
 	~AbstractPropertyParser() = default;
@@ -917,7 +921,6 @@ StyleSheetNode* StyleSheetParser::ImportProperties(StyleSheetNode* node, const S
 				// Read until we hit the next identifier. Don't match inside parenthesis in case of structural selectors.
 				for (; end_index < rule.size(); end_index++)
 				{
-					static const String identifiers = "#.:[ >+~";
 					if (parenthesis_count == 0 && identifiers.find(rule[end_index]) != String::npos)
 						break;
 
@@ -956,7 +959,6 @@ StyleSheetNode* StyleSheetParser::ImportProperties(StyleSheetNode* node, const S
 
 					AttributeSelector attribute;
 
-					static const String attribute_operators = "=~|^$*]";
 					size_t i_cursor = Math::Min(static_cast<size_t>(rule.find_first_of(attribute_operators, i_attr_begin)), i_attr_end);
 					attribute.name = rule.substr(i_attr_begin, i_cursor - i_attr_begin);
 
@@ -989,7 +991,6 @@ StyleSheetNode* StyleSheetParser::ImportProperties(StyleSheetNode* node, const S
 			index = end_index;
 
 			// If we reached a combinator then we submit the current node and start fresh with a new node.
-			static const String combinators(" >+~");
 			if (combinators.find(rule[index]) != String::npos)
 				break;
 		}

--- a/Source/Core/SystemInterface.cpp
+++ b/Source/Core/SystemInterface.cpp
@@ -7,9 +7,9 @@
 
 namespace Rml {
 
+static String clipboard_text;
 static String& GlobalClipBoardText()
 {
-	static String clipboard_text;
 	return clipboard_text;
 }
 


### PR DESCRIPTION
Description
---

fix issue: https://github.com/mikke89/RmlUi/issues/882

Problem
---

When RmlUi is statically linked into a dynamic library, and that library is later loaded by a foreign runtime (e.g. Java via JNI), we observed consistent crashes during static initialization of function-local static variables of non-trivial types such as String, Vector, and other container-like objects.

The issue does not occur when:

- RmlUi is built and used as a standalone static executable, or
- RmlUi is built and used as a standalone shared library.

But it does occur in mixed scenarios where:

- RmlUi is statically linked into a shared library, and
- that shared library is loaded by another runtime (e.g. JVM).

Crashes typically manifest as STATUS_ACCESS_VIOLATION during initialization of function-local static objects.

Root cause
---

Function-local static variables of non-trivial types(like `String`, `Vector`), may occur crashes during initialization in mixed static + dynamic linking scenarios.

Changes in this PR
---

This PR removes or relocates function-local static variables of non-trivial types and moves them to translation-unit scope.

Testing
---

Verified that the rmlui will not crashes when embedded into applications with foreign runtimes (JNI, etc.)