### PR TITLE
Backend for SDL3: fix Context dimensions when SDL_SetRenderLogicalPresentation is enabled

### DIFF
--- a/Backends/RmlUi_Platform_SDL.cpp
+++ b/Backends/RmlUi_Platform_SDL.cpp
@@ -252,6 +252,9 @@ bool RmlSDL::InputEventHandler(Rml::Context* context, SDL_Window* window, SDL_Ev
 		Rml::Vector2i dimensions(ev.window.data1, ev.window.data2);
 		
 	#if SDL_MAJOR_VERSION >= 3
+		// SDL_Renderer backend (SDL3): if SDL_SetRenderLogicalPresentation() is enabled, the renderer uses a fixed logical
+		// output size (render coordinates) and scales it to the window; use that logical size for the RmlUi context.
+		// Input events should be converted to render coordinates first (e.g. SDL_ConvertEventToRenderCoordinates()).
 		SDL_Renderer* renderer = SDL_GetRenderer(window);
 		if (renderer)
 		{

--- a/Backends/RmlUi_Platform_SDL.h
+++ b/Backends/RmlUi_Platform_SDL.h
@@ -47,6 +47,11 @@ private:
 namespace RmlSDL {
 
 // Applies input on the context based on the given SDL event.
+// 
+// Note (SDL3 + SDL_Renderer): When using SDL_SetRenderLogicalPresentation(), SDL_Renderer operates in render
+// coordinates (logical coordinates). Therefore, before passing an SDL_Event to InputEventHandler, input event
+// coordinates (mouse/touch/etc.) should be converted to render coordinates, e.g.
+// SDL_ConvertEventToRenderCoordinates(renderer, &ev).
 // @return True if the event is still propagating, false if it was handled by the context.
 bool InputEventHandler(Rml::Context* context, SDL_Window* window, SDL_Event& ev);
 


### PR DESCRIPTION
# Backend for SDL3: fix Context dimensions when SDL_SetRenderLogicalPresentation is enabled


## Problem

When `SDL_SetRenderLogicalPresentation(...)` is enabled, SDL renderer uses a fixed logical render size and scales to the window. However, RmlSDL platform handler updates Rml::Context dimensions from `SDL_EVENT_WINDOW_PIXEL_SIZE_CHANGED` (ev.window.data1, ev.window.data2), i.e. window pixel size. This mismatches the renderer’s logical coordinate space, causing UI to shift / render incorrectly on window resize.

## Fix

On `SDL_EVENT_WINDOW_PIXEL_SIZE_CHANGED`, query `SDL_GetRenderLogicalPresentation(...)` and, when a logical resolution is enabled (w > 0 && h > 0), set context->SetDimensions(...) to that logical size. Otherwise fallback to the window pixel size from the event. (`SDL_GetRenderLogicalPresentation(...)` reports 0 when not enabled).

## Repro steps

1) Create SDL_Window + SDL_Renderer
2) Call `SDL_SetRenderLogicalPresentation(renderer, w, h, mode)`
3) Init RmlUi and load rml document
4) Resize window.

## Testing

It was tested on:
1) Windows 11 with MSVC MT
2) Android with sdk-34

SDL3 version: 3.4.0
RmlUi version: 6.2.0

## Visual proof

| Before fix                                                                                  | After fix                                                                               |
| ------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
| ![current](https://github.com/user-attachments/assets/afff6780-3bc4-4805-af6b-6d4eed2b2d14) | ![fix](https://github.com/user-attachments/assets/00fd536c-46db-45cd-8fa5-211cd88914cf) |

