### PR TITLE
FreeType interface now prints error messages rather than codes.

### DIFF
--- a/Samples/basic/harfbuzz/src/FreeTypeInterface.cpp
+++ b/Samples/basic/harfbuzz/src/FreeTypeInterface.cpp
@@ -24,6 +24,7 @@ static const char* GetFreeTypeErrorString(FT_Error error_code)
 {
 #undef FTERRORS_H_
 #include "freetype/fterrors.h"
+	return "";
 }
 #endif
 

--- a/Source/Core/FontEngineDefault/FreeTypeInterface.cpp
+++ b/Source/Core/FontEngineDefault/FreeTypeInterface.cpp
@@ -35,6 +35,7 @@ static const char* GetFreeTypeErrorString(FT_Error error_code)
 {
 #undef FTERRORS_H_
 #include "freetype/fterrors.h"
+	return "";
 }
 #endif
 


### PR DESCRIPTION
The FreeType interface currently prints an error code when an error internal to FreeType itself is encountered. The message made it unclear what this error code related to and, even once we figured out where it was coming from, had us hunt down the actual message from the code by googling it. This pull request adds a function (via some [officially recommended macro wizardry](https://freetype.org/freetype2/docs/reference/ft2-error_enumerations.html)) that maps codes to messages and prints one of those instead.