### PR TITLE
Switch SDL_GPU renderer to use REPEAT sampler address mode instead of CLAMP_TO_EDGE

### DIFF
--- a/Backends/RmlUi_Renderer_SDL_GPU.cpp
+++ b/Backends/RmlUi_Renderer_SDL_GPU.cpp
@@ -160,9 +160,9 @@ RenderInterface_SDL_GPU::RenderInterface_SDL_GPU(SDL_GPUDevice* device, SDL_Wind
 	info.min_filter = SDL_GPU_FILTER_LINEAR;
 	info.mag_filter = SDL_GPU_FILTER_LINEAR;
 	info.mipmap_mode = SDL_GPU_SAMPLERMIPMAPMODE_LINEAR;
-	info.address_mode_u = SDL_GPU_SAMPLERADDRESSMODE_CLAMP_TO_EDGE;
-	info.address_mode_v = SDL_GPU_SAMPLERADDRESSMODE_CLAMP_TO_EDGE;
-	info.address_mode_w = SDL_GPU_SAMPLERADDRESSMODE_CLAMP_TO_EDGE;
+	info.address_mode_u = SDL_GPU_SAMPLERADDRESSMODE_REPEAT;
+	info.address_mode_v = SDL_GPU_SAMPLERADDRESSMODE_REPEAT;
+	info.address_mode_w = SDL_GPU_SAMPLERADDRESSMODE_REPEAT;
 	linear_sampler = SDL_CreateGPUSampler(device, &info);
 	if (!linear_sampler)
 	{


### PR DESCRIPTION
Simple change to make the texture sampler in the SDL_GPU renderer use `SDL_GPU_SAMPLERADDRESSMODE_REPEAT` instead of `SDL_GPU_SAMPLERADDRESSMODE_CLAMP_TO_EDGE`

This behavior matches the GL3 renderer as far as I can tell, and fixes rendering of image decorators set to `repeat`, `repeat-x`, or `repeat-y`