### PR TITLE
Add interface to override font family on `LoadFontFace`

### DIFF
--- a/Source/Core/FontEngineDefault/FontProvider.cpp
+++ b/Source/Core/FontEngineDefault/FontProvider.cpp
@@ -84,6 +84,11 @@ void FontProvider::ReleaseFontResources()
 
 bool FontProvider::LoadFontFace(const String& file_name, int face_index, bool fallback_face, Style::FontWeight weight)
 {
+	return LoadFontFace(file_name, face_index, {}, fallback_face, weight);
+}
+
+bool FontProvider::LoadFontFace(const String& file_name, int face_index, const String& font_family, bool fallback_face, Style::FontWeight weight)
+{
 	FileInterface* file_interface = GetFileInterface();
 	FileHandle handle = file_interface->Open(file_name);
 
@@ -100,7 +105,7 @@ bool FontProvider::LoadFontFace(const String& file_name, int face_index, bool fa
 	file_interface->Read(buffer, length, handle);
 	file_interface->Close(handle);
 
-	bool result = Get().LoadFontFace({buffer, length}, face_index, fallback_face, std::move(buffer_ptr), file_name, {}, Style::FontStyle::Normal, weight);
+	bool result = Get().LoadFontFace({buffer, length}, face_index, fallback_face, std::move(buffer_ptr), file_name, font_family, Style::FontStyle::Normal, weight);
 
 	return result;
 }

--- a/Source/Core/FontEngineDefault/FontProvider.h
+++ b/Source/Core/FontEngineDefault/FontProvider.h
@@ -32,6 +32,9 @@ public:
 	/// Adds a new font face to the database. The face's family, style and weight will be determined from the face itself.
 	static bool LoadFontFace(const String& file_name, int face_index, bool fallback_face, Style::FontWeight weight = Style::FontWeight::Auto);
 
+	/// Adds a new font face to the database. The style and weight will be determined from the face itself. But you can override the font_family
+	static bool LoadFontFace(const String& file_name, int face_index, const String& font_family, bool fallback_face, Style::FontWeight weight = Style::FontWeight::Auto);
+
 	/// Adds a new font face from memory.
 	static bool LoadFontFace(Span<const byte> data, int face_index, const String& font_family, Style::FontStyle style, Style::FontWeight weight,
 		bool fallback_face);


### PR DESCRIPTION
This PR is to add a default method to control the font family name even when loading a font by path, is useful let the user override the font family