### PR TITLE
Support dynamic variables in `DataModel`

### DIFF
--- a/Include/RmlUi/Core/Context.h
+++ b/Include/RmlUi/Core/Context.h
@@ -255,10 +255,10 @@ public:
 	/// The returned constructor can be used to bind data variables. Elements can bind to the model using the attribute 'data-model="name"'.
 	/// @param[in] name The name of the data model.
 	/// @param[in] data_type_register The data type register to use for the data model, or null to use the default register.
-	/// @param[in] dynamic_variables If true, allows variables to be bound after document load. Views referencing
+	/// @param[in] allow_missing_variables If true, allows variables to be bound after document load. Views referencing
 	///            not-yet-bound variables will silently produce default values until the variable is bound and dirtied.
 	/// @return A constructor for the data model, or empty if it could not be created.
-	DataModelConstructor CreateDataModel(const String& name, DataTypeRegister* data_type_register = nullptr, bool dynamic_variables = false);
+	DataModelConstructor CreateDataModel(const String& name, DataTypeRegister* data_type_register = nullptr, bool allow_missing_variables = false);
 	/// Retrieves the constructor for an existing data model.
 	/// The returned constructor can be used to add additional bindings to an existing model.
 	/// @param[in] name The name of the data model.

--- a/Include/RmlUi/Core/Context.h
+++ b/Include/RmlUi/Core/Context.h
@@ -255,8 +255,10 @@ public:
 	/// The returned constructor can be used to bind data variables. Elements can bind to the model using the attribute 'data-model="name"'.
 	/// @param[in] name The name of the data model.
 	/// @param[in] data_type_register The data type register to use for the data model, or null to use the default register.
+	/// @param[in] dynamic_variables If true, allows variables to be bound after document load. Views referencing
+	///            not-yet-bound variables will silently produce default values until the variable is bound and dirtied.
 	/// @return A constructor for the data model, or empty if it could not be created.
-	DataModelConstructor CreateDataModel(const String& name, DataTypeRegister* data_type_register = nullptr);
+	DataModelConstructor CreateDataModel(const String& name, DataTypeRegister* data_type_register = nullptr, bool dynamic_variables = false);
 	/// Retrieves the constructor for an existing data model.
 	/// The returned constructor can be used to add additional bindings to an existing model.
 	/// @param[in] name The name of the data model.

--- a/Source/Core/Context.cpp
+++ b/Source/Core/Context.cpp
@@ -1050,7 +1050,7 @@ void Context::SetInstancer(ContextInstancer* _instancer)
 	instancer = _instancer;
 }
 
-DataModelConstructor Context::CreateDataModel(const String& name, DataTypeRegister* data_type_register)
+DataModelConstructor Context::CreateDataModel(const String& name, DataTypeRegister* data_type_register, bool dynamic_variables)
 {
 	if (!data_type_register)
 	{
@@ -1059,7 +1059,7 @@ DataModelConstructor Context::CreateDataModel(const String& name, DataTypeRegist
 		data_type_register = default_data_type_register.get();
 	}
 
-	auto result = data_models.emplace(name, MakeUnique<DataModel>(data_type_register));
+	auto result = data_models.emplace(name, MakeUnique<DataModel>(data_type_register, dynamic_variables));
 	bool inserted = result.second;
 	if (inserted)
 		return DataModelConstructor(result.first->second.get());

--- a/Source/Core/Context.cpp
+++ b/Source/Core/Context.cpp
@@ -1050,7 +1050,7 @@ void Context::SetInstancer(ContextInstancer* _instancer)
 	instancer = _instancer;
 }
 
-DataModelConstructor Context::CreateDataModel(const String& name, DataTypeRegister* data_type_register, bool dynamic_variables)
+DataModelConstructor Context::CreateDataModel(const String& name, DataTypeRegister* data_type_register, bool allow_missing_variables)
 {
 	if (!data_type_register)
 	{
@@ -1059,7 +1059,7 @@ DataModelConstructor Context::CreateDataModel(const String& name, DataTypeRegist
 		data_type_register = default_data_type_register.get();
 	}
 
-	auto result = data_models.emplace(name, MakeUnique<DataModel>(data_type_register, dynamic_variables));
+	auto result = data_models.emplace(name, MakeUnique<DataModel>(data_type_register, allow_missing_variables));
 	bool inserted = result.second;
 	if (inserted)
 		return DataModelConstructor(result.first->second.get());

--- a/Source/Core/DataControllerDefault.cpp
+++ b/Source/Core/DataControllerDefault.cpp
@@ -23,7 +23,7 @@ bool DataControllerValue::Initialize(DataModel& model, Element* element, const S
 	if (variable_address.empty())
 		return false;
 
-	if (model.GetVariable(variable_address))
+	if (model.IsDynamicVariables() || model.GetVariable(variable_address))
 		address = std::move(variable_address);
 
 	element->AddEventListener(EventId::Change, this);

--- a/Source/Core/DataControllerDefault.cpp
+++ b/Source/Core/DataControllerDefault.cpp
@@ -23,7 +23,7 @@ bool DataControllerValue::Initialize(DataModel& model, Element* element, const S
 	if (variable_address.empty())
 		return false;
 
-	if (model.IsDynamicVariables() || model.GetVariable(variable_address))
+	if (model.AllowMissingVariables() || model.GetVariable(variable_address))
 		address = std::move(variable_address);
 
 	element->AddEventListener(EventId::Change, this);

--- a/Source/Core/DataModel.cpp
+++ b/Source/Core/DataModel.cpp
@@ -92,8 +92,8 @@ static String DataAddressToString(const DataAddress& address)
 	return result;
 }
 
-DataModel::DataModel(DataTypeRegister* data_type_register, bool dynamic_variables) :
-	data_type_register(data_type_register), dynamic_variables(dynamic_variables)
+DataModel::DataModel(DataTypeRegister* data_type_register, bool allow_missing_variables) :
+	data_type_register(data_type_register), allow_missing_variables(allow_missing_variables)
 {
 	views = MakeUnique<DataViews>();
 	controllers = MakeUnique<DataControllers>();
@@ -264,7 +264,7 @@ DataAddress DataModel::ResolveAddress(const String& address_str, Element* elemen
 		ancestor = ancestor->GetParentNode();
 	}
 
-	if (dynamic_variables)
+	if (allow_missing_variables)
 		return address;
 
 	Log::Message(Log::LT_WARNING, "Could not find variable name '%s' in data model.", address_str.c_str());
@@ -317,7 +317,7 @@ bool DataModel::GetVariableInto(const DataAddress& address, Variant& out_value) 
 {
 	DataVariable variable = GetVariable(address);
 	bool result = (variable && variable.Get(out_value));
-	if (!result && !dynamic_variables)
+	if (!result && !allow_missing_variables)
 		Log::Message(Log::LT_WARNING, "Could not get value from data variable '%s'.", DataAddressToString(address).c_str());
 	return result;
 }
@@ -325,7 +325,8 @@ bool DataModel::GetVariableInto(const DataAddress& address, Variant& out_value) 
 void DataModel::DirtyVariable(const String& variable_name)
 {
 	RMLUI_ASSERTMSG(LegalVariableName(variable_name) == nullptr, "Illegal variable name provided. Only top-level variables can be dirtied.");
-	RMLUI_ASSERTMSG(dynamic_variables || variables.count(variable_name) == 1, "In DirtyVariable: Variable name not found among added variables.");
+	RMLUI_ASSERTMSG(allow_missing_variables || variables.count(variable_name) == 1,
+		"In DirtyVariable: Variable name not found among added variables.");
 	dirty_variables.emplace(variable_name);
 }
 

--- a/Source/Core/DataModel.cpp
+++ b/Source/Core/DataModel.cpp
@@ -92,7 +92,8 @@ static String DataAddressToString(const DataAddress& address)
 	return result;
 }
 
-DataModel::DataModel(DataTypeRegister* data_type_register) : data_type_register(data_type_register)
+DataModel::DataModel(DataTypeRegister* data_type_register, bool dynamic_variables) :
+	data_type_register(data_type_register), dynamic_variables(dynamic_variables)
 {
 	views = MakeUnique<DataViews>();
 	controllers = MakeUnique<DataControllers>();
@@ -263,6 +264,9 @@ DataAddress DataModel::ResolveAddress(const String& address_str, Element* elemen
 		ancestor = ancestor->GetParentNode();
 	}
 
+	if (dynamic_variables)
+		return address;
+
 	Log::Message(Log::LT_WARNING, "Could not find variable name '%s' in data model.", address_str.c_str());
 
 	return DataAddress();
@@ -313,7 +317,7 @@ bool DataModel::GetVariableInto(const DataAddress& address, Variant& out_value) 
 {
 	DataVariable variable = GetVariable(address);
 	bool result = (variable && variable.Get(out_value));
-	if (!result)
+	if (!result && !dynamic_variables)
 		Log::Message(Log::LT_WARNING, "Could not get value from data variable '%s'.", DataAddressToString(address).c_str());
 	return result;
 }
@@ -321,7 +325,7 @@ bool DataModel::GetVariableInto(const DataAddress& address, Variant& out_value) 
 void DataModel::DirtyVariable(const String& variable_name)
 {
 	RMLUI_ASSERTMSG(LegalVariableName(variable_name) == nullptr, "Illegal variable name provided. Only top-level variables can be dirtied.");
-	RMLUI_ASSERTMSG(variables.count(variable_name) == 1, "In DirtyVariable: Variable name not found among added variables.");
+	RMLUI_ASSERTMSG(dynamic_variables || variables.count(variable_name) == 1, "In DirtyVariable: Variable name not found among added variables.");
 	dirty_variables.emplace(variable_name);
 }
 

--- a/Source/Core/DataModel.h
+++ b/Source/Core/DataModel.h
@@ -16,7 +16,7 @@ class FuncDefinition;
 
 class DataModel : NonCopyMoveable {
 public:
-	DataModel(DataTypeRegister* data_type_register = nullptr);
+	DataModel(DataTypeRegister* data_type_register = nullptr, bool dynamic_variables = false);
 	~DataModel();
 
 	void AddView(DataViewPtr view);
@@ -52,6 +52,7 @@ public:
 	bool Update(bool clear_dirty_variables);
 
 	DataTypeRegister* GetDataTypeRegister() const { return data_type_register; }
+	bool IsDynamicVariables() const { return dynamic_variables; }
 	const UnorderedMap<String, DataVariable>& GetAllVariables() const { return variables; }
 
 private:
@@ -68,6 +69,7 @@ private:
 	ScopedAliases aliases;
 
 	DataTypeRegister* data_type_register;
+	bool dynamic_variables;
 
 	SmallUnorderedSet<Element*> attached_elements;
 };

--- a/Source/Core/DataModel.h
+++ b/Source/Core/DataModel.h
@@ -16,7 +16,7 @@ class FuncDefinition;
 
 class DataModel : NonCopyMoveable {
 public:
-	DataModel(DataTypeRegister* data_type_register = nullptr, bool dynamic_variables = false);
+	DataModel(DataTypeRegister* data_type_register = nullptr, bool allow_missing_variables = false);
 	~DataModel();
 
 	void AddView(DataViewPtr view);
@@ -52,7 +52,7 @@ public:
 	bool Update(bool clear_dirty_variables);
 
 	DataTypeRegister* GetDataTypeRegister() const { return data_type_register; }
-	bool IsDynamicVariables() const { return dynamic_variables; }
+	bool AllowMissingVariables() const { return allow_missing_variables; }
 	const UnorderedMap<String, DataVariable>& GetAllVariables() const { return variables; }
 
 private:
@@ -69,7 +69,7 @@ private:
 	ScopedAliases aliases;
 
 	DataTypeRegister* data_type_register;
-	bool dynamic_variables;
+	bool allow_missing_variables;
 
 	SmallUnorderedSet<Element*> attached_elements;
 };

--- a/Tests/Source/UnitTests/DataBinding.cpp
+++ b/Tests/Source/UnitTests/DataBinding.cpp
@@ -672,7 +672,7 @@ TEST_CASE("data_binding.allow_missing_variables")
 <p id="unbound">{{ missing }}</p>
 <p id="aliased" data-alias-alt="greeting">{{ alt }}</p>
 <p id="set_bound" data-event-click="greeting = 'clicked'">click</p>
-<!-- <p id="set_missing" data-event-click="missing = 1">click</p> -->
+<p id="set_missing" data-event-click="missing = 'clicked'">click</p>
 <input id="input" type="text" data-value="greeting"/>
 <input id="input_missing" type="text" data-value="missing"/>
 </body>
@@ -724,12 +724,6 @@ TEST_CASE("data_binding.allow_missing_variables")
 	TestsShell::RenderLoop();
 	CHECK(document->GetElementById("unbound")->GetInnerRML() == "");
 
-	// Writing via data-value input to a missing variable is silently ignored.
-	document->GetElementById("input_missing")->Focus();
-	context->ProcessTextInput("test");
-	TestsShell::RenderLoop();
-	CHECK(document->GetElementById("unbound")->GetInnerRML() == "");
-
 	// Writing via data-value input updates the bound variable.
 	document->GetElementById("input")->Focus();
 	context->ProcessTextInput("world ");
@@ -738,6 +732,65 @@ TEST_CASE("data_binding.allow_missing_variables")
 	CHECK(greeting == "world dirty");
 	CHECK(document->GetElementById("bound")->GetInnerRML() == "world dirty");
 	CHECK(document->GetElementById("aliased")->GetInnerRML() == "world dirty");
+
+	Rml::String late_bound;
+	SUBCASE("late_bind_before_input")
+	{
+		// Late-bind a previously missing variable, then dirty it.
+		late_bound = "resolved";
+		constructor.Bind("missing", &late_bound);
+		handle.DirtyVariable("missing");
+		TestsShell::RenderLoop();
+
+		CHECK(document->GetElementById("unbound")->GetInnerRML() == "resolved");
+
+		// data-event-click assignment now works on the late-bound variable.
+		document->GetElementById("set_missing")->DispatchEvent(EventId::Click, Dictionary());
+		TestsShell::RenderLoop();
+
+		CHECK(late_bound == "clicked");
+		CHECK(document->GetElementById("unbound")->GetInnerRML() == "clicked");
+
+		// Writing via data-value input now updates the late-bound variable.
+		document->GetElementById("input_missing")->Focus();
+		context->ProcessTextInput("test ");
+		TestsShell::RenderLoop();
+
+		CHECK(late_bound == "test clicked");
+		CHECK(document->GetElementById("unbound")->GetInnerRML() == "test clicked");
+	}
+	SUBCASE("late_bind_after_input")
+	{
+		// Writing via data-value input to a missing variable is silently ignored.
+		document->GetElementById("input_missing")->Focus();
+		context->ProcessTextInput("test");
+		TestsShell::RenderLoop();
+		CHECK(document->GetElementById("unbound")->GetInnerRML() == "");
+
+		// Late-bind a previously missing variable, then dirty it.
+		late_bound = "resolved";
+		constructor.Bind("missing", &late_bound);
+		handle.DirtyVariable("missing");
+		TestsShell::RenderLoop();
+
+		CHECK(document->GetElementById("unbound")->GetInnerRML() == "resolved");
+
+		// data-event-click assignment now works on the late-bound variable.
+		document->GetElementById("set_missing")->DispatchEvent(EventId::Click, Dictionary());
+		TestsShell::RenderLoop();
+
+		CHECK(late_bound == "clicked");
+		CHECK(document->GetElementById("unbound")->GetInnerRML() == "clicked");
+
+		// The earlier input left a stale cursor in the widget. Text is inserted
+		// at the wrong position.
+		document->GetElementById("input_missing")->Focus();
+		context->ProcessTextInput("test ");
+		TestsShell::RenderLoop();
+
+		CHECK(late_bound == "clictest ked");
+		CHECK(document->GetElementById("unbound")->GetInnerRML() == "clictest ked");
+	}
 
 	document->Close();
 	TestsShell::ShutdownShell();

--- a/Tests/Source/UnitTests/DataBinding.cpp
+++ b/Tests/Source/UnitTests/DataBinding.cpp
@@ -334,9 +334,9 @@ struct Arrays {
 
 DataModelHandle model_handle;
 
-bool InitializeDataBindings(Context* context)
+bool InitializeDataBindings(Context* context, bool allow_missing_variables = false)
 {
-	Rml::DataModelConstructor constructor = context->CreateDataModel("basics");
+	Rml::DataModelConstructor constructor = context->CreateDataModel("basics", nullptr, allow_missing_variables);
 	if (!constructor)
 		return false;
 
@@ -534,7 +534,14 @@ TEST_CASE("data_binding")
 	Context* context = TestsShell::GetContext();
 	REQUIRE(context);
 
-	REQUIRE(InitializeDataBindings(context));
+	bool allow_missing_variables = false;
+	SUBCASE("default") {}
+	SUBCASE("allow_missing_variables")
+	{
+		allow_missing_variables = true;
+	}
+
+	REQUIRE(InitializeDataBindings(context, allow_missing_variables));
 
 	ElementDocument* document = context->LoadDocumentFromMemory(data_binding_rml);
 	REQUIRE(document);
@@ -564,7 +571,14 @@ TEST_CASE("data_binding.inside_string")
 	Context* context = TestsShell::GetContext();
 	REQUIRE(context);
 
-	REQUIRE(InitializeDataBindings(context));
+	bool allow_missing_variables = false;
+	SUBCASE("default") {}
+	SUBCASE("allow_missing_variables")
+	{
+		allow_missing_variables = true;
+	}
+
+	REQUIRE(InitializeDataBindings(context, allow_missing_variables));
 
 	ElementDocument* document = context->LoadDocumentFromMemory(inside_string_rml);
 	REQUIRE(document);
@@ -584,7 +598,14 @@ TEST_CASE("data_binding.aliasing")
 	Context* context = TestsShell::GetContext();
 	REQUIRE(context);
 
-	REQUIRE(InitializeDataBindings(context));
+	bool allow_missing_variables = false;
+	SUBCASE("default") {}
+	SUBCASE("allow_missing_variables")
+	{
+		allow_missing_variables = true;
+	}
+
+	REQUIRE(InitializeDataBindings(context, allow_missing_variables));
 
 	ElementDocument* document = context->LoadDocumentFromMemory(aliasing_rml);
 	REQUIRE(document);
@@ -632,6 +653,93 @@ TEST_CASE("data_binding.dynamic_variables")
 	document->Close();
 	*globals.i1 = 1;
 
+	TestsShell::ShutdownShell();
+}
+
+TEST_CASE("data_binding.allow_missing_variables")
+{
+	Context* context = TestsShell::GetContext();
+	REQUIRE(context);
+
+	static const String document_rml = R"(
+<rml>
+<head>
+	<title>Test</title>
+	<link type="text/template" href="/assets/window.rml"/>
+</head>
+<body template="window" data-model="late">
+<p id="bound">{{ greeting }}</p>
+<p id="unbound">{{ missing }}</p>
+<p id="aliased" data-alias-alt="greeting">{{ alt }}</p>
+<p id="set_bound" data-event-click="greeting = 'clicked'">click</p>
+<!-- <p id="set_missing" data-event-click="missing = 1">click</p> -->
+<input id="input" type="text" data-value="greeting"/>
+<input id="input_missing" type="text" data-value="missing"/>
+</body>
+</rml>
+)";
+
+	Rml::DataModelConstructor constructor = context->CreateDataModel("late", nullptr, true);
+	REQUIRE(constructor);
+
+	Rml::String greeting = "hi";
+	constructor.Bind("greeting", &greeting);
+	DataModelHandle handle = constructor.GetModelHandle();
+
+	ElementDocument* document = context->LoadDocumentFromMemory(document_rml);
+	REQUIRE(document);
+	document->Show();
+
+	TestsShell::RenderLoop();
+
+	CHECK(document->GetElementById("bound")->GetInnerRML() == "hi");
+	CHECK(document->GetElementById("unbound")->GetInnerRML() == "");
+	CHECK(document->GetElementById("aliased")->GetInnerRML() == "hi");
+	CHECK(document->GetElementById("input")->GetAttribute<String>("value", "") == "hi");
+
+	// data-event-click assignment to a bound variable.
+	document->GetElementById("set_bound")->DispatchEvent(EventId::Click, Dictionary());
+	TestsShell::RenderLoop();
+
+	CHECK(greeting == "clicked");
+	CHECK(document->GetElementById("bound")->GetInnerRML() == "clicked");
+	CHECK(document->GetElementById("aliased")->GetInnerRML() == "clicked");
+
+	// TODO: Test data-event-click assignment to a missing variable.
+	//       Currently triggers RMLUI_ERROR in the expression evaluator.
+	// document->GetElementById("set_missing")->DispatchEvent(EventId::Click, Dictionary());
+	// TestsShell::RenderLoop();
+	// CHECK(document->GetElementById("unbound")->GetInnerRML() == "");
+
+	// DirtyVariable on a bound variable propagates the update.
+	greeting = "dirty";
+	handle.DirtyVariable("greeting");
+	TestsShell::RenderLoop();
+
+	CHECK(document->GetElementById("bound")->GetInnerRML() == "dirty");
+	CHECK(document->GetElementById("aliased")->GetInnerRML() == "dirty");
+
+	// DirtyVariable on a missing variable is silently ignored.
+	handle.DirtyVariable("missing");
+	TestsShell::RenderLoop();
+	CHECK(document->GetElementById("unbound")->GetInnerRML() == "");
+
+	// Writing via data-value input to a missing variable is silently ignored.
+	document->GetElementById("input_missing")->Focus();
+	context->ProcessTextInput("test");
+	TestsShell::RenderLoop();
+	CHECK(document->GetElementById("unbound")->GetInnerRML() == "");
+
+	// Writing via data-value input updates the bound variable.
+	document->GetElementById("input")->Focus();
+	context->ProcessTextInput("world ");
+	TestsShell::RenderLoop();
+
+	CHECK(greeting == "world dirty");
+	CHECK(document->GetElementById("bound")->GetInnerRML() == "world dirty");
+	CHECK(document->GetElementById("aliased")->GetInnerRML() == "world dirty");
+
+	document->Close();
 	TestsShell::ShutdownShell();
 }
 


### PR DESCRIPTION
# Support dynamic variables in DataModel

## Problem

RmlUi's DataModel assumes all variables are registered at bind time. Unregistered names trigger warnings and return empty addresses, making it impossible for external bindings (e.g. RmlSolLua) to add variables after model creation.

## Changes

Add a `dynamic_variables` flag to DataModel. When enabled:

- `ResolveAddress` returns the parsed address as-is instead of warning and returning empty when the name is not found in `variables` or `aliases`.
- `GetVariableInto` suppresses the warning on missing variables.
- `DirtyVariable` relaxes the assert so unknown names are accepted.
- `DataControllerValue::Initialize` accepts unresolved addresses so `data-value` bindings work for variables that don't exist yet.

Closes #913 