### PR TITLE
Minor fixes for SDL GPU

### DIFF
--- a/Backends/RmlUi_Renderer_SDL_GPU.cpp
+++ b/Backends/RmlUi_Renderer_SDL_GPU.cpp
@@ -152,7 +152,7 @@ void RenderInterface_SDL_GPU::CreatePipelines()
 }
 
 RenderInterface_SDL_GPU::RenderInterface_SDL_GPU(SDL_GPUDevice* device, SDL_Window* window) :
-	device(device), window(window), copy_pass(nullptr), render_pass(nullptr)
+	device(device), window(window), render_pass(nullptr), copy_pass(nullptr)
 {
 	CreatePipelines();
 

--- a/Backends/RmlUi_Renderer_SDL_GPU.h
+++ b/Backends/RmlUi_Renderer_SDL_GPU.h
@@ -37,6 +37,7 @@ private:
 	Rml::Matrix4f proj;
 
 	struct Command {
+		virtual ~Command() = default;
 		virtual void Update(RenderInterface_SDL_GPU& interface) = 0;
 	};
 


### PR DESCRIPTION
Hi,

While trying out the lib I identified two minor issues with the SDL GPU backends, and thought you would be ok to integrate these fixes.

1) RenderInterface_SDL_GPU field init order, which leads to a compile warning

```
RmlUi/Backends/RmlUi_Renderer_SDL_GPU.h: In constructor ‘RenderInterface_SDL_GPU::RenderInterface_SDL_GPU(SDL_GPUDevice*, SDL_Window*)’:
RmlUi/Backends/RmlUi_Renderer_SDL_GPU.h:34:26: error: ‘RenderInterface_SDL_GPU::copy_pass’ will be initialized after [-Werror=reorder]
   34 |         SDL_GPUCopyPass* copy_pass;
      |                          ^~~~~~~~~
RmlUi/Backends/RmlUi_Renderer_SDL_GPU.h:33:28: error:   ‘SDL_GPURenderPass* RenderInterface_SDL_GPU::render_pass’ [-Werror=reorder]
   33 |         SDL_GPURenderPass* render_pass;
      |                            ^~~~~~~~~~~
RmlUi/Backends/RmlUi_Renderer_SDL_GPU.cpp:154:1: error:   when initialized here [-Werror=reorder]
  154 | RenderInterface_SDL_GPU::RenderInterface_SDL_GPU(SDL_GPUDevice* device, SDL_Window* window) :
      | ^~~~~~~~~~~~~~~~~~~~~~~
```

2) The Command struct does not have a virtual dtor, which prevents correct destruction of child classes, and leaks

```
==135899== Mismatched new/delete size value: 8
==135899==    at 0x48450A1: operator delete(void*, unsigned long) (vg_replace_malloc.c:1184)
==135899==    by 0x40995B: std::default_delete<RenderInterface_SDL_GPU::Command>::operator()(RenderInterface_SDL_GPU::Command*) const (unique_ptr.h:92)
==135899==    by 0x4089DE: std::unique_ptr<RenderInterface_SDL_GPU::Command, std::default_delete<RenderInterface_SDL_GPU::Command> >::~unique_ptr() (unique_ptr.h:398)
==135899==    by 0x40C3FE: void std::destroy_at<std::unique_ptr<RenderInterface_SDL_GPU::Command, std::default_delete<RenderInterface_SDL_GPU::Command> > >(std::unique_ptr<RenderInterface_SDL_GPU::Command, std::default_delete<RenderInterface_SDL_GPU::Command> >*) (stl_construct.h:88)
==135899==    by 0x40B8A3: void std::_Destroy<std::unique_ptr<RenderInterface_SDL_GPU::Command, std::default_delete<RenderInterface_SDL_GPU::Command> > >(std::unique_ptr<RenderInterface_SDL_GPU::Command, std::default_delete<RenderInterface_SDL_GPU::Command> >*) (stl_construct.h:164)
==135899==    by 0x40A571: void std::_Destroy<std::unique_ptr<RenderInterface_SDL_GPU::Command, std::default_delete<RenderInterface_SDL_GPU::Command> >*>(std::unique_ptr<RenderInterface_SDL_GPU::Command, std::default_delete<RenderInterface_SDL_GPU::Command> >*, std::unique_ptr<RenderInterface_SDL_GPU::Command, std::default_delete<RenderInterface_SDL_GPU::Command> >*) (stl_construct.h:226)
==135899==    by 0x409807: _Destroy<std::unique_ptr<RenderInterface_SDL_GPU::Command, std::default_delete<RenderInterface_SDL_GPU::Command> >*, std::unique_ptr<RenderInterface_SDL_GPU::Command, std::default_delete<RenderInterface_SDL_GPU::Command> > > (alloc_traits.h:1045)
==135899==    by 0x409807: std::vector<std::unique_ptr<RenderInterface_SDL_GPU::Command, std::default_delete<RenderInterface_SDL_GPU::Command> >, std::allocator<std::unique_ptr<RenderInterface_SDL_GPU::Command, std::default_delete<RenderInterface_SDL_GPU::Command> > > >::_M_erase_at_end(std::unique_ptr<RenderInterface_SDL_GPU::Command, std::default_delete<RenderInterface_SDL_GPU::Command> >*) (stl_vector.h:2238)
==135899==    by 0x408747: std::vector<std::unique_ptr<RenderInterface_SDL_GPU::Command, std::default_delete<RenderInterface_SDL_GPU::Command> >, std::allocator<std::unique_ptr<RenderInterface_SDL_GPU::Command, std::default_delete<RenderInterface_SDL_GPU::Command> > > >::clear() (stl_vector.h:1864)
==135899==    by 0x40628F: RenderInterface_SDL_GPU::EndFrame() (RmlUi_Renderer_SDL_GPU.cpp:207)
==135899==    by 0x40203C: SDL_AppIterate (main.cpp:153)
==135899==    by 0x622244: SDL_IterateMainCallbacks (SDL_main_callbacks.c:130)
==135899==    by 0x5F7278: GenericIterateMainCallbacks (SDL_sysmain_callbacks.c:51)
==135899==  Address 0xba95bd0 is 0 bytes inside a block of size 80 alloc'd
==135899==    at 0x48412AC: operator new(unsigned long) (vg_replace_malloc.c:488)
==135899==    by 0x40A14C: std::__detail::_MakeUniq<RenderInterface_SDL_GPU::SetTransformCommand>::__single_object std::make_unique<RenderInterface_SDL_GPU::SetTransformCommand, Rml::Matrix4<float, Rml::ColumnMajorStorage<float> > const*&>(Rml::Matrix4<float, Rml::ColumnMajorStorage<float> > const*&) (unique_ptr.h:1084)
==135899==    by 0x40928B: std::unique_ptr<RenderInterface_SDL_GPU::SetTransformCommand, std::default_delete<RenderInterface_SDL_GPU::SetTransformCommand> > Rml::MakeUnique<RenderInterface_SDL_GPU::SetTransformCommand, Rml::Matrix4<float, Rml::ColumnMajorStorage<float> > const*&>(Rml::Matrix4<float, Rml::ColumnMajorStorage<float> > const*&) (Config.h:130)
==135899==    by 0x4076C0: RenderInterface_SDL_GPU::SetTransform(Rml::Matrix4<float, Rml::ColumnMajorStorage<float> > const*) (RmlUi_Renderer_SDL_GPU.cpp:586)
==135899==    by 0x4061C3: RenderInterface_SDL_GPU::BeginFrame(SDL_GPUCommandBuffer*, SDL_GPUTexture*, unsigned int, unsigned int) (RmlUi_Renderer_SDL_GPU.cpp:197)
==135899==    by 0x40201E: SDL_AppIterate (main.cpp:151)
==135899==    by 0x622244: SDL_IterateMainCallbacks (SDL_main_callbacks.c:130)
==135899==    by 0x5F7278: GenericIterateMainCallbacks (SDL_sysmain_callbacks.c:51)
==135899==    by 0x5F7366: SDL_EnterAppMainCallbacks_REAL (SDL_sysmain_callbacks.c:62)
==135899==    by 0x41CDEF: SDL_EnterAppMainCallbacks (SDL_dynapi_procs.h:207)
==135899==    by 0x40185C: SDL_main (SDL_main_impl.h:59)
==135899==    by 0x622338: SDL_CallMainFunction (SDL_main_callbacks.c:164)
```

Thanks for your time,
JB.