### PR TITLE
Add IME support for SDL backends

### DIFF
--- a/Backends/RmlUi_Backend_SDL_DX12.cpp
+++ b/Backends/RmlUi_Backend_SDL_DX12.cpp
@@ -99,6 +99,7 @@ struct BackendData {
 
 	SystemInterface_SDL system_interface;
 	Rml::UniquePtr<RenderInterface_DX12_SDL> render_interface;
+	TextInputMethodEditor_SDL text_input_method_editor;
 
 	SDL_Window* window;
 
@@ -111,9 +112,11 @@ bool Backend::Initialize(const char* window_name, int width, int height, bool al
 	RMLUI_ASSERT(!data);
 
 #if SDL_MAJOR_VERSION >= 3
+	SDL_SetHint(SDL_HINT_IME_IMPLEMENTED_UI, "composition");
 	if (!SDL_Init(SDL_INIT_VIDEO | SDL_INIT_EVENTS))
 		return false;
 #else
+	SDL_SetHint(SDL_HINT_IME_SHOW_UI, "1");
 	if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_EVENTS | SDL_INIT_TIMER) != 0)
 		return false;
 #endif
@@ -202,6 +205,8 @@ bool Backend::Initialize(const char* window_name, int width, int height, bool al
 
 	data->render_interface->SetViewport(width, height);
 
+	Rml::SetTextInputHandler(&data->text_input_method_editor);
+
 	return true;
 }
 
@@ -273,6 +278,7 @@ bool Backend::ProcessEvents(Rml::Context* context, KeyDownCallback key_down_call
 	auto GetDisplayScale = []() { return SDL_GetWindowDisplayScale(data->window); };
 	constexpr auto event_quit = SDL_EVENT_QUIT;
 	constexpr auto event_key_down = SDL_EVENT_KEY_DOWN;
+	constexpr auto event_text_editing = SDL_EVENT_TEXT_EDITING;
 	constexpr auto event_window_size_changed = SDL_EVENT_WINDOW_PIXEL_SIZE_CHANGED;
 	bool has_event = false;
 #else
@@ -289,6 +295,7 @@ bool Backend::ProcessEvents(Rml::Context* context, KeyDownCallback key_down_call
 	auto GetDisplayScale = []() { return 1.f; };
 	constexpr auto event_quit = SDL_QUIT;
 	constexpr auto event_key_down = SDL_KEYDOWN;
+	constexpr auto event_text_editing = SDL_TEXTEDITING;
 	constexpr auto event_window_size_changed = SDL_WINDOWEVENT_SIZE_CHANGED;
 	int has_event = 0;
 #endif
@@ -329,6 +336,12 @@ bool Backend::ProcessEvents(Rml::Context* context, KeyDownCallback key_down_call
 			// The key was not consumed by the context either, try keyboard shortcuts of lower priority.
 			if (key_down_callback && !key_down_callback(context, key, key_modifier, native_dp_ratio, false))
 				break;
+		}
+		break;
+		case event_text_editing:
+		{
+			propagate_event = false;
+			data->text_input_method_editor.HandleEdit(ev.edit);
 		}
 		break;
 

--- a/Backends/RmlUi_Backend_SDL_GL2.cpp
+++ b/Backends/RmlUi_Backend_SDL_GL2.cpp
@@ -99,6 +99,7 @@ struct BackendData {
 
 	SystemInterface_SDL system_interface;
 	RenderInterface_GL2_SDL render_interface;
+	TextInputMethodEditor_SDL text_input_method_editor;
 
 	SDL_Window* window = nullptr;
 	SDL_GLContext glcontext = nullptr;
@@ -112,9 +113,11 @@ bool Backend::Initialize(const char* window_name, int width, int height, bool al
 	RMLUI_ASSERT(!data);
 
 #if SDL_MAJOR_VERSION >= 3
+	SDL_SetHint(SDL_HINT_IME_IMPLEMENTED_UI, "composition");
 	if (!SDL_Init(SDL_INIT_VIDEO | SDL_INIT_EVENTS))
 		return false;
 #else
+	SDL_SetHint(SDL_HINT_IME_SHOW_UI, "1");
 	if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_EVENTS | SDL_INIT_TIMER) != 0)
 		return false;
 #endif
@@ -191,6 +194,8 @@ bool Backend::Initialize(const char* window_name, int width, int height, bool al
 
 	data->render_interface.SetViewport(width, height);
 
+	Rml::SetTextInputHandler(&data->text_input_method_editor);
+
 	return true;
 }
 
@@ -234,6 +239,7 @@ bool Backend::ProcessEvents(Rml::Context* context, KeyDownCallback key_down_call
 	auto GetDisplayScale = []() { return SDL_GetWindowDisplayScale(data->window); };
 	constexpr auto event_quit = SDL_EVENT_QUIT;
 	constexpr auto event_key_down = SDL_EVENT_KEY_DOWN;
+	constexpr auto event_text_editing = SDL_EVENT_TEXT_EDITING;
 	constexpr auto event_window_size_changed = SDL_EVENT_WINDOW_PIXEL_SIZE_CHANGED;
 	bool has_event = false;
 #else
@@ -250,6 +256,7 @@ bool Backend::ProcessEvents(Rml::Context* context, KeyDownCallback key_down_call
 	auto GetDisplayScale = []() { return 1.f; };
 	constexpr auto event_quit = SDL_QUIT;
 	constexpr auto event_key_down = SDL_KEYDOWN;
+	constexpr auto event_text_editing = SDL_TEXTEDITING;
 	constexpr auto event_window_size_changed = SDL_WINDOWEVENT_SIZE_CHANGED;
 	int has_event = 0;
 #endif
@@ -290,6 +297,12 @@ bool Backend::ProcessEvents(Rml::Context* context, KeyDownCallback key_down_call
 			// The key was not consumed by the context either, try keyboard shortcuts of lower priority.
 			if (key_down_callback && !key_down_callback(context, key, key_modifier, native_dp_ratio, false))
 				break;
+		}
+		break;
+		case event_text_editing:
+		{
+			propagate_event = false;
+			data->text_input_method_editor.HandleEdit(ev.edit);
 		}
 		break;
 

--- a/Backends/RmlUi_Backend_SDL_GL3.cpp
+++ b/Backends/RmlUi_Backend_SDL_GL3.cpp
@@ -104,6 +104,7 @@ struct BackendData {
 
 	SystemInterface_SDL system_interface;
 	RenderInterface_GL3_SDL render_interface;
+	TextInputMethodEditor_SDL text_input_method_editor;
 
 	SDL_Window* window = nullptr;
 	SDL_GLContext glcontext = nullptr;
@@ -117,9 +118,11 @@ bool Backend::Initialize(const char* window_name, int width, int height, bool al
 	RMLUI_ASSERT(!data);
 
 #if SDL_MAJOR_VERSION >= 3
+	SDL_SetHint(SDL_HINT_IME_IMPLEMENTED_UI, "composition");
 	if (!SDL_Init(SDL_INIT_VIDEO | SDL_INIT_EVENTS))
 		return false;
 #else
+	SDL_SetHint(SDL_HINT_IME_SHOW_UI, "1");
 	if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_EVENTS | SDL_INIT_TIMER) != 0)
 		return false;
 #endif
@@ -206,6 +209,8 @@ bool Backend::Initialize(const char* window_name, int width, int height, bool al
 
 	data->render_interface.SetViewport(width, height);
 
+	Rml::SetTextInputHandler(&data->text_input_method_editor);
+
 	return true;
 }
 
@@ -263,6 +268,7 @@ bool Backend::ProcessEvents(Rml::Context* context, KeyDownCallback key_down_call
 	auto GetDisplayScale = []() { return SDL_GetWindowDisplayScale(data->window); };
 	constexpr auto event_quit = SDL_EVENT_QUIT;
 	constexpr auto event_key_down = SDL_EVENT_KEY_DOWN;
+	constexpr auto event_text_editing = SDL_EVENT_TEXT_EDITING;
 	constexpr auto event_window_size_changed = SDL_EVENT_WINDOW_PIXEL_SIZE_CHANGED;
 	bool has_event = false;
 #else
@@ -279,6 +285,7 @@ bool Backend::ProcessEvents(Rml::Context* context, KeyDownCallback key_down_call
 	auto GetDisplayScale = []() { return 1.f; };
 	constexpr auto event_quit = SDL_QUIT;
 	constexpr auto event_key_down = SDL_KEYDOWN;
+	constexpr auto event_text_editing = SDL_TEXTEDITING;
 	constexpr auto event_window_size_changed = SDL_WINDOWEVENT_SIZE_CHANGED;
 	int has_event = 0;
 #endif
@@ -319,6 +326,12 @@ bool Backend::ProcessEvents(Rml::Context* context, KeyDownCallback key_down_call
 			// The key was not consumed by the context either, try keyboard shortcuts of lower priority.
 			if (key_down_callback && !key_down_callback(context, key, key_modifier, native_dp_ratio, false))
 				break;
+		}
+		break;
+		case event_text_editing:
+		{
+			propagate_event = false;
+			data->text_input_method_editor.HandleEdit(ev.edit);
 		}
 		break;
 

--- a/Backends/RmlUi_Backend_SDL_GPU.cpp
+++ b/Backends/RmlUi_Backend_SDL_GPU.cpp
@@ -19,6 +19,7 @@ struct BackendData {
 
 	SystemInterface_SDL system_interface;
 	RenderInterface_SDL_GPU render_interface;
+	TextInputMethodEditor_SDL text_input_method_editor;
 
 	SDL_Window* window = nullptr;
 	SDL_GPUDevice* device = nullptr;
@@ -31,6 +32,8 @@ static Rml::UniquePtr<BackendData> data;
 bool Backend::Initialize(const char* window_name, int width, int height, bool allow_resize)
 {
 	RMLUI_ASSERT(!data);
+
+	SDL_SetHint(SDL_HINT_IME_IMPLEMENTED_UI, "composition");
 
 	if (!SDL_Init(SDL_INIT_VIDEO))
 		return false;
@@ -90,6 +93,8 @@ bool Backend::Initialize(const char* window_name, int width, int height, bool al
 	const char* renderer_name = SDL_GetGPUDeviceDriver(device);
 	data->system_interface.LogMessage(Rml::Log::LT_INFO, Rml::CreateString("Using SDL device driver: %s", renderer_name));
 
+	Rml::SetTextInputHandler(&data->text_input_method_editor);
+
 	return true;
 }
 
@@ -128,6 +133,7 @@ bool Backend::ProcessEvents(Rml::Context* context, KeyDownCallback key_down_call
 	auto GetDisplayScale = []() { return SDL_GetWindowDisplayScale(data->window); };
 	constexpr auto event_quit = SDL_EVENT_QUIT;
 	constexpr auto event_key_down = SDL_EVENT_KEY_DOWN;
+	constexpr auto event_text_editing = SDL_EVENT_TEXT_EDITING;
 	bool has_event = false;
 
 	bool result = data->running;
@@ -166,6 +172,12 @@ bool Backend::ProcessEvents(Rml::Context* context, KeyDownCallback key_down_call
 			// The key was not consumed by the context either, try keyboard shortcuts of lower priority.
 			if (key_down_callback && !key_down_callback(context, key, key_modifier, native_dp_ratio, false))
 				break;
+		}
+		break;
+		case event_text_editing:
+		{
+			propagate_event = false;
+			data->text_input_method_editor.HandleEdit(ev.edit);
 		}
 		break;
 		default: break;

--- a/Backends/RmlUi_Backend_SDL_SDLrenderer.cpp
+++ b/Backends/RmlUi_Backend_SDL_SDLrenderer.cpp
@@ -15,6 +15,7 @@ struct BackendData {
 
 	SystemInterface_SDL system_interface;
 	RenderInterface_SDL render_interface;
+	TextInputMethodEditor_SDL text_input_method_editor;
 
 	SDL_Window* window = nullptr;
 	SDL_Renderer* renderer = nullptr;
@@ -28,9 +29,11 @@ bool Backend::Initialize(const char* window_name, int width, int height, bool al
 	RMLUI_ASSERT(!data);
 
 #if SDL_MAJOR_VERSION >= 3
+	SDL_SetHint(SDL_HINT_IME_IMPLEMENTED_UI, "composition");
 	if (!SDL_Init(SDL_INIT_VIDEO | SDL_INIT_EVENTS))
 		return false;
 #else
+	SDL_SetHint(SDL_HINT_IME_SHOW_UI, "1");
 	if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_EVENTS | SDL_INIT_TIMER) != 0)
 		return false;
 #endif
@@ -114,6 +117,8 @@ bool Backend::Initialize(const char* window_name, int width, int height, bool al
 	if (renderer_name)
 		data->system_interface.LogMessage(Rml::Log::LT_INFO, Rml::CreateString("Using SDL renderer: %s", renderer_name));
 
+	Rml::SetTextInputHandler(&data->text_input_method_editor);
+
 	return true;
 }
 
@@ -150,12 +155,14 @@ bool Backend::ProcessEvents(Rml::Context* context, KeyDownCallback key_down_call
 	auto GetDisplayScale = []() { return SDL_GetWindowDisplayScale(data->window); };
 	constexpr auto event_quit = SDL_EVENT_QUIT;
 	constexpr auto event_key_down = SDL_EVENT_KEY_DOWN;
+	constexpr auto event_text_editing = SDL_EVENT_TEXT_EDITING;
 	bool has_event = false;
 #else
 	auto GetKey = [](const SDL_Event& event) { return event.key.keysym.sym; };
 	auto GetDisplayScale = []() { return 1.f; };
 	constexpr auto event_quit = SDL_QUIT;
 	constexpr auto event_key_down = SDL_KEYDOWN;
+	constexpr auto event_text_editing = SDL_TEXTEDITING;
 	int has_event = 0;
 #endif
 
@@ -195,6 +202,12 @@ bool Backend::ProcessEvents(Rml::Context* context, KeyDownCallback key_down_call
 			// The key was not consumed by the context either, try keyboard shortcuts of lower priority.
 			if (key_down_callback && !key_down_callback(context, key, key_modifier, native_dp_ratio, false))
 				break;
+		}
+		break;
+		case event_text_editing:
+		{
+			propagate_event = false;
+			data->text_input_method_editor.HandleEdit(ev.edit);
 		}
 		break;
 		default: break;

--- a/Backends/RmlUi_Backend_SDL_VK.cpp
+++ b/Backends/RmlUi_Backend_SDL_VK.cpp
@@ -26,6 +26,7 @@ struct BackendData {
 
 	SystemInterface_SDL system_interface;
 	RenderInterface_VK render_interface;
+	TextInputMethodEditor_SDL text_input_method_editor;
 
 	SDL_Window* window = nullptr;
 
@@ -38,9 +39,11 @@ bool Backend::Initialize(const char* window_name, int width, int height, bool al
 	RMLUI_ASSERT(!data);
 
 #if SDL_MAJOR_VERSION >= 3
+	SDL_SetHint(SDL_HINT_IME_IMPLEMENTED_UI, "composition");
 	if (!SDL_Init(SDL_INIT_VIDEO | SDL_INIT_EVENTS))
 		return false;
 #else
+	SDL_SetHint(SDL_HINT_IME_SHOW_UI, "1");
 	if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_EVENTS | SDL_INIT_TIMER) != 0)
 		return false;
 #endif
@@ -131,6 +134,8 @@ bool Backend::Initialize(const char* window_name, int width, int height, bool al
 
 	data->render_interface.SetViewport(width, height);
 
+	Rml::SetTextInputHandler(&data->text_input_method_editor);
+
 	return true;
 }
 
@@ -202,6 +207,7 @@ bool Backend::ProcessEvents(Rml::Context* context, KeyDownCallback key_down_call
 	auto GetDisplayScale = []() { return SDL_GetWindowDisplayScale(data->window); };
 	constexpr auto event_quit = SDL_EVENT_QUIT;
 	constexpr auto event_key_down = SDL_EVENT_KEY_DOWN;
+	constexpr auto event_text_editing = SDL_EVENT_TEXT_EDITING;
 	constexpr auto event_window_size_changed = SDL_EVENT_WINDOW_PIXEL_SIZE_CHANGED;
 	bool has_event = false;
 #else
@@ -218,6 +224,7 @@ bool Backend::ProcessEvents(Rml::Context* context, KeyDownCallback key_down_call
 	auto GetDisplayScale = []() { return 1.f; };
 	constexpr auto event_quit = SDL_QUIT;
 	constexpr auto event_key_down = SDL_KEYDOWN;
+	constexpr auto event_text_editing = SDL_TEXTEDITING;
 	constexpr auto event_window_size_changed = SDL_WINDOWEVENT_SIZE_CHANGED;
 	int has_event = 0;
 #endif
@@ -258,6 +265,12 @@ bool Backend::ProcessEvents(Rml::Context* context, KeyDownCallback key_down_call
 			// The key was not consumed by the context either, try keyboard shortcuts of lower priority.
 			if (key_down_callback && !key_down_callback(context, key, key_modifier, native_dp_ratio, false))
 				break;
+		}
+		break;
+		case event_text_editing:
+		{
+			propagate_event = false;
+			data->text_input_method_editor.HandleEdit(ev.edit);
 		}
 		break;
 

--- a/Backends/RmlUi_Platform_SDL.cpp
+++ b/Backends/RmlUi_Platform_SDL.cpp
@@ -3,6 +3,7 @@
 #include <RmlUi/Core/Input.h>
 #include <RmlUi/Core/StringUtilities.h>
 #include <RmlUi/Core/SystemInterface.h>
+#include <RmlUi/Core/TextInputContext.h>
 
 static Rml::TouchList TouchEventToTouchList(SDL_Event& ev, Rml::Context* context, SDL_FingerID finger_id)
 {
@@ -518,4 +519,51 @@ int RmlSDL::GetKeyModifierState()
 		retval |= Rml::Input::KM_CAPSLOCK;
 
 	return retval;
+}
+
+void TextInputMethodEditor_SDL::OnActivate(Rml::TextInputContext* input_context)
+{
+	context = input_context;
+}
+
+void TextInputMethodEditor_SDL::OnDeactivate(Rml::TextInputContext* input_context)
+{
+	if (context == input_context)
+		context = nullptr;
+}
+
+void TextInputMethodEditor_SDL::OnDestroy(Rml::TextInputContext* input_context)
+{
+	if (context == input_context)
+		context = nullptr;
+}
+
+void TextInputMethodEditor_SDL::HandleEdit(const SDL_TextEditingEvent& ev)
+{
+	if (context == nullptr)
+		return;
+
+	auto string = Rml::String(ev.text);
+	auto length = static_cast<int>(Rml::StringUtilities::LengthUTF8(string));
+
+	auto composing = start != end;
+
+	if (!composing)
+		context->GetSelectionRange(start, end);
+
+	if (composing || length > 0)
+		context->SetText(string, start, end);
+
+	end = start + length;
+	context->SetCompositionRange(start, end);
+
+	if (length > 0 && ev.start >= 0 && ev.length >= 0)
+		context->SetSelectionRange(start + ev.start, start + ev.start + ev.length);
+	else if (composing)
+		context->SetCursorPosition(end);
+
+	// When committing, SDL sends a text editing event with an empty string and a
+	// separate text input event with the committed text.
+	if (composing && length == 0)
+		context->CommitComposition(Rml::StringView());
 }

--- a/Backends/RmlUi_Platform_SDL.h
+++ b/Backends/RmlUi_Platform_SDL.h
@@ -2,6 +2,7 @@
 
 #include <RmlUi/Core/Input.h>
 #include <RmlUi/Core/SystemInterface.h>
+#include <RmlUi/Core/TextInputHandler.h>
 #include <RmlUi/Core/Types.h>
 
 #if RMLUI_SDL_VERSION_MAJOR == 3
@@ -62,3 +63,16 @@ int ConvertMouseButton(int sdl_mouse_button);
 int GetKeyModifierState();
 
 } // namespace RmlSDL
+
+class TextInputMethodEditor_SDL final : public Rml::TextInputHandler {
+public:
+	void OnActivate(Rml::TextInputContext* input_context) override;
+	void OnDeactivate(Rml::TextInputContext* input_context) override;
+	void OnDestroy(Rml::TextInputContext* input_context) override;
+
+	void HandleEdit(const SDL_TextEditingEvent& ev);
+
+private:
+	Rml::TextInputContext* context = nullptr;
+	int start = 0, end = 0;
+};

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ option(BUILD_SHARED_LIBS "CMake standard option. Choose whether to build shared 
 #   - Do not include a verb prefix (such as "enable" and "build"), as these are often superfluous.
 option(RMLUI_SAMPLES "Build samples of the library." OFF)
 option(RMLUI_BACKEND_SIMULATE_TOUCH "Simulate touch events with mouse events" OFF)
+option(RMLUI_IME_SAMPLE_USE_NOTO_FONTS "Enable Noto fonts as fallback for Asian languages in IME sample. Downloads the fonts at build time." OFF)
 set(RMLUI_BACKEND "auto" CACHE STRING "Backend to use when building the RmlUi samples. Choose one from ./CMake/OptionsLists.cmake.")
 set_property(CACHE RMLUI_BACKEND PROPERTY STRINGS ${RMLUI_BACKEND_OPTIONS})
 if(NOT RMLUI_BACKEND IN_LIST RMLUI_BACKEND_OPTIONS)

--- a/Samples/.gitignore
+++ b/Samples/.gitignore
@@ -1,0 +1,1 @@
+/assets/external/

--- a/Samples/basic/CMakeLists.txt
+++ b/Samples/basic/CMakeLists.txt
@@ -30,10 +30,12 @@ if(RMLUI_FONT_ENGINE_ENABLED)
 		message(STATUS "SVG sample disabled due to RMLUI_SVG_PLUGIN=OFF")
 	endif()
 
-	# Enable the IME sample only for Windows backends; no other platform backend is currently supported.
-	if(RMLUI_BACKEND MATCHES "^Win32")
+	# Enable the IME sample only for SDL or Windows backends; no other platform backend is currently supported.
+	if(RMLUI_BACKEND MATCHES "^Win32" OR (RMLUI_IME_SAMPLE_USE_NOTO_FONTS AND RMLUI_BACKEND MATCHES "^SDL"))
 		add_subdirectory("ime")
+	elseif (RMLUI_BACKEND MATCHES "^SDL")
+		message(STATUS "IME sample disabled - no Asian language fonts available, see RMLUI_IME_SAMPLE_USE_NOTO_FONTS")
 	else()
-		message(STATUS "IME sample disabled - only available with Win32 backends, see RMLUI_BACKEND")
+		message(STATUS "IME sample disabled - only available with SDL or Win32 backends, see RMLUI_BACKEND")
 	endif()
 endif()

--- a/Samples/basic/ime/CMakeLists.txt
+++ b/Samples/basic/ime/CMakeLists.txt
@@ -1,14 +1,40 @@
 set(SAMPLE_NAME "ime")
 set(TARGET_NAME "${RMLUI_SAMPLE_PREFIX}${SAMPLE_NAME}")
 
-add_executable(${TARGET_NAME} WIN32
-	src/SystemFontWin32.cpp
-	src/SystemFontWin32.h
-	src/main.cpp
-)
+if(RMLUI_IME_SAMPLE_USE_NOTO_FONTS)
+	add_executable(${TARGET_NAME} WIN32
+		src/main.cpp
+	)
+else()
+	add_executable(${TARGET_NAME} WIN32
+		src/SystemFontWin32.cpp
+		src/SystemFontWin32.h
+		src/main.cpp
+	)
+endif()
 
 set_common_target_options(${TARGET_NAME})
 
 target_link_libraries(${TARGET_NAME} PRIVATE rmlui_shell)
 
 install_sample_target(${TARGET_NAME})
+
+if(RMLUI_IME_SAMPLE_USE_NOTO_FONTS)
+	target_compile_definitions(${TARGET_NAME} PRIVATE "RMLUI_IME_SAMPLE_USE_NOTO_FONTS")
+	set(external_assets_dir "${CMAKE_SOURCE_DIR}/Samples/assets/external")
+	file(DOWNLOAD "https://github.com/google/fonts/raw/47831f08ec6d6d7ad6b465f23dc9f9a890a2a04b/ofl/notosanssc/NotoSansSC%5Bwght%5D.ttf" "${external_assets_dir}/NotoSansSC[wght].ttf"
+		EXPECTED_HASH SHA256=a3041811a78c361b1de50f953c805e0244951c21c5bd412f7232ef0d899af0da
+	)
+	file(DOWNLOAD "https://github.com/google/fonts/raw/47831f08ec6d6d7ad6b465f23dc9f9a890a2a04b/ofl/notosansjp/NotoSansJP%5Bwght%5D.ttf" "${external_assets_dir}/NotoSansJP[wght].ttf"
+		EXPECTED_HASH SHA256=c2f3b4d463500a2ddcd3849cded1fceeb9fd6d1c32e6cbecd568453ba50fc68f
+	)
+	file(DOWNLOAD "https://github.com/google/fonts/raw/47831f08ec6d6d7ad6b465f23dc9f9a890a2a04b/ofl/notosanskr/NotoSansKR%5Bwght%5D.ttf" "${external_assets_dir}/NotoSansKR[wght].ttf"
+		EXPECTED_HASH SHA256=194018e6b2b293a7964f037b25c0249ce1418bc9ab3c971060a03aa57861e252
+	)
+	file(DOWNLOAD "https://github.com/google/fonts/raw/47831f08ec6d6d7ad6b465f23dc9f9a890a2a04b/ofl/notosansthai/NotoSansThai%5Bwdth,wght%5D.ttf" "${external_assets_dir}/NotoSansThai[wdth,wght].ttf"
+		EXPECTED_HASH SHA256=5a1c559bb539583c8a1fd99d1c5b9491e5e14478c9cd2bd0970d5c3096cc9ef8
+	)
+	file(DOWNLOAD "https://github.com/google/fonts/raw/47831f08ec6d6d7ad6b465f23dc9f9a890a2a04b/ofl/notosansarabic/NotoSansArabic%5Bwdth,wght%5D.ttf" "${external_assets_dir}/NotoSansArabic[wdth,wght].ttf"
+		EXPECTED_HASH SHA256=63111b5b2e074dd48cc67692e0a2726d86ee94c1c37fe8598257b7b4e87e869e
+	)
+endif()

--- a/Samples/basic/ime/src/main.cpp
+++ b/Samples/basic/ime/src/main.cpp
@@ -1,13 +1,15 @@
-﻿#include "SystemFontWin32.h"
+﻿#include <RmlUi/Core/Platform.h>
+#if !defined RMLUI_IME_SAMPLE_USE_NOTO_FONTS
+	#include "SystemFontWin32.h"
+#endif
 #include <RmlUi/Core.h>
 #include <RmlUi/Debugger.h>
 #include <PlatformExtensions.h>
 #include <RmlUi_Backend.h>
-#include <RmlUi_Include_Windows.h>
 #include <Shell.h>
 
-#if !defined RMLUI_PLATFORM_WIN32
-	#error "This sample works only on Windows!"
+#if !defined RMLUI_IME_SAMPLE_USE_NOTO_FONTS && !defined RMLUI_PLATFORM_WIN32
+	#error "No Asian language fonts available. Please set RMLUI_IME_SAMPLE_USE_NOTO_FONTS to use Noto fonts."
 #endif
 
 static void LoadFonts()
@@ -23,14 +25,35 @@ static void LoadFonts()
 		{"assets/LatoLatin-BoldItalic.ttf", false},
 	};
 
+#if !defined RMLUI_IME_SAMPLE_USE_NOTO_FONTS
 	for (const Rml::String& path : GetSelectedSystemFonts())
 		font_faces.push_back({path, true});
+#endif
 
 	for (const FontFace& face : font_faces)
 		Rml::LoadFontFace(face.filename, face.fallback_face);
+
+#if defined RMLUI_IME_SAMPLE_USE_NOTO_FONTS
+	Rml::Vector<FontFace> noto_font_faces = {
+		{"assets/external/NotoSansSC[wght].ttf", true},
+		{"assets/external/NotoSansJP[wght].ttf", true},
+		{"assets/external/NotoSansKR[wght].ttf", true},
+		{"assets/external/NotoSansThai[wdth,wght].ttf", true},
+		{"assets/external/NotoSansArabic[wdth,wght].ttf", true},
+		{"assets/NotoEmoji-Regular.ttf", true},
+	};
+
+	for (const FontFace& face : noto_font_faces)
+		Rml::LoadFontFace(face.filename, face.fallback_face, Rml::Style::FontWeight::Normal);
+#endif
 }
 
+#if defined RMLUI_PLATFORM_WIN32
+	#include <RmlUi_Include_Windows.h>
 int APIENTRY WinMain(HINSTANCE /*instance_handle*/, HINSTANCE /*previous_instance_handle*/, char* /*command_line*/, int /*command_show*/)
+#else
+int main(int /*argc*/, char** /*argv*/)
+#endif
 {
 	const int window_width = 1024;
 	const int window_height = 768;


### PR DESCRIPTION
I have only tested with SDL3 so far, and haven't tested all of the backends.

I was going to commit a change to enable building the IME sample when using SDL backends as well, but then I realised it's relying on Windows system fonts. The fonts committed to the assets directory haven't got support for all of the languages used in the IME sample. If there is a suitable font you'd like to add as an asset, we could change the IME sample to use that rather than Windows system fonts.
