### PR TITLE
Add `OnDataModelCreate`/`OnDataModelDestroy` to plugin API

### DIFF
--- a/Include/RmlUi/Core/DataModelHandle.h
+++ b/Include/RmlUi/Core/DataModelHandle.h
@@ -21,6 +21,14 @@ public:
 
 	explicit operator bool() { return model; }
 
+	// Returns an opaque pointer that uniquely identifies the underlying data model for the lifetime of the model.
+	// Useful as a key when tracking data models externally (e.g. from a plugin) without needing to hash their names.
+	// Two handles compare equal if and only if they refer to the same data model.
+	const void* GetId() const { return model; }
+
+	friend bool operator==(DataModelHandle lhs, DataModelHandle rhs) { return lhs.model == rhs.model; }
+	friend bool operator!=(DataModelHandle lhs, DataModelHandle rhs) { return lhs.model != rhs.model; }
+
 private:
 	DataModel* model;
 };

--- a/Include/RmlUi/Core/DataModelHandle.h
+++ b/Include/RmlUi/Core/DataModelHandle.h
@@ -21,14 +21,6 @@ public:
 
 	explicit operator bool() { return model; }
 
-	// Returns an opaque pointer that uniquely identifies the underlying data model for the lifetime of the model.
-	// Useful as a key when tracking data models externally (e.g. from a plugin) without needing to hash their names.
-	// Two handles compare equal if and only if they refer to the same data model.
-	const void* GetId() const { return model; }
-
-	friend bool operator==(DataModelHandle lhs, DataModelHandle rhs) { return lhs.model == rhs.model; }
-	friend bool operator!=(DataModelHandle lhs, DataModelHandle rhs) { return lhs.model != rhs.model; }
-
 private:
 	DataModel* model;
 };

--- a/Include/RmlUi/Core/Plugin.h
+++ b/Include/RmlUi/Core/Plugin.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "DataModelHandle.h"
 #include "Header.h"
 #include "Types.h"
 
@@ -18,11 +19,12 @@ public:
 	virtual ~Plugin();
 
 	enum EventClasses {
-		EVT_BASIC = (1 << 0),    // Initialise, Shutdown, ContextCreate, ContextDestroy
-		EVT_DOCUMENT = (1 << 1), // DocumentOpen, DocumentLoad, DocumentUnload
-		EVT_ELEMENT = (1 << 2),  // ElementCreate, ElementDestroy
+		EVT_BASIC = (1 << 0),      // Initialise, Shutdown, ContextCreate, ContextDestroy
+		EVT_DOCUMENT = (1 << 1),   // DocumentOpen, DocumentLoad, DocumentUnload
+		EVT_ELEMENT = (1 << 2),    // ElementCreate, ElementDestroy
+		EVT_DATA_MODEL = (1 << 3), // DataModelCreate, DataModelDestroy
 
-		EVT_ALL = EVT_BASIC | EVT_DOCUMENT | EVT_ELEMENT
+		EVT_ALL = EVT_BASIC | EVT_DOCUMENT | EVT_ELEMENT | EVT_DATA_MODEL
 	};
 	/// Called when the plugin is registered to determine which of the above event types the plugin is interested in.
 	virtual int GetEventClasses();
@@ -51,6 +53,13 @@ public:
 	virtual void OnElementCreate(Element* element);
 	/// Called when an element is destroyed.
 	virtual void OnElementDestroy(Element* element);
+
+	/// Called when a new data model is created on a context.
+	virtual void OnDataModelCreate(Context* context, const String& name, DataModelHandle model);
+	/// Called when a data model is about to be destroyed, either explicitly through Context::RemoveDataModel or
+	/// implicitly when the owning context is destroyed. At this point the data model is still accessible through
+	/// Context::GetDataModel, but will be unusable as soon as this callback returns.
+	virtual void OnDataModelDestroy(Context* context, const String& name, DataModelHandle model);
 };
 
 } // namespace Rml

--- a/Include/RmlUi/Core/Plugin.h
+++ b/Include/RmlUi/Core/Plugin.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "DataModelHandle.h"
 #include "Header.h"
 #include "Types.h"
 
@@ -55,11 +54,11 @@ public:
 	virtual void OnElementDestroy(Element* element);
 
 	/// Called when a new data model is created on a context.
-	virtual void OnDataModelCreate(Context* context, const String& name, DataModelHandle model);
+	virtual void OnDataModelCreate(Context* context, const String& name);
 	/// Called when a data model is about to be destroyed, either explicitly through Context::RemoveDataModel or
 	/// implicitly when the owning context is destroyed. At this point the data model is still accessible through
 	/// Context::GetDataModel, but will be unusable as soon as this callback returns.
-	virtual void OnDataModelDestroy(Context* context, const String& name, DataModelHandle model);
+	virtual void OnDataModelDestroy(Context* context, const String& name);
 };
 
 } // namespace Rml

--- a/Source/Core/Context.cpp
+++ b/Source/Core/Context.cpp
@@ -111,7 +111,7 @@ Context::~Context()
 	ReleaseUnloadedDocuments();
 
 	for (const auto& pair : data_models)
-		PluginRegistry::NotifyDataModelDestroy(this, pair.first, DataModelHandle(pair.second.get()));
+		PluginRegistry::NotifyDataModelDestroy(this, pair.first);
 	data_models.clear();
 
 	root.reset();
@@ -1068,7 +1068,7 @@ DataModelConstructor Context::CreateDataModel(const String& name, DataTypeRegist
 	if (inserted)
 	{
 		DataModel* model = result.first->second.get();
-		PluginRegistry::NotifyDataModelCreate(this, name, DataModelHandle(model));
+		PluginRegistry::NotifyDataModelCreate(this, name);
 		return DataModelConstructor(model);
 	}
 
@@ -1106,7 +1106,7 @@ bool Context::RemoveDataModel(const String& name)
 	for (Element* element : elements)
 		element->SetDataModel(nullptr);
 
-	PluginRegistry::NotifyDataModelDestroy(this, it->first, DataModelHandle(model));
+	PluginRegistry::NotifyDataModelDestroy(this, it->first);
 
 	data_models.erase(it);
 

--- a/Source/Core/Context.cpp
+++ b/Source/Core/Context.cpp
@@ -110,6 +110,10 @@ Context::~Context()
 
 	ReleaseUnloadedDocuments();
 
+	for (const auto& pair : data_models)
+		PluginRegistry::NotifyDataModelDestroy(this, pair.first, DataModelHandle(pair.second.get()));
+	data_models.clear();
+
 	root.reset();
 
 	cursor_proxy.reset();
@@ -1062,7 +1066,11 @@ DataModelConstructor Context::CreateDataModel(const String& name, DataTypeRegist
 	auto result = data_models.emplace(name, MakeUnique<DataModel>(data_type_register, allow_missing_variables));
 	bool inserted = result.second;
 	if (inserted)
-		return DataModelConstructor(result.first->second.get());
+	{
+		DataModel* model = result.first->second.get();
+		PluginRegistry::NotifyDataModelCreate(this, name, DataModelHandle(model));
+		return DataModelConstructor(model);
+	}
 
 	Log::Message(Log::LT_ERROR, "Data model name '%s' already exists.", name.c_str());
 	return DataModelConstructor();
@@ -1097,6 +1105,8 @@ bool Context::RemoveDataModel(const String& name)
 
 	for (Element* element : elements)
 		element->SetDataModel(nullptr);
+
+	PluginRegistry::NotifyDataModelDestroy(this, it->first, DataModelHandle(model));
 
 	data_models.erase(it);
 

--- a/Source/Core/Plugin.cpp
+++ b/Source/Core/Plugin.cpp
@@ -27,4 +27,8 @@ void Plugin::OnElementCreate(Element* /*element*/) {}
 
 void Plugin::OnElementDestroy(Element* /*element*/) {}
 
+void Plugin::OnDataModelCreate(Context* /*context*/, const String& /*name*/, DataModelHandle /*model*/) {}
+
+void Plugin::OnDataModelDestroy(Context* /*context*/, const String& /*name*/, DataModelHandle /*model*/) {}
+
 } // namespace Rml

--- a/Source/Core/Plugin.cpp
+++ b/Source/Core/Plugin.cpp
@@ -27,8 +27,8 @@ void Plugin::OnElementCreate(Element* /*element*/) {}
 
 void Plugin::OnElementDestroy(Element* /*element*/) {}
 
-void Plugin::OnDataModelCreate(Context* /*context*/, const String& /*name*/, DataModelHandle /*model*/) {}
+void Plugin::OnDataModelCreate(Context* /*context*/, const String& /*name*/) {}
 
-void Plugin::OnDataModelDestroy(Context* /*context*/, const String& /*name*/, DataModelHandle /*model*/) {}
+void Plugin::OnDataModelDestroy(Context* /*context*/, const String& /*name*/) {}
 
 } // namespace Rml

--- a/Source/Core/PluginRegistry.cpp
+++ b/Source/Core/PluginRegistry.cpp
@@ -9,6 +9,7 @@ struct PluginVectors {
 	Vector<Plugin*> basic;
 	Vector<Plugin*> document;
 	Vector<Plugin*> element;
+	Vector<Plugin*> data_model;
 };
 
 static ControlledLifetimeResource<PluginVectors> plugin_vectors;
@@ -33,10 +34,17 @@ void PluginRegistry::RegisterPlugin(Plugin* plugin)
 		plugin_vectors->document.push_back(plugin);
 	if (event_classes & Plugin::EVT_ELEMENT)
 		plugin_vectors->element.push_back(plugin);
+	if (event_classes & Plugin::EVT_DATA_MODEL)
+		plugin_vectors->data_model.push_back(plugin);
 }
 
 void PluginRegistry::UnregisterPlugin(Plugin* plugin)
 {
+	// Safe to call after NotifyShutdown() (e.g. from a plugin destructor): the backing storage has been released
+	// and there is nothing left to unregister.
+	if (!plugin_vectors)
+		return;
+
 	auto erase_value = [](Vector<Plugin*>& container, Plugin* value) {
 		container.erase(std::remove(container.begin(), container.end(), value), container.end());
 	};
@@ -48,6 +56,8 @@ void PluginRegistry::UnregisterPlugin(Plugin* plugin)
 		erase_value(plugin_vectors->document, plugin);
 	if (event_classes & Plugin::EVT_ELEMENT)
 		erase_value(plugin_vectors->element, plugin);
+	if (event_classes & Plugin::EVT_DATA_MODEL)
+		erase_value(plugin_vectors->data_model, plugin);
 }
 
 void PluginRegistry::NotifyInitialise()
@@ -110,6 +120,18 @@ void PluginRegistry::NotifyElementDestroy(Element* element)
 {
 	for (Plugin* plugin : plugin_vectors->element)
 		plugin->OnElementDestroy(element);
+}
+
+void PluginRegistry::NotifyDataModelCreate(Context* context, const String& name, DataModelHandle model)
+{
+	for (Plugin* plugin : plugin_vectors->data_model)
+		plugin->OnDataModelCreate(context, name, model);
+}
+
+void PluginRegistry::NotifyDataModelDestroy(Context* context, const String& name, DataModelHandle model)
+{
+	for (Plugin* plugin : plugin_vectors->data_model)
+		plugin->OnDataModelDestroy(context, name, model);
 }
 
 } // namespace Rml

--- a/Source/Core/PluginRegistry.cpp
+++ b/Source/Core/PluginRegistry.cpp
@@ -122,16 +122,16 @@ void PluginRegistry::NotifyElementDestroy(Element* element)
 		plugin->OnElementDestroy(element);
 }
 
-void PluginRegistry::NotifyDataModelCreate(Context* context, const String& name, DataModelHandle model)
+void PluginRegistry::NotifyDataModelCreate(Context* context, const String& name)
 {
 	for (Plugin* plugin : plugin_vectors->data_model)
-		plugin->OnDataModelCreate(context, name, model);
+		plugin->OnDataModelCreate(context, name);
 }
 
-void PluginRegistry::NotifyDataModelDestroy(Context* context, const String& name, DataModelHandle model)
+void PluginRegistry::NotifyDataModelDestroy(Context* context, const String& name)
 {
 	for (Plugin* plugin : plugin_vectors->data_model)
-		plugin->OnDataModelDestroy(context, name, model);
+		plugin->OnDataModelDestroy(context, name);
 }
 
 } // namespace Rml

--- a/Source/Core/PluginRegistry.h
+++ b/Source/Core/PluginRegistry.h
@@ -36,6 +36,11 @@ public:
 	/// Calls OnElementDestroy() on all plugins.
 	static void NotifyElementDestroy(Element* element);
 
+	/// Calls OnDataModelCreate() on all plugins.
+	static void NotifyDataModelCreate(Context* context, const String& name, DataModelHandle model);
+	/// Calls OnDataModelDestroy() on all plugins.
+	static void NotifyDataModelDestroy(Context* context, const String& name, DataModelHandle model);
+
 private:
 	PluginRegistry() = delete;
 };

--- a/Source/Core/PluginRegistry.h
+++ b/Source/Core/PluginRegistry.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "../../Include/RmlUi/Core/DataModelHandle.h"
 #include "../../Include/RmlUi/Core/Types.h"
 
 namespace Rml {

--- a/Source/Core/PluginRegistry.h
+++ b/Source/Core/PluginRegistry.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "../../Include/RmlUi/Core/DataModelHandle.h"
 #include "../../Include/RmlUi/Core/Types.h"
 
 namespace Rml {
@@ -38,9 +37,9 @@ public:
 	static void NotifyElementDestroy(Element* element);
 
 	/// Calls OnDataModelCreate() on all plugins.
-	static void NotifyDataModelCreate(Context* context, const String& name, DataModelHandle model);
+	static void NotifyDataModelCreate(Context* context, const String& name);
 	/// Calls OnDataModelDestroy() on all plugins.
-	static void NotifyDataModelDestroy(Context* context, const String& name, DataModelHandle model);
+	static void NotifyDataModelDestroy(Context* context, const String& name);
 
 private:
 	PluginRegistry() = delete;

--- a/Tests/Source/UnitTests/CMakeLists.txt
+++ b/Tests/Source/UnitTests/CMakeLists.txt
@@ -36,6 +36,7 @@ add_executable(${TARGET_NAME}
 	URL.cpp
 	Variant.cpp
 	XMLParser.cpp
+	PluginDataModel.cpp
 )
 
 set_common_target_options(${TARGET_NAME})

--- a/Tests/Source/UnitTests/PluginDataModel.cpp
+++ b/Tests/Source/UnitTests/PluginDataModel.cpp
@@ -14,14 +14,11 @@ class DataModelTrackingPlugin : public Plugin {
 public:
 	int GetEventClasses() override { return EVT_DATA_MODEL; }
 
-	void OnDataModelCreate(Context* context, const String& name, DataModelHandle model) override
-	{
-		created.push_back({context, name, static_cast<bool>(model)});
-	}
+	void OnDataModelCreate(Context* context, const String& name) override { created.push_back({context, name}); }
 
-	void OnDataModelDestroy(Context* context, const String& name, DataModelHandle model) override
+	void OnDataModelDestroy(Context* context, const String& name) override
 	{
-		destroyed.push_back({context, name, static_cast<bool>(model)});
+		destroyed.push_back({context, name});
 		// The data model should still be resolvable at this point.
 		model_resolvable_on_destroy = static_cast<bool>(context->GetDataModel(name));
 	}
@@ -29,7 +26,6 @@ public:
 	struct Entry {
 		Context* context;
 		String name;
-		bool handle_valid;
 	};
 
 	Vector<Entry> created;
@@ -54,7 +50,6 @@ TEST_CASE("plugin.data_model_notifications")
 		REQUIRE(plugin.created.size() == 1);
 		CHECK(plugin.created[0].context == context);
 		CHECK(plugin.created[0].name == "plugin_test_model");
-		CHECK(plugin.created[0].handle_valid);
 		CHECK(plugin.destroyed.empty());
 	}
 
@@ -74,7 +69,6 @@ TEST_CASE("plugin.data_model_notifications")
 		REQUIRE(plugin.destroyed.size() == 1);
 		CHECK(plugin.destroyed[0].context == context);
 		CHECK(plugin.destroyed[0].name == "plugin_test_model");
-		CHECK(plugin.destroyed[0].handle_valid);
 		CHECK(plugin.model_resolvable_on_destroy);
 	}
 
@@ -101,10 +95,10 @@ TEST_CASE("plugin.data_model_notifications")
 		Vector<String> names_destroyed_on_shutdown;
 		for (size_t i = destroyed_before; i < plugin.destroyed.size(); ++i)
 			names_destroyed_on_shutdown.push_back(plugin.destroyed[i].name);
-		CHECK(std::find(names_destroyed_on_shutdown.begin(), names_destroyed_on_shutdown.end(), "plugin_model_a") !=
-			names_destroyed_on_shutdown.end());
-		CHECK(std::find(names_destroyed_on_shutdown.begin(), names_destroyed_on_shutdown.end(), "plugin_model_b") !=
-			names_destroyed_on_shutdown.end());
+		CHECK(
+			std::find(names_destroyed_on_shutdown.begin(), names_destroyed_on_shutdown.end(), "plugin_model_a") != names_destroyed_on_shutdown.end());
+		CHECK(
+			std::find(names_destroyed_on_shutdown.begin(), names_destroyed_on_shutdown.end(), "plugin_model_b") != names_destroyed_on_shutdown.end());
 	}
 
 	Rml::UnregisterPlugin(&plugin);

--- a/Tests/Source/UnitTests/PluginDataModel.cpp
+++ b/Tests/Source/UnitTests/PluginDataModel.cpp
@@ -1,0 +1,111 @@
+#include "../Common/TestsShell.h"
+#include <RmlUi/Core/Context.h>
+#include <RmlUi/Core/Core.h>
+#include <RmlUi/Core/DataModelHandle.h>
+#include <RmlUi/Core/Plugin.h>
+#include <algorithm>
+#include <doctest.h>
+
+using namespace Rml;
+
+namespace {
+
+class DataModelTrackingPlugin : public Plugin {
+public:
+	int GetEventClasses() override { return EVT_DATA_MODEL; }
+
+	void OnDataModelCreate(Context* context, const String& name, DataModelHandle model) override
+	{
+		created.push_back({context, name, static_cast<bool>(model)});
+	}
+
+	void OnDataModelDestroy(Context* context, const String& name, DataModelHandle model) override
+	{
+		destroyed.push_back({context, name, static_cast<bool>(model)});
+		// The data model should still be resolvable at this point.
+		model_resolvable_on_destroy = static_cast<bool>(context->GetDataModel(name));
+	}
+
+	struct Entry {
+		Context* context;
+		String name;
+		bool handle_valid;
+	};
+
+	Vector<Entry> created;
+	Vector<Entry> destroyed;
+	bool model_resolvable_on_destroy = false;
+};
+
+} // namespace
+
+TEST_CASE("plugin.data_model_notifications")
+{
+	Context* context = TestsShell::GetContext();
+	REQUIRE(context);
+
+	DataModelTrackingPlugin plugin;
+	Rml::RegisterPlugin(&plugin);
+
+	// Creation notification.
+	{
+		DataModelConstructor constructor = context->CreateDataModel("plugin_test_model");
+		REQUIRE(constructor);
+		REQUIRE(plugin.created.size() == 1);
+		CHECK(plugin.created[0].context == context);
+		CHECK(plugin.created[0].name == "plugin_test_model");
+		CHECK(plugin.created[0].handle_valid);
+		CHECK(plugin.destroyed.empty());
+	}
+
+	// Duplicate create should not fire another notification.
+	{
+		TestsShell::SetNumExpectedWarnings(1);
+		DataModelConstructor duplicate = context->CreateDataModel("plugin_test_model");
+		TestsShell::SetNumExpectedWarnings(0);
+		CHECK(!duplicate);
+		CHECK(plugin.created.size() == 1);
+	}
+
+	// Explicit removal fires destroy notification, and the model is still resolvable during the callback.
+	{
+		const bool removed = context->RemoveDataModel("plugin_test_model");
+		CHECK(removed);
+		REQUIRE(plugin.destroyed.size() == 1);
+		CHECK(plugin.destroyed[0].context == context);
+		CHECK(plugin.destroyed[0].name == "plugin_test_model");
+		CHECK(plugin.destroyed[0].handle_valid);
+		CHECK(plugin.model_resolvable_on_destroy);
+	}
+
+	// Removing a nonexistent data model should not fire a notification.
+	{
+		const bool removed = context->RemoveDataModel("plugin_test_model");
+		CHECK_FALSE(removed);
+		CHECK(plugin.destroyed.size() == 1);
+	}
+
+	// Context destruction should fire destroy notifications for any remaining data models.
+	{
+		DataModelConstructor a = context->CreateDataModel("plugin_model_a");
+		DataModelConstructor b = context->CreateDataModel("plugin_model_b");
+		REQUIRE(a);
+		REQUIRE(b);
+		CHECK(plugin.created.size() == 3);
+
+		const size_t destroyed_before = plugin.destroyed.size();
+
+		TestsShell::ShutdownShell();
+
+		CHECK(plugin.destroyed.size() == destroyed_before + 2);
+		Vector<String> names_destroyed_on_shutdown;
+		for (size_t i = destroyed_before; i < plugin.destroyed.size(); ++i)
+			names_destroyed_on_shutdown.push_back(plugin.destroyed[i].name);
+		CHECK(std::find(names_destroyed_on_shutdown.begin(), names_destroyed_on_shutdown.end(), "plugin_model_a") !=
+			names_destroyed_on_shutdown.end());
+		CHECK(std::find(names_destroyed_on_shutdown.begin(), names_destroyed_on_shutdown.end(), "plugin_model_b") !=
+			names_destroyed_on_shutdown.end());
+	}
+
+	Rml::UnregisterPlugin(&plugin);
+}


### PR DESCRIPTION
# Plugin hooks for data model lifetime

Adds `Plugin::OnDataModelCreate` / `OnDataModelDestroy` so external code (e.g. scripting bindings) can track data model lifetime without relying on implementation details.

Resolves [#903](https://github.com/mikke89/RmlUi/discussions/903).