### PR TITLE
Fix RmlUi_Backend_SDL_GL3 crash on Wayland

### DIFF
--- a/Backends/RmlUi_Backend_SDL_GL3.cpp
+++ b/Backends/RmlUi_Backend_SDL_GL3.cpp
@@ -213,15 +213,18 @@ void Backend::Shutdown()
 {
 	RMLUI_ASSERT(data);
 
+    SDL_Window* window = data->window;
+    SDL_GLContext glcontext = data->glcontext;
+
+    data.reset();
+
 #if SDL_MAJOR_VERSION >= 3
-	SDL_GL_DestroyContext(data->glcontext);
+	SDL_GL_DestroyContext(glcontext);
 #else
-	SDL_GL_DeleteContext(data->glcontext);
+	SDL_GL_DeleteContext(glcontext);
 #endif
 
-	SDL_DestroyWindow(data->window);
-
-	data.reset();
+	SDL_DestroyWindow(window);
 
 	SDL_Quit();
 }


### PR DESCRIPTION
Fixed a crash in the SDL_GL3 backend when calling Backend::Shutdown() on Wayland.

Resolves #931