### PR TITLE
Add RCSS custom properties and var() references

### DIFF
--- a/Include/RmlUi/Core/Context.h
+++ b/Include/RmlUi/Core/Context.h
@@ -99,6 +99,19 @@ public:
 	/// @return True if the theme is activated.
 	bool IsThemeActive(const String& theme_name) const;
 
+	/// Set a custom property on the context. Custom properties can be referenced from RCSS using the var() function.
+	/// @param[in] name The variable name including the leading "--" (e.g. "--primary").
+	/// @param[in] value The value as an RCSS-valid token string (e.g. "red", "16px", "1px solid black").
+	void SetVariable(const String& name, const String& value);
+	/// Remove a custom property previously set via SetVariable. Var() lookups will then fall through
+	/// to per-document defaults (RCSS-declared) on the next Update.
+	/// @param[in] name The variable name including the leading "--".
+	void RemoveVariable(const String& name);
+	/// Look up a custom property on the context.
+	/// @param[in] name The variable name including the leading "--".
+	/// @return Pointer to the stored value string, or nullptr if no such variable exists.
+	const String* FindVariable(const String& name) const;
+
 	/// Returns the first document in the context with the given id.
 	/// @param[in] id The id of the desired document.
 	/// @return The document (if it was found), or nullptr if no document exists with the ID.
@@ -306,6 +319,8 @@ private:
 	RenderManager* render_manager;
 
 	SmallUnorderedSet<String> active_themes;
+
+	SmallUnorderedMap<String, String> custom_properties;
 
 	ContextInstancer* instancer;
 

--- a/Include/RmlUi/Core/Element.h
+++ b/Include/RmlUi/Core/Element.h
@@ -318,6 +318,12 @@ public:
 	/// Returns the element's context.
 	/// @return The context this element's document exists within.
 	Context* GetContext() const;
+
+	/// Look up a custom property visible to this element. Checks the context's variable map first
+	/// (which acts as a runtime override layer), then falls back to the owning document's variable map.
+	/// @param[in] name The variable name including the leading "--".
+	/// @return Pointer to the resolved value string, or nullptr if no such variable is in scope.
+	const String* FindVariable(const String& name) const;
 	/// Returns the element's render manager.
 	/// @return The render manager responsible for this element.
 	RenderManager* GetRenderManager() const;

--- a/Include/RmlUi/Core/ElementDocument.h
+++ b/Include/RmlUi/Core/ElementDocument.h
@@ -69,6 +69,26 @@ public:
 	/// Sets the style sheet this document, and all of its children, uses.
 	void SetStyleSheetContainer(SharedPtr<StyleSheetContainer> style_sheet);
 
+	/// Set a custom property on this document programmatically. Persists across stylesheet recompiles
+	/// (e.g. theme toggles). Shadows RCSS-declared variables of the same name.
+	/// @param[in] name The variable name including the leading "--".
+	/// @param[in] value The value as an RCSS-valid token string.
+	void SetVariable(const String& name, const String& value);
+	/// Remove a custom property previously set via SetVariable. RCSS-declared variables of the same
+	/// name remain visible via FindVariable until their containing @media block deactivates.
+	/// @param[in] name The variable name including the leading "--".
+	void RemoveVariable(const String& name);
+	/// Look up a custom property visible to this document. Programmatic values set via SetVariable
+	/// are checked first; RCSS-declared values from the active compiled stylesheet are the fallback.
+	/// @param[in] name The variable name including the leading "--".
+	/// @return Pointer to the stored value string, or nullptr if no such variable is in scope.
+	const String* FindVariable(const String& name) const;
+
+	/// Mark every var()-consuming property in this document as needing re-resolution on the next
+	/// Update. Called by Context::SetVariable so runtime theme changes propagate without the caller
+	/// having to re-set individual properties.
+	void DirtyVariableConsumers();
+
 	/// Brings the document to the front of the document stack.
 	void PullToFront();
 	/// Sends the document to the back of the document stack.
@@ -168,6 +188,12 @@ private:
 
 	bool layout_dirty;
 	bool position_dirty;
+
+	// Programmatically-set variables (via SetVariable). Persist across stylesheet recompiles.
+	SmallUnorderedMap<String, String> custom_properties;
+	// RCSS-declared variables, re-derived from the compiled stylesheet on each DirtyMediaQueries
+	// pass so values from now-inactive @media blocks disappear.
+	SmallUnorderedMap<String, String> rcss_custom_properties;
 
 	friend class Rml::Context;
 	friend class Rml::Factory;

--- a/Include/RmlUi/Core/Property.h
+++ b/Include/RmlUi/Core/Property.h
@@ -54,6 +54,9 @@ public:
 	const PropertyDefinition* definition = nullptr;
 	int parser_index = -1;
 
+	// True when the value text contains a var() reference whose typed parse is deferred to compute time.
+	bool contains_variable = false;
+
 	SharedPtr<const PropertySource> source;
 };
 

--- a/Include/RmlUi/Core/StyleSheet.h
+++ b/Include/RmlUi/Core/StyleSheet.h
@@ -57,6 +57,10 @@ public:
 	const DecoratorPtrList& InstanceDecorators(RenderManager& render_manager, const DecoratorDeclarationList& declaration_list,
 		const PropertySource* decorator_source) const;
 
+	/// Returns the custom property declarations collected from this stylesheet (any `--name: value;`
+	/// declaration encountered during parsing, regardless of which selector contained it).
+	const SmallUnorderedMap<String, String>& GetCustomProperties() const { return custom_properties; }
+
 private:
 	StyleSheet();
 
@@ -89,6 +93,9 @@ private:
 	// Cached decorator instances.
 	using DecoratorCache = UnorderedMap<String, Vector<SharedPtr<const Decorator>>>;
 	mutable DecoratorCache decorator_cache;
+
+	// Custom property (`--name: value;`) declarations collected during parsing.
+	SmallUnorderedMap<String, String> custom_properties;
 
 	friend Rml::StyleSheetParser;
 	friend Rml::StyleSheetContainer;

--- a/Samples/basic/CMakeLists.txt
+++ b/Samples/basic/CMakeLists.txt
@@ -11,6 +11,7 @@ if(RMLUI_FONT_ENGINE_ENABLED)
 	add_subdirectory("drag")
 	add_subdirectory("effects")
 	add_subdirectory("load_document")
+	add_subdirectory("rcss_variables")
 	add_subdirectory("transform")
 	add_subdirectory("tree_view")
 

--- a/Samples/basic/rcss_variables/CMakeLists.txt
+++ b/Samples/basic/rcss_variables/CMakeLists.txt
@@ -1,0 +1,12 @@
+set(SAMPLE_NAME "rcss_variables")
+set(TARGET_NAME "${RMLUI_SAMPLE_PREFIX}${SAMPLE_NAME}")
+
+add_executable(${TARGET_NAME} WIN32
+	src/main.cpp
+)
+
+set_common_target_options(${TARGET_NAME})
+
+target_link_libraries(${TARGET_NAME} PRIVATE rmlui_shell)
+
+install_sample_target(${TARGET_NAME})

--- a/Samples/basic/rcss_variables/data/rcss_variables.rml
+++ b/Samples/basic/rcss_variables/data/rcss_variables.rml
@@ -1,0 +1,507 @@
+<rml>
+<head>
+<title>RCSS variables demo</title>
+<style>
+
+/*
+    RCSS variables: context/document-scoped dialect of CSS custom properties. Not W3C CSS
+    variables (no per-element cascade or inheritance). Variables live on the document
+    (RCSS-declared) or the context (programmatic) and resolve at compute time.
+
+    Three palettes are declared in @media (theme: x) blocks below. Theme switching is via
+    Context::ActivateTheme. Context::SetVariable overrides any declared value at runtime.
+*/
+
+:root
+{
+	--bg:          #f0ebd8;
+	--surface:     #ffffff;
+	--surface-alt: #e6dfc6;
+	--fg:          #1d1d1d;
+	--muted:       #6a6a6a;
+	--primary:     #b73a2a;
+	--secondary:   #1c8a73;
+	--accent:      #d35400;
+	--border:      #c8c2a8;
+
+	--success:     #15803d;
+	--warning:     #ca8a04;
+	--info:        #1d4ed8;
+	--danger:      #b91c1c;
+
+	--radius:      10px;
+	--radius-sm:   6px;
+
+	--gap-xs:      4px;
+	--gap-sm:      8px;
+	--gap:         16px;
+	--gap-lg:      24px;
+	--gap-xl:      40px;
+
+	--text-display:  38px;
+	--text-heading:  24px;
+	--text-body:     17px;
+	--text-small:    13px;
+	--text-eyebrow:  12px;
+
+	--strip-thick:   6px;
+}
+
+@media (theme: dark)
+{
+	:root
+	{
+		/* Zinc scale: R, G, B near-equal so the greys read neutral, not navy. */
+		--bg:          #18181b;
+		--surface:     #27272a;
+		--surface-alt: #3f3f46;
+		--fg:          #f4f4f5;
+		--muted:       #a1a1aa;
+		--primary:     #f87171;
+		--secondary:   #2dd4bf;
+		--accent:      #fbbf24;
+		--border:      #52525b;
+
+		--success:     #4ade80;
+		--warning:     #f59e0b;
+		--info:        #60a5fa;
+		--danger:      #ef4444;
+	}
+}
+
+@media (theme: high-contrast)
+{
+	:root
+	{
+		--bg:          #000000;
+		--surface:     #0a0a0a;
+		--surface-alt: #1a1a1a;
+		--fg:          #ffffff;
+		--muted:       #cccccc;
+		--primary:     #ffff00;
+		--secondary:   #00ffff;
+		--accent:      #ff00ff;
+		--border:      #ffffff;
+
+		--success:     #00ff00;
+		--warning:     #ffaa00;
+		--info:        #4488ff;
+		--danger:      #ff4444;
+	}
+}
+
+body
+{
+	display: block;
+	width: 1024px;
+	height: 768px;
+	font-family: LatoLatin;
+	font-size: var(--text-body);
+	background-color: var(--bg);
+	color: var(--fg);
+	padding: var(--gap-lg);
+}
+
+.shell
+{
+	display: block;
+	width: 880px;
+	margin-left: auto;
+	margin-right: auto;
+}
+
+/* 540 + 16 (gap) + 324 = 880 (full shell width). Explicit `flex: <grow> <shrink> <basis>`
+   with zero grow/shrink so layout resolves in one pass without recalculation. */
+.row
+{
+	display: flex;
+	flex-direction: row;
+	margin-bottom: var(--gap);
+}
+
+.col-main
+{
+	flex: 0 0 540px;
+	margin-right: var(--gap);
+}
+
+.col-aside
+{
+	flex: 0 0 324px;
+}
+
+/* ---- Banner -------------------------------------------------------- */
+
+.banner
+{
+	display: block;
+	background-color: var(--primary);
+	color: var(--bg);
+	border-radius: var(--radius);
+	padding: var(--gap);
+	margin-bottom: var(--gap);
+}
+
+.banner-eyebrow
+{
+	display: block;
+	color: var(--bg);
+	font-size: var(--text-eyebrow);
+	font-weight: bold;
+	margin-bottom: var(--gap-sm);
+}
+
+.banner-title
+{
+	display: block;
+	color: var(--bg);
+	font-size: var(--text-display);
+	font-weight: bold;
+	margin-bottom: var(--gap-xs);
+}
+
+.banner-subtitle
+{
+	display: block;
+	color: var(--bg);
+	font-size: var(--text-body);
+}
+
+/* ---- Hero ---------------------------------------------------------- */
+
+.hero
+{
+	display: block;
+	background-color: var(--surface);
+	border-color: var(--border);
+	border-width: 1px;
+	border-radius: var(--radius);
+	padding: var(--gap);
+}
+
+.hero-eyebrow
+{
+	display: block;
+	color: var(--secondary);
+	font-size: var(--text-eyebrow);
+	font-weight: bold;
+	margin-bottom: var(--gap-sm);
+}
+
+.hero-heading
+{
+	display: block;
+	color: var(--fg);
+	font-size: var(--text-heading);
+	font-weight: bold;
+	margin-bottom: var(--gap-sm);
+}
+
+.hero-body
+{
+	display: block;
+	color: var(--muted);
+	font-size: var(--text-body);
+	margin-bottom: var(--gap);
+}
+
+/* ---- Buttons ------------------------------------------------------- */
+
+.button
+{
+	display: inline-block;
+	background-color: var(--primary);
+	color: var(--bg);
+	border-color: var(--primary);
+	border-width: 2px;
+	border-radius: var(--radius-sm);
+	font-size: var(--text-body);
+	font-weight: bold;
+	padding: var(--gap-sm) var(--gap);
+	margin-right: var(--gap-sm);
+	transition: background-color 0.18s, color 0.18s, border-color 0.18s;
+}
+
+.button:hover
+{
+	background-color: var(--accent);
+	color: var(--bg);
+	border-color: var(--accent);
+}
+
+.button.ghost
+{
+	background-color: transparent;
+	color: var(--fg);
+	border-color: var(--border);
+}
+
+.button.ghost:hover
+{
+	background-color: var(--surface-alt);
+	color: var(--fg);
+	border-color: var(--secondary);
+}
+
+/* ---- Alerts: showcase the semantic palette (success / warning / info / danger) ---- */
+
+.alerts
+{
+	display: block;
+	background-color: var(--surface);
+	border-color: var(--border);
+	border-width: 1px;
+	border-radius: var(--radius);
+	padding: var(--gap);
+}
+
+.alerts-title
+{
+	display: block;
+	color: var(--muted);
+	font-size: var(--text-eyebrow);
+	font-weight: bold;
+	margin-bottom: var(--gap-sm);
+}
+
+.alert
+{
+	display: block;
+	background-color: var(--surface-alt);
+	border-color: var(--border);
+	border-width: 1px;
+	border-radius: var(--radius-sm);
+	padding: var(--gap-sm);
+	margin-bottom: var(--gap-xs);
+	font-size: var(--text-small);
+	color: var(--fg);
+}
+
+.alert-dot
+{
+	display: inline-block;
+	width: 10px;
+	height: 10px;
+	border-radius: 999px;
+	margin-right: var(--gap-sm);
+}
+
+.alert.info    .alert-dot { background-color: var(--info); }
+.alert.success .alert-dot { background-color: var(--success); }
+.alert.warning .alert-dot { background-color: var(--warning); }
+.alert.danger  .alert-dot { background-color: var(--danger); }
+
+.alert-tag
+{
+	display: inline-block;
+	font-weight: bold;
+	margin-right: var(--gap-sm);
+}
+
+.alert.info    .alert-tag { color: var(--info); }
+.alert.success .alert-tag { color: var(--success); }
+.alert.warning .alert-tag { color: var(--warning); }
+.alert.danger  .alert-tag { color: var(--danger); }
+
+/* ---- Stat grid ----------------------------------------------------- */
+
+/* Flex (not inline-block) so source-text whitespace between siblings doesn't add to row
+   width. Sizes are explicit (`flex: 0 0 248px`) for one-pass resolution. */
+.stats
+{
+	display: flex;
+	flex-direction: row;
+	margin-bottom: var(--gap);
+}
+
+/* flex-basis is content width (content-box). Card outer = basis + 32 padding + 2 border = 282
+   for a basis of 248. 3 cards x 282 + 2 x 16 (gap) = 878, fits the 880 shell. */
+.stat-card
+{
+	flex: 0 0 248px;
+	background-color: var(--surface);
+	border-color: var(--border);
+	border-width: 1px;
+	border-radius: var(--radius);
+	padding: var(--gap);
+	margin-right: var(--gap);
+}
+
+.stat-card.last
+{
+	margin-right: 0;
+}
+
+.stat-label
+{
+	display: block;
+	color: var(--secondary);
+	font-size: var(--text-eyebrow);
+	font-weight: bold;
+	margin-bottom: var(--gap-xs);
+}
+
+.stat-value
+{
+	display: block;
+	color: var(--accent);
+	font-size: var(--text-display);
+	font-weight: bold;
+	margin-bottom: var(--gap-xs);
+}
+
+.stat-trend
+{
+	display: block;
+	color: var(--secondary);
+	font-size: var(--text-small);
+}
+
+/* ---- Toolbar ------------------------------------------------------- */
+
+.toolbar
+{
+	display: block;
+	background-color: var(--surface-alt);
+	border-color: var(--border);
+	border-width: 1px;
+	border-radius: var(--radius);
+	padding: var(--gap);
+	margin-bottom: var(--gap);
+}
+
+.toolbar-row
+{
+	display: block;
+}
+
+.toolbar-row.second
+{
+	margin-top: var(--gap-sm);
+}
+
+.toolbar-label
+{
+	display: inline-block;
+	color: var(--muted);
+	font-size: var(--text-eyebrow);
+	font-weight: bold;
+	margin-right: var(--gap-sm);
+}
+
+.kbd
+{
+	display: inline-block;
+	background-color: var(--bg);
+	color: var(--fg);
+	border-color: var(--border);
+	border-width: 1px;
+	border-radius: var(--radius-sm);
+	font-size: var(--text-small);
+	font-weight: bold;
+	padding: 2px var(--gap-sm);
+	margin-right: var(--gap-xs);
+}
+
+.kbd-action
+{
+	display: inline-block;
+	color: var(--fg);
+	font-size: var(--text-small);
+	margin-right: var(--gap);
+}
+
+/* ---- Footer -------------------------------------------------------- */
+
+.footer
+{
+	display: block;
+	color: var(--muted);
+	font-size: var(--text-small);
+	padding-top: var(--gap);
+	border-top-color: var(--border);
+	border-top-width: 1px;
+}
+
+</style>
+</head>
+<body>
+
+<div class="shell">
+
+	<div class="banner">
+		<div class="banner-eyebrow">SECTOR 7-G · AETHER COMMAND</div>
+		<div class="banner-title">Resupply rendezvous in progress</div>
+		<div class="banner-subtitle">Convoy ETA two hours. Shields nominal. All hands accounted for.</div>
+	</div>
+
+	<div class="row">
+		<div class="col-main">
+			<div class="hero">
+				<div class="hero-eyebrow">CURRENT MISSION</div>
+				<div class="hero-heading">Hold position until the supply convoy arrives.</div>
+				<div class="hero-body">Hover the actions below: transitions resolve var() endpoints at trigger time, so they animate the same as any other coloured transition.</div>
+				<div class="button">Continue mission</div>
+				<div class="button ghost">View briefing</div>
+			</div>
+		</div>
+		<div class="col-aside">
+			<div class="alerts">
+				<div class="alerts-title">SYSTEM STATUS</div>
+				<div class="alert info">
+					<span class="alert-dot"/><span class="alert-tag">INFO</span>Convoy ETA 14:00.
+				</div>
+				<div class="alert success">
+					<span class="alert-dot"/><span class="alert-tag">OK</span>Sector clear.
+				</div>
+				<div class="alert warning">
+					<span class="alert-dot"/><span class="alert-tag">WARN</span>Ion storm in sector 8.
+				</div>
+				<div class="alert danger">
+					<span class="alert-dot"/><span class="alert-tag">FAULT</span>Relay 4 intermittent.
+				</div>
+			</div>
+		</div>
+	</div>
+
+	<div class="stats">
+		<div class="stat-card">
+			<div class="stat-label">ENERGY</div>
+			<div class="stat-value">87%</div>
+			<div class="stat-trend">+3% over last cycle</div>
+		</div>
+		<div class="stat-card">
+			<div class="stat-label">SHIELDS</div>
+			<div class="stat-value">100%</div>
+			<div class="stat-trend">Holding at maximum</div>
+		</div>
+		<div class="stat-card last">
+			<div class="stat-label">CREW</div>
+			<div class="stat-value">42</div>
+			<div class="stat-trend">All hands accounted</div>
+		</div>
+	</div>
+
+	<div class="toolbar">
+		<div class="toolbar-row">
+			<span class="toolbar-label">THEME</span>
+			<span class="kbd">1</span><span class="kbd-action">Dark</span>
+			<span class="kbd">2</span><span class="kbd-action">Light</span>
+			<span class="kbd">3</span><span class="kbd-action">High contrast</span>
+		</div>
+		<div class="toolbar-row second">
+			<span class="toolbar-label">OVERRIDE</span>
+			<span class="kbd">R</span><span class="kbd-action">Random accent</span>
+			<span class="kbd">C</span><span class="kbd-action">Clear</span>
+			<span class="kbd">ESC</span><span class="kbd-action">Quit</span>
+		</div>
+	</div>
+
+	<div class="footer">
+		Themes declared in @media (theme: x) { :root { --vars } } blocks; Context::ActivateTheme switches between them. Context::SetVariable provides a runtime override layer.
+	</div>
+
+</div>
+
+</body>
+</rml>

--- a/Samples/basic/rcss_variables/src/main.cpp
+++ b/Samples/basic/rcss_variables/src/main.cpp
@@ -1,0 +1,165 @@
+#include <RmlUi/Core.h>
+#include <RmlUi/Debugger.h>
+#include <RmlUi_Backend.h>
+#include <Shell.h>
+#include <algorithm>
+#include <cmath>
+#include <cstdlib>
+
+/*
+    RCSS variables demo. Canonical pattern:
+    - Default palette declared at `:root` in the always-on stylesheet.
+    - Theme variants declared in `@media (theme: x) { :root { --vars } }` blocks.
+    - Theme switching at runtime via `Context::ActivateTheme(name, true/false)`.
+    - `Context::SetVariable(name, value)` for runtime customization beyond declared themes
+      (here, randomising --accent on demand via the R key).
+*/
+
+namespace {
+
+void DeactivateAllThemes(Rml::Context* context)
+{
+	context->ActivateTheme("dark", false);
+	context->ActivateTheme("high-contrast", false);
+}
+
+void ApplyTheme(Rml::Context* context, const char* theme_name)
+{
+	DeactivateAllThemes(context);
+	if (theme_name != nullptr)
+		context->ActivateTheme(theme_name, true);
+	Rml::Log::Message(Rml::Log::LT_INFO, "Active theme: %s", theme_name ? theme_name : "default");
+}
+
+// HSL → RGB. h in [0,360), s and l in [0,1]. Output channels in [0,255].
+void HslToRgb(float h, float s, float l, int& r, int& g, int& b)
+{
+	const auto channel = [&](float n) {
+		const float k = std::fmod(n + h / 30.0f, 12.0f);
+		const float a = s * std::min(l, 1.0f - l);
+		return l - a * std::max(-1.0f, std::min({k - 3.0f, 9.0f - k, 1.0f}));
+	};
+	r = static_cast<int>(std::round(channel(0) * 255.0f));
+	g = static_cast<int>(std::round(channel(8) * 255.0f));
+	b = static_cast<int>(std::round(channel(4) * 255.0f));
+}
+
+void RandomizeAccent(Rml::Context* context)
+{
+	// HSL with random hue, high saturation, and theme-shifted lightness so the random accent
+	// reads as a proper accent against the active theme's background.
+	const float hue = static_cast<float>(std::rand() % 360);
+	const float saturation = 0.78f + (std::rand() % 23) * 0.01f;
+
+	float lightness;
+	if (context->IsThemeActive("high-contrast"))
+		lightness = 0.50f;
+	else if (context->IsThemeActive("dark"))
+		lightness = 0.58f + (std::rand() % 14) * 0.01f;
+	else
+		lightness = 0.36f + (std::rand() % 14) * 0.01f;
+
+	int r, g, b;
+	HslToRgb(hue, saturation, lightness, r, g, b);
+	char buf[16];
+	std::snprintf(buf, sizeof(buf), "#%02x%02x%02x", r, g, b);
+	context->SetVariable("--accent", buf);
+	Rml::Log::Message(Rml::Log::LT_INFO, "Accent override set to %s (HSL %.0f/%.2f/%.2f, use 'C' to clear)",
+		buf, hue, saturation, lightness);
+}
+
+void ClearAccentOverride(Rml::Context* context)
+{
+	// Removing the context-level override lets resolution fall through to the RCSS-declared --accent
+	// from the active theme.
+	context->RemoveVariable("--accent");
+	Rml::Log::Message(Rml::Log::LT_INFO, "Accent override cleared, falling back to RCSS-declared value");
+}
+
+bool ProcessKey(Rml::Context* context, Rml::Input::KeyIdentifier key, int key_modifier, float native_dp_ratio, bool priority)
+{
+	switch (key)
+	{
+	case Rml::Input::KI_1:
+		ApplyTheme(context, "dark");
+		return false;
+	case Rml::Input::KI_2:
+		ApplyTheme(context, nullptr); // default :root, no @media block active
+		return false;
+	case Rml::Input::KI_3:
+		ApplyTheme(context, "high-contrast");
+		return false;
+	case Rml::Input::KI_R:
+		RandomizeAccent(context);
+		return false;
+	case Rml::Input::KI_C:
+		ClearAccentOverride(context);
+		return false;
+	case Rml::Input::KI_ESCAPE:
+		Backend::RequestExit();
+		return false;
+	default:
+		return Shell::ProcessKeyDownShortcuts(context, key, key_modifier, native_dp_ratio, priority);
+	}
+}
+
+} // namespace
+
+#if defined RMLUI_PLATFORM_WIN32
+	#include <RmlUi_Include_Windows.h>
+int APIENTRY WinMain(HINSTANCE /*instance_handle*/, HINSTANCE /*previous_instance_handle*/, char* /*command_line*/, int /*command_show*/)
+#else
+int main(int /*argc*/, char** /*argv*/)
+#endif
+{
+	const int window_width = 1024;
+	const int window_height = 768;
+
+	if (!Shell::Initialize())
+		return -1;
+
+	if (!Backend::Initialize("RCSS Variables Sample", window_width, window_height, true))
+	{
+		Shell::Shutdown();
+		return -1;
+	}
+
+	Rml::SetSystemInterface(Backend::GetSystemInterface());
+	Rml::SetRenderInterface(Backend::GetRenderInterface());
+
+	Rml::Initialise();
+
+	Rml::Context* context = Rml::CreateContext("main", Rml::Vector2i(window_width, window_height));
+	if (!context)
+	{
+		Rml::Shutdown();
+		Backend::Shutdown();
+		Shell::Shutdown();
+		return -1;
+	}
+
+	Rml::Debugger::Initialise(context);
+
+	Shell::LoadFonts();
+
+	if (Rml::ElementDocument* document = context->LoadDocument("basic/rcss_variables/data/rcss_variables.rml"))
+		document->Show();
+
+	// Open with the dark theme active so the demo lands on the most visually striking variant.
+	context->ActivateTheme("dark", true);
+
+	bool running = true;
+	while (running)
+	{
+		running = Backend::ProcessEvents(context, &ProcessKey, true);
+		context->Update();
+		Backend::BeginFrame();
+		context->Render();
+		Backend::PresentFrame();
+	}
+
+	Rml::Shutdown();
+	Backend::Shutdown();
+	Shell::Shutdown();
+	return 0;
+}

--- a/Source/Core/Context.cpp
+++ b/Source/Core/Context.cpp
@@ -417,6 +417,40 @@ bool Context::IsThemeActive(const String& theme_name) const
 	return active_themes.count(theme_name);
 }
 
+void Context::SetVariable(const String& name, const String& value)
+{
+	auto it = custom_properties.find(name);
+	const bool changed = (it == custom_properties.end() || it->second != value);
+	custom_properties[name] = value;
+
+	if (changed)
+	{
+		for (int i = 0; i < root->GetNumChildren(true); ++i)
+		{
+			if (ElementDocument* document = root->GetChild(i)->GetOwnerDocument())
+				document->DirtyVariableConsumers();
+		}
+	}
+}
+
+void Context::RemoveVariable(const String& name)
+{
+	if (custom_properties.erase(name) == 0)
+		return;
+
+	for (int i = 0; i < root->GetNumChildren(true); ++i)
+	{
+		if (ElementDocument* document = root->GetChild(i)->GetOwnerDocument())
+			document->DirtyVariableConsumers();
+	}
+}
+
+const String* Context::FindVariable(const String& name) const
+{
+	auto it = custom_properties.find(name);
+	return it == custom_properties.end() ? nullptr : &it->second;
+}
+
 ElementDocument* Context::GetDocument(const String& id)
 {
 	for (int i = 0; i < root->GetNumChildren(); i++)

--- a/Source/Core/Element.cpp
+++ b/Source/Core/Element.cpp
@@ -858,6 +858,20 @@ Context* Element::GetContext() const
 	return nullptr;
 }
 
+const String* Element::FindVariable(const String& name) const
+{
+	// Context-level variables shadow document-level ones so that programmatic context->SetVariable
+	// acts as a global runtime override above any RCSS- or API-set document defaults.
+	if (Context* context = GetContext())
+	{
+		if (const String* value = context->FindVariable(name))
+			return value;
+	}
+	if (ElementDocument* document = GetOwnerDocument())
+		return document->FindVariable(name);
+	return nullptr;
+}
+
 RenderManager* Element::GetRenderManager() const
 {
 	if (Context* context = GetContext())

--- a/Source/Core/ElementDocument.cpp
+++ b/Source/Core/ElementDocument.cpp
@@ -276,6 +276,33 @@ void ElementDocument::SetStyleSheetContainer(SharedPtr<StyleSheetContainer> _sty
 	DirtyMediaQueries();
 }
 
+void ElementDocument::SetVariable(const String& name, const String& value)
+{
+	custom_properties[name] = value;
+}
+
+const String* ElementDocument::FindVariable(const String& name) const
+{
+	if (auto it = custom_properties.find(name); it != custom_properties.end())
+		return &it->second;
+	if (auto it = rcss_custom_properties.find(name); it != rcss_custom_properties.end())
+		return &it->second;
+	return nullptr;
+}
+
+void ElementDocument::RemoveVariable(const String& name)
+{
+	if (custom_properties.erase(name) > 0)
+		DirtyVariableConsumers();
+}
+
+void ElementDocument::DirtyVariableConsumers()
+{
+	// Dirty all var()-deferred properties (stored with Unit::STRING) so they re-resolve against
+	// the current variable map on the next ComputeValues.
+	GetStyle()->DirtyPropertiesWithUnitsRecursive(Unit::STRING);
+}
+
 void ElementDocument::ReloadStyleSheet()
 {
 	if (!context)
@@ -308,8 +335,18 @@ void ElementDocument::DirtyMediaQueries()
 
 		if (changed_style_sheet)
 		{
+			// Variables from now-inactive @media blocks must drop out, so rebuild rather than merge.
+			// Programmatic values set via SetVariable live in a separate map and persist.
+			rcss_custom_properties.clear();
+			if (StyleSheet* compiled = style_sheet_container->GetCompiledStyleSheet())
+			{
+				for (const auto& kv : compiled->GetCustomProperties())
+					rcss_custom_properties[kv.first] = kv.second;
+			}
+
 			DirtyDefinition(Element::DirtyNodes::Self);
 			OnStyleSheetChangeRecursive();
+			DirtyVariableConsumers();
 		}
 	}
 }

--- a/Source/Core/ElementStyle.cpp
+++ b/Source/Core/ElementStyle.cpp
@@ -13,6 +13,7 @@
 #include "../../Include/RmlUi/Core/PropertyDictionary.h"
 #include "../../Include/RmlUi/Core/PropertyIdSet.h"
 #include "../../Include/RmlUi/Core/StyleSheet.h"
+#include "../../Include/RmlUi/Core/StringUtilities.h"
 #include "../../Include/RmlUi/Core/StyleSheetSpecification.h"
 #include "../../Include/RmlUi/Core/TransformPrimitive.h"
 #include "ComputeProperty.h"
@@ -21,6 +22,143 @@
 #include <algorithm>
 
 namespace Rml {
+
+namespace {
+
+// Returns the index of the matching ')' for the '(' immediately before start_after_paren,
+// tracking nested parens so var(--x, var(--y)) is matched correctly. npos if unmatched.
+size_t FindMatchingClosingParen(const String& value, size_t start_after_paren)
+{
+	int depth = 1;
+	for (size_t i = start_after_paren; i < value.size(); ++i)
+	{
+		const char c = value[i];
+		if (c == '(')
+			depth++;
+		else if (c == ')')
+		{
+			if (--depth == 0)
+				return i;
+		}
+	}
+	return String::npos;
+}
+
+// Expand var(--name) and var(--name, fallback) references against the variable map reachable from
+// the element. Recursive (a variable's value may itself contain var()) with cycle detection: when
+// resolution would re-enter a name already on the expansion stack, the cycle propagates via
+// `cycle_at_this_call` so the originating var() can use its fallback.
+String SubstituteVariablesImpl(const String& value, const Element* element, SmallUnorderedSet<String>& in_progress,
+	bool& cycle_at_this_call);
+
+String SubstituteVariablesImpl(const String& value, const Element* element, SmallUnorderedSet<String>& in_progress,
+	bool& cycle_at_this_call)
+{
+	if (!element)
+		return value;
+
+	String out;
+	out.reserve(value.size());
+	size_t pos = 0;
+	while (true)
+	{
+		const size_t var_start = value.find("var(", pos);
+		if (var_start == String::npos)
+		{
+			out.append(value, pos, String::npos);
+			return out;
+		}
+		out.append(value, pos, var_start - pos);
+
+		const size_t paren_end = FindMatchingClosingParen(value, var_start + 4);
+		if (paren_end == String::npos)
+		{
+			out.append(value, var_start, String::npos);
+			return out;
+		}
+
+		const String contents = value.substr(var_start + 4, paren_end - (var_start + 4));
+		const size_t comma = contents.find(',');
+		String name, fallback;
+		if (comma != String::npos)
+		{
+			name = StringUtilities::StripWhitespace(contents.substr(0, comma));
+			fallback = StringUtilities::StripWhitespace(contents.substr(comma + 1));
+		}
+		else
+		{
+			name = StringUtilities::StripWhitespace(contents);
+		}
+
+		const bool would_recurse_into_self = (in_progress.count(name) > 0);
+		const String* resolved = (would_recurse_into_self ? nullptr : element->FindVariable(name));
+
+		if (resolved)
+		{
+			in_progress.insert(name);
+			bool inner_cycle = false;
+			const String inner_result = SubstituteVariablesImpl(*resolved, element, in_progress, inner_cycle);
+			in_progress.erase(name);
+
+			if (inner_cycle && !fallback.empty())
+			{
+				bool fallback_cycle = false;
+				out.append(SubstituteVariablesImpl(fallback, element, in_progress, fallback_cycle));
+				cycle_at_this_call = cycle_at_this_call || fallback_cycle;
+			}
+			else
+			{
+				out.append(inner_result);
+				cycle_at_this_call = cycle_at_this_call || inner_cycle;
+			}
+		}
+		else if (would_recurse_into_self)
+		{
+			cycle_at_this_call = true;
+			if (!fallback.empty())
+			{
+				bool fallback_cycle = false;
+				out.append(SubstituteVariablesImpl(fallback, element, in_progress, fallback_cycle));
+				cycle_at_this_call = cycle_at_this_call || fallback_cycle;
+			}
+		}
+		else if (!fallback.empty())
+		{
+			bool fallback_cycle = false;
+			out.append(SubstituteVariablesImpl(fallback, element, in_progress, fallback_cycle));
+			cycle_at_this_call = cycle_at_this_call || fallback_cycle;
+		}
+
+		pos = paren_end + 1;
+	}
+}
+
+String SubstituteVariables(const String& value, const Element* element)
+{
+	SmallUnorderedSet<String> in_progress;
+	bool cycle = false;
+	return SubstituteVariablesImpl(value, element, in_progress, cycle);
+}
+
+// If the property's parse was deferred because it contained a var() reference, substitute and re-parse now.
+// On success, the resolved Property is written into `storage` and returned. Otherwise the original is returned.
+const Property* ResolveVariableProperty(const Property* p, PropertyId id, Element* element, Property& storage)
+{
+	if (!p || !p->contains_variable)
+		return p;
+	if (!element)
+		return p;
+
+	const String resolved_text = SubstituteVariables(p->Get<String>(), element);
+	const PropertyDefinition* def = StyleSheetSpecification::GetProperty(id);
+	if (!def)
+		return p;
+	if (def->ParseValue(storage, resolved_text))
+		return &storage;
+	return p;
+}
+
+} // namespace
 
 inline PseudoClassState operator|(PseudoClassState lhs, PseudoClassState rhs)
 {
@@ -107,6 +245,13 @@ void ElementStyle::TransitionPropertyChanges(Element* element, PropertyIdSet& pr
 				bool transition_added = false;
 				const Property* start_value = GetProperty(transition.id, element, inline_properties, old_definition);
 				const Property* target_value = GetProperty(transition.id, element, empty_properties, new_definition);
+				// Resolve var() at trigger time so the animation system stores typed endpoints
+				// it can interpolate, not raw String values the per-frame interpolator can't handle.
+				Property start_resolved, target_resolved;
+				if (start_value && start_value->contains_variable)
+					start_value = ResolveVariableProperty(start_value, transition.id, element, start_resolved);
+				if (target_value && target_value->contains_variable)
+					target_value = ResolveVariableProperty(target_value, transition.id, element, target_resolved);
 				if (start_value && target_value && (*start_value != *target_value))
 					transition_added = element->StartTransition(transition, *start_value, *target_value);
 				return transition_added;
@@ -507,7 +652,11 @@ PropertyIdSet ElementStyle::ComputeValues(Style::ComputedValues& values, const S
 	if (dirty_properties.Contains(PropertyId::FontSize))
 	{
 		if (auto p = GetLocalProperty(PropertyId::FontSize))
+		{
+			Property var_storage;
+			p = ResolveVariableProperty(p, PropertyId::FontSize, element, var_storage);
 			values.font_size(ComputeFontsize(p->GetNumericValue(), values, parent_values, document_values, dp_ratio, vp_dimensions));
+		}
 		else if (parent_values)
 			values.font_size(parent_values->font_size());
 
@@ -530,6 +679,8 @@ PropertyIdSet ElementStyle::ComputeValues(Style::ComputedValues& values, const S
 	{
 		if (auto p = GetLocalProperty(PropertyId::LineHeight))
 		{
+			Property var_storage;
+			p = ResolveVariableProperty(p, PropertyId::LineHeight, element, var_storage);
 			values.line_height(ComputeLineHeight(p, font_size, document_font_size, dp_ratio, vp_dimensions));
 		}
 		else if (parent_values)
@@ -558,6 +709,9 @@ PropertyIdSet ElementStyle::ComputeValues(Style::ComputedValues& values, const S
 		auto name_property_pair = *it;
 		const PropertyId id = name_property_pair.first;
 		const Property* p = &name_property_pair.second;
+
+		Property var_storage;
+		p = ResolveVariableProperty(p, id, element, var_storage);
 
 		if (dirty_em_properties && p->unit == Unit::EM)
 			dirty_properties.Insert(id);

--- a/Source/Core/PropertySpecification.cpp
+++ b/Source/Core/PropertySpecification.cpp
@@ -219,6 +219,16 @@ bool PropertySpecification::ParsePropertyDeclaration(PropertyDictionary& diction
 	if (!property_definition)
 		return false;
 
+	// If the value text contains a var() reference, defer typed parsing to compute time.
+	// The raw value is stored as a String and re-parsed once variable substitution has occurred.
+	if (property_value.find("var(") != String::npos)
+	{
+		Property deferred(property_value, Unit::STRING);
+		deferred.contains_variable = true;
+		dictionary.SetProperty(property_id, deferred);
+		return true;
+	}
+
 	StringList property_values;
 	ParsePropertyValues(property_values, property_value, SplitOption::None);
 	if (property_values.empty())
@@ -299,12 +309,12 @@ bool PropertySpecification::ParseShorthandDeclaration(PropertyDictionary& dictio
 		for (int i = 0; i < 4; i++)
 		{
 			RMLUI_ASSERT(shorthand_definition->items[i].type == ShorthandItemType::Property);
-			Property new_property;
-			int value_index = box_side_to_value_index[i];
-			if (!shorthand_definition->items[i].property_definition->ParseValue(new_property, property_values[value_index]))
+			const int value_index = box_side_to_value_index[i];
+			// Route through ParsePropertyDeclaration so the var() detection hook handles values like
+			// `border-color: var(--col)` or `margin: 10px var(--gap)` per-component.
+			if (!ParsePropertyDeclaration(dictionary, shorthand_definition->items[i].property_definition->GetId(),
+					property_values[value_index]))
 				return false;
-
-			dictionary.SetProperty(shorthand_definition->items[i].property_definition->GetId(), new_property);
 		}
 	}
 	else if (shorthand_definition->type == ShorthandType::RecursiveRepeat)

--- a/Source/Core/StyleSheet.cpp
+++ b/Source/Core/StyleSheet.cpp
@@ -30,6 +30,7 @@ UniquePtr<StyleSheet> StyleSheet::CombineStyleSheet(const StyleSheet& other_shee
 	new_sheet->keyframes = keyframes;
 	new_sheet->named_decorator_map = named_decorator_map;
 	new_sheet->spritesheet_list = spritesheet_list;
+	new_sheet->custom_properties = custom_properties;
 
 	new_sheet->MergeStyleSheet(other_sheet);
 
@@ -60,6 +61,10 @@ void StyleSheet::MergeStyleSheet(const StyleSheet& other_sheet)
 	spritesheet_list.Reserve(spritesheet_list.NumSpriteSheets() + other_sheet.spritesheet_list.NumSpriteSheets(),
 		spritesheet_list.NumSprites() + other_sheet.spritesheet_list.NumSprites());
 	spritesheet_list.Merge(other_sheet.spritesheet_list);
+
+	// Custom property declarations: later definitions overwrite earlier ones (same as named decorators).
+	for (const auto& kv : other_sheet.custom_properties)
+		custom_properties[kv.first] = kv.second;
 }
 
 void StyleSheet::BuildNodeIndex()

--- a/Source/Core/StyleSheetParser.cpp
+++ b/Source/Core/StyleSheetParser.cpp
@@ -134,12 +134,25 @@ private:
 	// The specification used to parse the values. Normally the default stylesheet specification, but not for e.g. all at-rules such as decorators.
 	const PropertySpecification& specification;
 
+	// Custom property (`--name: value;`) declarations collected here instead of in the typed dictionary.
+	SmallUnorderedMap<String, String> custom_properties;
+
 public:
 	PropertySpecificationParser(PropertyDictionary& properties, const PropertySpecification& specification) :
 		properties(properties), specification(specification)
 	{}
 
-	bool Parse(const String& name, const String& value) override { return specification.ParsePropertyDeclaration(properties, name, value); }
+	bool Parse(const String& name, const String& value) override
+	{
+		if (name.size() >= 2 && name[0] == '-' && name[1] == '-')
+		{
+			custom_properties[name] = value;
+			return true;
+		}
+		return specification.ParsePropertyDeclaration(properties, name, value);
+	}
+
+	const SmallUnorderedMap<String, String>& GetCustomProperties() const { return custom_properties; }
 };
 
 /*
@@ -730,6 +743,12 @@ bool StyleSheetParser::Parse(MediaBlockList& style_sheets, Stream* _stream, int 
 					PropertyDictionary properties;
 					PropertySpecificationParser parser(properties, StyleSheetSpecification::GetPropertySpecification());
 					ReadProperties(parser);
+
+					// Collect any custom property (`--name: value;`) declarations into the stylesheet's
+					// variable map. The containing selector is not significant in this dialect:
+					// variables are document/context scoped, not cascaded onto matched elements.
+					for (const auto& kv : parser.GetCustomProperties())
+						current_block.stylesheet->custom_properties[kv.first] = kv.second;
 
 					StringList rule_name_list;
 					StringUtilities::ExpandString(rule_name_list, pre_token_str, ',', '(', ')');

--- a/Tests/Source/Benchmarks/CMakeLists.txt
+++ b/Tests/Source/Benchmarks/CMakeLists.txt
@@ -11,6 +11,7 @@ add_executable(${TARGET_NAME}
 	DataBinding.cpp
 	Flexbox.cpp
 	FontEffect.cpp
+	Variables.cpp
 	WidgetTextInput.cpp
 )
 

--- a/Tests/Source/Benchmarks/Variables.cpp
+++ b/Tests/Source/Benchmarks/Variables.cpp
@@ -1,0 +1,108 @@
+#include "../Common/TestsInterface.h"
+#include <RmlUi/Core/ComputedValues.h>
+#include <RmlUi/Core/Context.h>
+#include <RmlUi/Core/Core.h>
+#include <RmlUi/Core/Element.h>
+#include <RmlUi/Core/ElementDocument.h>
+#include <RmlUi/Core/FontEngineInterface.h>
+#include <doctest.h>
+#include <nanobench.h>
+
+/*
+    Microbenchmarks for RCSS variables. Compares non-var property compute (baseline), var()-deferred
+    property compute, runtime SetVariable + Update (theme-toggle), and the no-event steady-state cost.
+*/
+
+using namespace ankerl;
+using namespace Rml;
+
+namespace {
+
+constexpr int kNumChildren = 100;
+
+String BuildBodyWithoutVars()
+{
+	String s;
+	s.reserve(kNumChildren * 80);
+	for (int i = 0; i < kNumChildren; ++i)
+		s += "<div style=\"background-color: red; color: blue; padding: 10px;\"/>";
+	return s;
+}
+
+String BuildBodyWithVars()
+{
+	String s;
+	s.reserve(kNumChildren * 90);
+	for (int i = 0; i < kNumChildren; ++i)
+		s += "<div style=\"background-color: var(--bg); color: var(--fg); padding: var(--pad);\"/>";
+	return s;
+}
+
+const String& BodyWithoutVars()
+{
+	static const String s = BuildBodyWithoutVars();
+	return s;
+}
+const String& BodyWithVars()
+{
+	static const String s = BuildBodyWithVars();
+	return s;
+}
+
+} // namespace
+
+TEST_CASE("Variables benchmark")
+{
+	TestsSystemInterface system_interface;
+	TestsRenderInterface render_interface;
+	FontEngineInterface font_interface;
+	SetRenderInterface(&render_interface);
+	SetSystemInterface(&system_interface);
+	SetFontEngineInterface(&font_interface);
+
+	Rml::Initialise();
+
+	Context* context = Rml::CreateContext("bench", Vector2i(1024, 768));
+	REQUIRE(context != nullptr);
+	ElementDocument* document = context->CreateDocument();
+	REQUIRE(document != nullptr);
+
+	context->SetVariable("--bg", "red");
+	context->SetVariable("--fg", "blue");
+	context->SetVariable("--pad", "10px");
+
+	nanobench::Bench bench;
+	bench.title("Context variables: compute and runtime cost");
+	bench.timeUnit(std::chrono::microseconds(1), "us");
+	bench.relative(true);
+	bench.minEpochIterations(20);
+
+	// Baseline: SetInnerRML with concrete property values; no var() in the property pipeline.
+	bench.run("no-vars: SetInnerRML + Update (100 divs)", [&] {
+		document->SetInnerRML(BodyWithoutVars());
+		context->Update();
+	});
+
+	// Feature path: same shape but every property uses var(), forcing the deferred-resolution path.
+	bench.run("with-vars: SetInnerRML + Update (100 divs)", [&] {
+		document->SetInnerRML(BodyWithVars());
+		context->Update();
+	});
+
+	// Pre-load var-using DOM, then measure the cost of changing one variable and re-Update.
+	document->SetInnerRML(BodyWithVars());
+	context->Update();
+
+	int toggle = 0;
+	bench.run("theme-toggle: SetVariable(--bg) + Update", [&] {
+		context->SetVariable("--bg", (toggle++ & 1) ? "red" : "blue");
+		context->Update();
+	});
+
+	// Per-frame steady-state cost: ComputeValues short-circuits when no properties are dirty.
+	bench.run("steady-state: Update with var-using DOM, no changes", [&] {
+		context->Update();
+	});
+
+	Rml::Shutdown();
+}

--- a/Tests/Source/UnitTests/Properties.cpp
+++ b/Tests/Source/UnitTests/Properties.cpp
@@ -1,9 +1,11 @@
 #include "../Common/TestsInterface.h"
+#include <RmlUi/Core/ComputedValues.h>
 #include <RmlUi/Core/Context.h>
 #include <RmlUi/Core/Core.h>
 #include <RmlUi/Core/DecorationTypes.h>
 #include <RmlUi/Core/Element.h>
 #include <RmlUi/Core/ElementDocument.h>
+#include <RmlUi/Core/FontEngineInterface.h>
 #include <RmlUi/Core/PropertyDictionary.h>
 #include <RmlUi/Core/StyleSheetSpecification.h>
 #include <RmlUi/Core/StyleSheetTypes.h>
@@ -211,6 +213,420 @@ TEST_CASE("Properties")
 			CHECK(result.ToString() == test_case.expected_parsed_string);
 			CHECK(result.Get<ColorStopList>() == test_case.expected_color_stops);
 		}
+	}
+
+	Rml::Shutdown();
+}
+
+TEST_CASE("Context custom properties")
+{
+	TestsSystemInterface system_interface;
+	TestsRenderInterface render_interface;
+	FontEngineInterface font_interface;
+	SetRenderInterface(&render_interface);
+	SetSystemInterface(&system_interface);
+	SetFontEngineInterface(&font_interface);
+
+	Rml::Initialise();
+
+	Context* context = Rml::CreateContext("main", Vector2i(1024, 768));
+	REQUIRE(context != nullptr);
+
+	SUBCASE("storage round-trip")
+	{
+		CHECK(context->FindVariable("--primary") == nullptr);
+
+		context->SetVariable("--primary", "red");
+		REQUIRE(context->FindVariable("--primary") != nullptr);
+		CHECK(*context->FindVariable("--primary") == "red");
+
+		context->SetVariable("--primary", "blue");
+		CHECK(*context->FindVariable("--primary") == "blue");
+
+		context->SetVariable("--secondary", "16px");
+		CHECK(*context->FindVariable("--primary") == "blue");
+		CHECK(*context->FindVariable("--secondary") == "16px");
+
+		CHECK(context->FindVariable("--undefined") == nullptr);
+	}
+
+	Rml::Shutdown();
+}
+
+TEST_CASE("Property var() detection")
+{
+	TestsSystemInterface system_interface;
+	TestsRenderInterface render_interface;
+	FontEngineInterface font_interface;
+	SetRenderInterface(&render_interface);
+	SetSystemInterface(&system_interface);
+	SetFontEngineInterface(&font_interface);
+
+	Rml::Initialise();
+
+	Context* context = Rml::CreateContext("main", Vector2i(1024, 768));
+	REQUIRE(context != nullptr);
+	ElementDocument* document = context->CreateDocument();
+	REQUIRE(document != nullptr);
+
+	SUBCASE("var() reference defers typed parsing")
+	{
+		REQUIRE(document->SetProperty("color", "var(--primary)"));
+		const Property* p = document->GetProperty(PropertyId::Color);
+		REQUIRE(p != nullptr);
+		CHECK(p->contains_variable == true);
+		CHECK(p->unit == Unit::STRING);
+		CHECK(p->Get<String>() == "var(--primary)");
+	}
+
+	SUBCASE("plain value parses normally")
+	{
+		REQUIRE(document->SetProperty("color", "red"));
+		const Property* p = document->GetProperty(PropertyId::Color);
+		REQUIRE(p != nullptr);
+		CHECK(p->contains_variable == false);
+		CHECK(p->unit == Unit::COLOUR);
+	}
+
+	SUBCASE("var() inside a longer value also defers")
+	{
+		REQUIRE(document->SetProperty("background-color", "var(--bg, #fff)"));
+		const Property* p = document->GetProperty(PropertyId::BackgroundColor);
+		REQUIRE(p != nullptr);
+		CHECK(p->contains_variable == true);
+		CHECK(p->Get<String>() == "var(--bg, #fff)");
+	}
+
+	Rml::Shutdown();
+}
+
+TEST_CASE("Variable resolution at compute time")
+{
+	TestsSystemInterface system_interface;
+	TestsRenderInterface render_interface;
+	FontEngineInterface font_interface;
+	SetRenderInterface(&render_interface);
+	SetSystemInterface(&system_interface);
+	SetFontEngineInterface(&font_interface);
+
+	Rml::Initialise();
+
+	Context* context = Rml::CreateContext("main", Vector2i(1024, 768));
+	REQUIRE(context != nullptr);
+	ElementDocument* document = context->CreateDocument();
+	REQUIRE(document != nullptr);
+
+	SUBCASE("simple var() substitutes into computed background-color")
+	{
+		context->SetVariable("--primary", "red");
+		REQUIRE(document->SetProperty("background-color", "var(--primary)"));
+		context->Update();
+		CHECK(document->GetComputedValues().background_color() == Colourb(255, 0, 0, 255));
+	}
+
+	SUBCASE("fallback wins when variable undefined")
+	{
+		REQUIRE(document->SetProperty("background-color", "var(--missing, blue)"));
+		context->Update();
+		CHECK(document->GetComputedValues().background_color() == Colourb(0, 0, 255, 255));
+	}
+
+	SUBCASE("named variable wins over fallback when both present")
+	{
+		context->SetVariable("--accent", "lime");
+		REQUIRE(document->SetProperty("background-color", "var(--accent, magenta)"));
+		context->Update();
+		CHECK(document->GetComputedValues().background_color() == Colourb(0, 255, 0, 255));
+	}
+
+	SUBCASE("variable value containing var() is recursively resolved")
+	{
+		context->SetVariable("--accent", "red");
+		context->SetVariable("--bg", "var(--accent)");
+		REQUIRE(document->SetProperty("background-color", "var(--bg)"));
+		context->Update();
+		CHECK(document->GetComputedValues().background_color() == Colourb(255, 0, 0, 255));
+	}
+
+	SUBCASE("cycle between two variables resolves to fallback without hanging")
+	{
+		context->SetVariable("--a", "var(--b)");
+		context->SetVariable("--b", "var(--a)");
+		REQUIRE(document->SetProperty("background-color", "var(--a, blue)"));
+		context->Update();
+		CHECK(document->GetComputedValues().background_color() == Colourb(0, 0, 255, 255));
+	}
+
+	SUBCASE("nested fallback resolves when outer variable missing")
+	{
+		context->SetVariable("--inner", "yellow");
+		REQUIRE(document->SetProperty("background-color", "var(--missing, var(--inner, magenta))"));
+		context->Update();
+		CHECK(document->GetComputedValues().background_color() == Colourb(255, 255, 0, 255));
+	}
+
+	SUBCASE("document-scoped variable resolves")
+	{
+		document->SetVariable("--doc-color", "red");
+		REQUIRE(document->SetProperty("background-color", "var(--doc-color)"));
+		context->Update();
+		CHECK(document->GetComputedValues().background_color() == Colourb(255, 0, 0, 255));
+	}
+
+	SUBCASE("context variable shadows document variable of the same name")
+	{
+		document->SetVariable("--shared", "blue");
+		context->SetVariable("--shared", "red");
+		REQUIRE(document->SetProperty("background-color", "var(--shared)"));
+		context->Update();
+		CHECK(document->GetComputedValues().background_color() == Colourb(255, 0, 0, 255));
+	}
+
+	SUBCASE("context variable visible when document has no shadowing entry")
+	{
+		context->SetVariable("--ctx-only", "red");
+		REQUIRE(document->SetProperty("background-color", "var(--ctx-only)"));
+		context->Update();
+		CHECK(document->GetComputedValues().background_color() == Colourb(255, 0, 0, 255));
+	}
+
+	Rml::Shutdown();
+}
+
+TEST_CASE("RCSS custom property declarations")
+{
+	TestsSystemInterface system_interface;
+	TestsRenderInterface render_interface;
+	FontEngineInterface font_interface;
+	SetRenderInterface(&render_interface);
+	SetSystemInterface(&system_interface);
+	SetFontEngineInterface(&font_interface);
+
+	Rml::Initialise();
+
+	Context* context = Rml::CreateContext("main", Vector2i(1024, 768));
+	REQUIRE(context != nullptr);
+
+	const String rml_source =
+		"<rml>"
+		"<head>"
+		"<style>"
+		":root { --primary: red; --spacing: 16px; }"
+		"</style>"
+		"</head>"
+		"<body/>"
+		"</rml>";
+
+	ElementDocument* document = context->LoadDocumentFromMemory(rml_source);
+	REQUIRE(document != nullptr);
+
+	SUBCASE("declarations populate the document variable map")
+	{
+		REQUIRE(document->FindVariable("--primary") != nullptr);
+		CHECK(*document->FindVariable("--primary") == "red");
+		REQUIRE(document->FindVariable("--spacing") != nullptr);
+		CHECK(*document->FindVariable("--spacing") == "16px");
+	}
+
+	SUBCASE("RCSS-declared variables resolve through var() at compute time")
+	{
+		REQUIRE(document->SetProperty("background-color", "var(--primary)"));
+		context->Update();
+		CHECK(document->GetComputedValues().background_color() == Colourb(255, 0, 0, 255));
+	}
+
+	SUBCASE("context variable overrides RCSS-declared default")
+	{
+		context->SetVariable("--primary", "blue");
+		REQUIRE(document->SetProperty("background-color", "var(--primary)"));
+		context->Update();
+		CHECK(document->GetComputedValues().background_color() == Colourb(0, 0, 255, 255));
+	}
+
+	Rml::Shutdown();
+}
+
+TEST_CASE("RCSS custom properties: @media theme integration")
+{
+	TestsSystemInterface system_interface;
+	TestsRenderInterface render_interface;
+	FontEngineInterface font_interface;
+	SetRenderInterface(&render_interface);
+	SetSystemInterface(&system_interface);
+	SetFontEngineInterface(&font_interface);
+
+	Rml::Initialise();
+
+	Context* context = Rml::CreateContext("main", Vector2i(1024, 768));
+	REQUIRE(context != nullptr);
+
+	const String rml_source =
+		"<rml>"
+		"<head>"
+		"<style>"
+		"@media (theme: dark) { :root { --primary: red; } }"
+		"</style>"
+		"</head>"
+		"<body/>"
+		"</rml>";
+
+	ElementDocument* document = context->LoadDocumentFromMemory(rml_source);
+	REQUIRE(document != nullptr);
+	REQUIRE(document->SetProperty("background-color", "var(--primary, blue)"));
+
+	SUBCASE("variable from @media block is absent when theme is inactive")
+	{
+		context->Update();
+		CHECK(document->GetComputedValues().background_color() == Colourb(0, 0, 255, 255));
+	}
+
+	SUBCASE("variable from @media block appears on activate, clears on deactivate")
+	{
+		context->ActivateTheme("dark", true);
+		context->Update();
+		CHECK(document->GetComputedValues().background_color() == Colourb(255, 0, 0, 255));
+
+		context->ActivateTheme("dark", false);
+		context->Update();
+		CHECK(document->GetComputedValues().background_color() == Colourb(0, 0, 255, 255));
+	}
+
+	SUBCASE("programmatic SetVariable persists across theme toggles")
+	{
+		document->SetVariable("--primary", "lime");
+		context->Update();
+		CHECK(document->GetComputedValues().background_color() == Colourb(0, 255, 0, 255));
+
+		context->ActivateTheme("dark", true);
+		context->Update();
+		CHECK(document->GetComputedValues().background_color() == Colourb(0, 255, 0, 255));
+
+		context->ActivateTheme("dark", false);
+		context->Update();
+		CHECK(document->GetComputedValues().background_color() == Colourb(0, 255, 0, 255));
+	}
+
+	SUBCASE("document RemoveVariable falls through to RCSS @media value")
+	{
+		document->SetVariable("--primary", "lime");
+		context->ActivateTheme("dark", true);
+		context->Update();
+		CHECK(document->GetComputedValues().background_color() == Colourb(0, 255, 0, 255));
+
+		document->RemoveVariable("--primary");
+		context->Update();
+		CHECK(document->GetComputedValues().background_color() == Colourb(255, 0, 0, 255));
+	}
+
+	Rml::Shutdown();
+}
+
+TEST_CASE("RCSS custom properties: base + @media combine correctly")
+{
+	// Regression: variables declared in an always-on :root block must survive @media block
+	// activation. CombineStyleSheet must merge custom_properties along with keyframes / decorators.
+	TestsSystemInterface system_interface;
+	TestsRenderInterface render_interface;
+	FontEngineInterface font_interface;
+	SetRenderInterface(&render_interface);
+	SetSystemInterface(&system_interface);
+	SetFontEngineInterface(&font_interface);
+
+	Rml::Initialise();
+
+	Context* context = Rml::CreateContext("main", Vector2i(1024, 768));
+	REQUIRE(context != nullptr);
+
+	const String rml_source =
+		"<rml>"
+		"<head>"
+		"<style>"
+		":root { --bg: blue; --width: 16px; }"
+		"@media (theme: dark) { :root { --bg: red; } }"
+		"</style>"
+		"</head>"
+		"<body/>"
+		"</rml>";
+
+	ElementDocument* document = context->LoadDocumentFromMemory(rml_source);
+	REQUIRE(document != nullptr);
+	REQUIRE(document->SetProperty("background-color", "var(--bg)"));
+	REQUIRE(document->SetProperty("border-top-width", "var(--width)"));
+
+	SUBCASE("base structural var survives @media activation")
+	{
+		context->ActivateTheme("dark", true);
+		context->Update();
+		// --bg overridden by @media (red), --width inherited from base (16px), must NOT vanish.
+		CHECK(document->GetComputedValues().background_color() == Colourb(255, 0, 0, 255));
+		CHECK(document->GetComputedValues().border_top_width() == 16);
+	}
+
+	SUBCASE("base structural var still present after @media deactivation")
+	{
+		context->ActivateTheme("dark", true);
+		context->Update();
+		context->ActivateTheme("dark", false);
+		context->Update();
+		// --bg falls back to base (blue), --width still from base (16px).
+		CHECK(document->GetComputedValues().background_color() == Colourb(0, 0, 255, 255));
+		CHECK(document->GetComputedValues().border_top_width() == 16);
+	}
+
+	Rml::Shutdown();
+}
+
+TEST_CASE("Variable resolution edge cases")
+{
+	TestsSystemInterface system_interface;
+	TestsRenderInterface render_interface;
+	FontEngineInterface font_interface;
+	SetRenderInterface(&render_interface);
+	SetSystemInterface(&system_interface);
+	SetFontEngineInterface(&font_interface);
+
+	Rml::Initialise();
+
+	Context* context = Rml::CreateContext("main", Vector2i(1024, 768));
+	REQUIRE(context != nullptr);
+	ElementDocument* document = context->CreateDocument();
+	REQUIRE(document != nullptr);
+
+	SUBCASE("multiple var() refs inside one function expression")
+	{
+		context->SetVariable("--r", "255");
+		context->SetVariable("--g", "128");
+		context->SetVariable("--b", "0");
+		REQUIRE(document->SetProperty("background-color", "rgb(var(--r), var(--g), var(--b))"));
+		context->Update();
+		CHECK(document->GetComputedValues().background_color() == Colourb(255, 128, 0, 255));
+	}
+
+	SUBCASE("var() inside a shorthand component is resolved per-component")
+	{
+		context->SetVariable("--col", "red");
+		REQUIRE(document->SetProperty("border-color", "var(--col)"));
+		context->Update();
+		CHECK(document->GetComputedValues().border_top_color() == Colourb(255, 0, 0, 255));
+	}
+
+	SUBCASE("Context::SetVariable triggers re-resolution on next Update")
+	{
+		// Property is set first; variable is undefined so the fallback resolves.
+		REQUIRE(document->SetProperty("background-color", "var(--late, blue)"));
+		context->Update();
+		CHECK(document->GetComputedValues().background_color() == Colourb(0, 0, 255, 255));
+
+		// Defining the variable later dirties consuming properties via DirtyVariableConsumers, so
+		// the next Update re-resolves them without the caller having to re-set the property.
+		context->SetVariable("--late", "lime");
+		context->Update();
+		CHECK(document->GetComputedValues().background_color() == Colourb(0, 255, 0, 255));
+
+		// Changing the variable to a new value also triggers re-resolution.
+		context->SetVariable("--late", "red");
+		context->Update();
+		CHECK(document->GetComputedValues().background_color() == Colourb(255, 0, 0, 255));
 	}
 
 	Rml::Shutdown();

--- a/changelog.md
+++ b/changelog.md
@@ -38,6 +38,7 @@ Introducing native touch input processing and inertial (momentum) scrolling. Thi
 
 ### RCSS
 
+- Add support for **custom properties** (`--name: value;`) and `var()` references in RCSS, as a deliberately **context/document-scoped** semantic dialect (not the W3C element-cascade model; see #517 for design rationale and #388 for the prior element-cascade attempt). Declare via `:root { --primary: red; }` in RCSS; reference via `var(--primary, fallback)` in any property value; override programmatically via `Context::SetVariable("--primary", "blue")` for runtime theme switching. Properties that do not use `var()` keep the existing parse and compute paths unchanged. Recommended pattern: pair with `@media (theme: x) { :root { --vars } }` for declarative theme palettes. #517
 - Add [`font-kerning`](https://mikke89.github.io/RmlUiDoc/pages/rcss/fonts.html#font-kerning) property. #843 (thanks @TriangulumDesire)
 - Add [`inset`](https://mikke89.github.io/RmlUiDoc/pages/rcss/visual_formatting_model.html#top_right_bottom_left) property. A shorthand for specifying the `top`, `right`, `bottom`, and `left` properties.
 - Add [`text-overflow`](https://mikke89.github.io/RmlUiDoc/pages/rcss/text.html#text-overflow) property. Includes support for ellipsis as well as custom strings. #849


### PR DESCRIPTION
Draft PR for the RCSS custom properties feature requested in #517.

The feature is a context/document-scoped dialect of CSS custom properties: same `var()` syntax, deliberately not the W3C element-cascade model that #388 implemented and was rejected on perf grounds. Properties without `var()` keep their existing parse and compute paths byte-identical to master.

### Contents

- `Add RCSS custom properties and var() references` (16 files, ~862 LOC):
  Core feature, unit tests, microbenchmark, changelog entry.
- `Add basic/rcss_variables sample` (4 files, ~685 LOC):
  Canonical-pattern demo (default `:root` + `@media (theme: x)` palettes, `ActivateTheme` switching, hover transitions over `var()`-using properties, `SetVariable` runtime override).

### Tradeoffs

Setting variables can happen only on context and on documents.
Shorthand properties will not accept `var()` as values ie. `border: 1dp var(--red)`

### Test status

7 TEST_CASEs, 123 assertions, all green on the `dev` preset (`BUILD_TESTING=ON`, freetype).

Marked Draft pending considerations in #517.

Screenshots of the sample with a basic implementation.
<img width="1023" height="774" alt="Screenshot 2026-04-26 170421" src="https://github.com/user-attachments/assets/2a3eb44e-6928-40d9-a848-d179e34e3fc7" />