### PR TITLE
Fix flex layout for direct text nodes

### DIFF
--- a/Source/Core/Layout/BlockFormattingContext.cpp
+++ b/Source/Core/Layout/BlockFormattingContext.cpp
@@ -1,6 +1,7 @@
 #include "BlockFormattingContext.h"
 #include "../../../Include/RmlUi/Core/ComputedValues.h"
 #include "../../../Include/RmlUi/Core/Element.h"
+#include "../../../Include/RmlUi/Core/ElementText.h"
 #include "../../../Include/RmlUi/Core/Profiling.h"
 #include "../../../Include/RmlUi/Core/PropertyDefinition.h"
 #include "../../../Include/RmlUi/Core/StyleSheetSpecification.h"
@@ -84,6 +85,21 @@ static OuterDisplayType GetOuterDisplayType(Style::Display display)
 	return OuterDisplayType::Invalid;
 }
 
+static bool FormatRootTextElement(BlockContainer* container, ElementText* text_element)
+{
+	// Text nodes may themselves be formatted as independent block containers, for example when they are direct children
+	// of flex containers. In that case, use the text node as the root's inline content so it generates line boxes.
+	const Vector2f containing_block = LayoutDetails::GetContainingBlock(container, text_element->GetPosition()).size;
+
+	Box box;
+	LayoutDetails::BuildBox(box, containing_block, text_element, BuildBoxMode::Inline);
+
+	const InlineBoxHandle inline_box_handle = container->AddInlineElement(text_element, box);
+	container->CloseInlineElement(inline_box_handle);
+
+	return true;
+}
+
 UniquePtr<LayoutBox> BlockFormattingContext::Format(ContainerBox* parent_container, Element* element, const Box* override_initial_box)
 {
 	RMLUI_ASSERT(parent_container && element);
@@ -116,6 +132,13 @@ UniquePtr<LayoutBox> BlockFormattingContext::Format(ContainerBox* parent_contain
 	for (int layout_iteration = 0; layout_iteration < 3; layout_iteration++)
 	{
 		bool all_children_formatted = true;
+
+		if (auto text_element = rmlui_dynamic_cast<ElementText*>(element))
+		{
+			if (!FormatRootTextElement(container.get(), text_element))
+				all_children_formatted = false;
+		}
+
 		for (int i = 0; i < element->GetNumChildren() && all_children_formatted; i++)
 		{
 			if (!FormatBlockContainerChild(container.get(), element->GetChild(i)))

--- a/Tests/Source/UnitTests/FlexFormatting.cpp
+++ b/Tests/Source/UnitTests/FlexFormatting.cpp
@@ -3,6 +3,7 @@
 #include <RmlUi/Core/Core.h>
 #include <RmlUi/Core/Element.h>
 #include <RmlUi/Core/ElementDocument.h>
+#include <RmlUi/Core/ElementText.h>
 #include <doctest.h>
 
 using namespace Rml;
@@ -170,6 +171,78 @@ TEST_CASE("FlexFormatting.dp_ratio")
 		CHECK(window->GetBox().GetSize().x == window_width);
 		CHECK(window->GetBox().GetSize().y == doctest::Approx((window_width / native_width) * native_height));
 	}
+
+	document->Close();
+
+	TestsShell::ShutdownShell();
+}
+
+static const String document_flex_text_items_rml = R"(
+<rml>
+<head>
+	<link type="text/rcss" href="/assets/rml.rcss"/>
+	<style>
+		body {
+			width: 400px;
+			height: 300px;
+			font-family: LatoLatin;
+			font-size: 20px;
+			line-height: 24px;
+		}
+		.flex {
+			display: flex;
+			align-items: center;
+			justify-content: center;
+			width: 180px;
+			height: 80px;
+		}
+		.wrap {
+			width: 72px;
+			justify-content: flex-start;
+		}
+	</style>
+</head>
+<body>
+	<div id="direct" class="flex">Direct text</div>
+	<div id="wrapped" class="flex"><span id="wrapped_span">Direct text</span></div>
+	<div id="direct_wrap" class="flex wrap">Alpha beta gamma</div>
+</body>
+</rml>
+)";
+
+TEST_CASE("FlexFormatting.text_items")
+{
+	Context* context = TestsShell::GetContext();
+	REQUIRE(context);
+
+	ElementDocument* document = context->LoadDocumentFromMemory(document_flex_text_items_rml);
+	REQUIRE(document);
+	document->Show();
+
+	TestsShell::RenderLoop();
+
+	Element* direct = document->GetElementById("direct");
+	Element* wrapped_span = document->GetElementById("wrapped_span");
+	Element* direct_wrap = document->GetElementById("direct_wrap");
+	REQUIRE(direct);
+	REQUIRE(wrapped_span);
+	REQUIRE(direct_wrap);
+
+	REQUIRE(direct->GetNumChildren() == 1);
+	ElementText* direct_text = rmlui_dynamic_cast<ElementText*>(direct->GetChild(0));
+	ElementText* wrapped_text = rmlui_dynamic_cast<ElementText*>(wrapped_span->GetChild(0));
+	ElementText* direct_wrap_text = rmlui_dynamic_cast<ElementText*>(direct_wrap->GetChild(0));
+	REQUIRE(direct_text);
+	REQUIRE(wrapped_text);
+	REQUIRE(direct_wrap_text);
+
+	REQUIRE(direct_text->GetLines().size() == 1);
+	REQUIRE(wrapped_text->GetLines().size() == 1);
+	CHECK(direct_text->GetLines()[0].text == wrapped_text->GetLines()[0].text);
+	CHECK(direct_text->GetBox().GetSize().x == doctest::Approx(wrapped_span->GetBox().GetSize().x));
+	CHECK(direct_text->GetBox().GetSize().y == doctest::Approx(wrapped_span->GetBox().GetSize().y));
+
+	CHECK(direct_wrap_text->GetLines().size() > 1);
 
 	document->Close();
 


### PR DESCRIPTION
CSS flexbox treats text nodes as anonymous block-container flex items. RmlUi already formatted flex children through an independent block formatting context, but when that child was an `ElementText`, the block formatter only walked children and never seeded the text node itself into inline layout. As a result, the text generated no line boxes unless it was wrapped in an element such as `<span>`.

This updates block formatting so a root `ElementText` can format itself as inline content within its block container.

Unit test added.