### PR TITLE
Include trailing flex overflow in scroll size

### DIFF
--- a/Source/Core/Layout/ContainerBox.cpp
+++ b/Source/Core/Layout/ContainerBox.cpp
@@ -196,7 +196,8 @@ bool ContainerBox::SubmitBox(const Vector2f content_overflow_size, const Box& bo
 		element->SetBox(box);
 
 		// Scrollable overflow is the set of things extending our padding area, for which scrolling could be provided.
-		const Vector2f scrollable_overflow_size = Math::Max(padding_size - scrollbar_size, padding_top_left + content_overflow_size);
+		const Vector2f scrollable_content_size = padding_top_left + content_overflow_size + padding_bottom_right;
+		const Vector2f scrollable_overflow_size = Math::Max(padding_size - scrollbar_size, scrollable_content_size);
 		// Set the overflow size but defer clamping of the scroll offset, see `LayoutEngine::FormatElement`.
 		element->SetScrollableOverflowRectangle(scrollable_overflow_size, false);
 

--- a/Source/Core/Layout/FlexFormattingContext.cpp
+++ b/Source/Core/Layout/FlexFormattingContext.cpp
@@ -959,8 +959,9 @@ void FlexFormattingContext::Format(Vector2f& flex_resulting_content_size, Vector
 				baseline_set = true;
 			}
 
-			// The cell contents may overflow, propagate this to the flex container.
-			const Vector2f overflow_size = item_offset + item_layout_box->GetVisibleOverflowSize();
+			// The item and its contents may overflow, propagate this to the flex container.
+			const Vector2f item_margin_overflow_size = item.box.GetPosition(BoxArea::Margin) + item.box.GetSize(BoxArea::Margin);
+			const Vector2f overflow_size = item_offset + Math::Max(item_layout_box->GetVisibleOverflowSize(), item_margin_overflow_size);
 
 			flex_content_overflow_size = Math::Max(flex_content_overflow_size, overflow_size);
 		}

--- a/Tests/Source/UnitTests/FlexFormatting.cpp
+++ b/Tests/Source/UnitTests/FlexFormatting.cpp
@@ -175,3 +175,101 @@ TEST_CASE("FlexFormatting.dp_ratio")
 
 	TestsShell::ShutdownShell();
 }
+
+static const String document_flex_scrollable_overflow_rml = R"(
+<rml>
+<head>
+	<link type="text/rcss" href="/assets/rml.rcss"/>
+	<style>
+		body {
+			width: 400px;
+			height: 300px;
+		}
+		.scroller {
+			display: flex;
+		}
+		.vertical {
+			flex-direction: column;
+			overflow-x: hidden;
+			overflow-y: auto;
+			width: 100px;
+			height: 80px;
+		}
+		.horizontal {
+			flex-direction: row;
+			overflow-x: auto;
+			overflow-y: hidden;
+			width: 80px;
+			height: 100px;
+		}
+		.item {
+			flex-shrink: 0;
+			width: 20px;
+			height: 100px;
+		}
+		.horizontal .item {
+			width: 100px;
+			height: 20px;
+		}
+		#padding_scroller {
+			padding-top: 7px;
+			padding-bottom: 13px;
+		}
+		#margin_item {
+			margin-bottom: 17px;
+		}
+		#horizontal_padding_scroller {
+			padding-left: 7px;
+			padding-right: 13px;
+		}
+		#horizontal_margin_item {
+			margin-right: 17px;
+		}
+	</style>
+</head>
+<body>
+	<div id="padding_scroller" class="scroller vertical">
+		<div class="item"/>
+	</div>
+	<div id="margin_scroller" class="scroller vertical">
+		<div id="margin_item" class="item"/>
+	</div>
+	<div id="horizontal_padding_scroller" class="scroller horizontal">
+		<div class="item"/>
+	</div>
+	<div id="horizontal_margin_scroller" class="scroller horizontal">
+		<div id="horizontal_margin_item" class="item"/>
+	</div>
+</body>
+</rml>
+)";
+
+TEST_CASE("FlexFormatting.scrollable_overflow")
+{
+	Context* context = TestsShell::GetContext();
+	REQUIRE(context);
+
+	ElementDocument* document = context->LoadDocumentFromMemory(document_flex_scrollable_overflow_rml);
+	REQUIRE(document);
+	document->Show();
+
+	TestsShell::RenderLoop();
+
+	Element* padding_scroller = document->GetElementById("padding_scroller");
+	Element* margin_scroller = document->GetElementById("margin_scroller");
+	Element* horizontal_padding_scroller = document->GetElementById("horizontal_padding_scroller");
+	Element* horizontal_margin_scroller = document->GetElementById("horizontal_margin_scroller");
+	REQUIRE(padding_scroller);
+	REQUIRE(margin_scroller);
+	REQUIRE(horizontal_padding_scroller);
+	REQUIRE(horizontal_margin_scroller);
+
+	CHECK(padding_scroller->GetScrollHeight() == doctest::Approx(120.f));
+	CHECK(margin_scroller->GetScrollHeight() == doctest::Approx(117.f));
+	CHECK(horizontal_padding_scroller->GetScrollWidth() == doctest::Approx(120.f));
+	CHECK(horizontal_margin_scroller->GetScrollWidth() == doctest::Approx(117.f));
+
+	document->Close();
+
+	TestsShell::ShutdownShell();
+}


### PR DESCRIPTION
Fixes scrollable flex containers so trailing padding and flex item margins are included in the scrollable overflow size.

Previously, scrollable overflow only added the container's leading padding to child overflow, so trailing padding was not reachable when scrolling to the end. Flex item margins were also not included in the propagated overflow size. Before this patch, I needed to add explicit trailing spacer elements to get the expected trailing space.

Unit test added.