### PR TITLE
Fix LuaDataModel

### DIFF
--- a/Samples/lua_invaders/data/options.rml
+++ b/Samples/lua_invaders/data/options.rml
@@ -33,7 +33,7 @@ if Options.datamodel == nil then
 		options_changed = false,
 		audios = {
 			{id="reverb", label="Reverb", checked=true},
-			{id="3d", label="3D Spatialisation"},
+			{id="3d", label="3D Spatialisation", checked=false},
 		}
 	})
 end

--- a/Samples/lua_invaders/data/options.rml
+++ b/Samples/lua_invaders/data/options.rml
@@ -38,6 +38,11 @@ if Options.datamodel == nil then
 	})
 end
 
+function Options.CloseDataModel()
+	rmlui.contexts["main"]:CloseDataModel("options")
+	Options.datamodel = nil
+end
+
 function Options.Serialize(filename,options)
 	local file,message = io.open(filename,'w+') --w+ will erase the previous data
 	if file == nil then Log.Message(Log.logtype.error, "Error saving options in options.rml: " .. message) return end
@@ -97,8 +102,8 @@ function Options.SaveOptions(event)
 end
 	</script>
 	</head>
-	<body template="luawindow" onload="Window.OnWindowLoad(document) Options.LoadOptions(document)" onkeydown="if Window.EscapePressed(event) then Window.LoadMenu('main_menu',document) end">
-		<form data-model="options" onsubmit="Options.SaveOptions(event) Window.LoadMenu('main_menu',document)" data-event-change="options_changed = true">
+	<body template="luawindow" onload="Window.OnWindowLoad(document) Options.LoadOptions(document)" onkeydown="if Window.EscapePressed(event) then Options.CloseDataModel() Window.LoadMenu('main_menu',document) end">
+		<form data-model="options" onsubmit="Options.SaveOptions(event) Options.CloseDataModel() Window.LoadMenu('main_menu',document)" data-event-change="options_changed = true">
 			<div>
 				<p>
 					Graphics<br />
@@ -110,7 +115,7 @@ end
 				<p>
 					Audio<br />
 					<span data-for="audio : audios">
-						<label><input data-attr-id="audio.id" type="checkbox" data-attr-name="audio.id" data-attrif-checked="audio.checked" /> {{audio.label}}</label><br />
+						<label><input data-attr-id="audio.id" type="checkbox" data-attr-name="audio.id" data-checked="audio.checked" /> {{audio.label}}</label><br />
 					</span>
 				</p>
 			</div>

--- a/Source/Lua/Context.cpp
+++ b/Source/Lua/Context.cpp
@@ -108,6 +108,12 @@ int ContextOpenDataModel(lua_State* L, Context* obj)
 	return 1;
 }
 
+int ContextCloseDataModel(lua_State* L, Context* obj)
+{
+	CloseLuaDataModel(L, obj, 1);
+	return 0;
+}
+
 // input
 int ContextProcessMouseMove(lua_State* L, Context* obj)
 {
@@ -278,7 +284,7 @@ RegType<Context> ContextMethods[] = {
 	RMLUI_LUAMETHOD(Context, UnloadDocument),
 	RMLUI_LUAMETHOD(Context, Update),
 	RMLUI_LUAMETHOD(Context, OpenDataModel),
-	// todo: CloseDataModel
+	RMLUI_LUAMETHOD(Context, CloseDataModel),
 	RMLUI_LUAMETHOD(Context, ProcessMouseMove),
 	RMLUI_LUAMETHOD(Context, ProcessMouseButtonDown),
 	RMLUI_LUAMETHOD(Context, ProcessMouseButtonUp),

--- a/Source/Lua/LuaDataModel.cpp
+++ b/Source/Lua/LuaDataModel.cpp
@@ -87,166 +87,261 @@ inline bool invoke(lua_State* L, call_t f, int argn = 0)
 }
 } // namespace luabind
 
-class LuaScalarDef;
-class LuaTableDef;
+class LuaObjectDef;
 
 struct LuaDataModel {
 	DataModelConstructor constructor;
 	DataModelHandle handle;
-	lua_State* dataL;
-	LuaScalarDef* scalarDef;
-	LuaTableDef* tableDef;
-	int top;
+	lua_State* L;
+	LuaObjectDef* objectDef;
+	int model_ref = LUA_NOREF;
+	int valuestore_ref = LUA_NOREF;
+	int tablestore_ref = LUA_NOREF;
 };
 
-class LuaTableDef : public VariableDefinition {
+class LuaObjectDef : public VariableDefinition {
 public:
-	LuaTableDef(const struct LuaDataModel* model);
+	LuaObjectDef(struct LuaDataModel* model);
 	bool Get(void* ptr, Variant& variant) override;
 	bool Set(void* ptr, const Variant& variant) override;
 	int Size(void* ptr) override;
 	DataVariable Child(void* ptr, const DataAddressEntry& address) override;
 
 protected:
-	const struct LuaDataModel* model;
+	struct LuaDataModel* model;
 };
 
-class LuaScalarDef final : public LuaTableDef {
-public:
-	LuaScalarDef(const struct LuaDataModel* model);
-	DataVariable Child(void* ptr, const DataAddressEntry& address) override;
-};
-
-LuaTableDef::LuaTableDef(const struct LuaDataModel* model) : VariableDefinition(DataVariableType::Scalar), model(model) {}
-
-bool LuaTableDef::Get(void* ptr, Variant& variant)
+void PushValue(struct LuaDataModel* model, int ref)
 {
-	lua_State* L = model->dataL;
-	if (!L)
-		return false;
-	int id = (int)(intptr_t)ptr;
-	GetVariant(L, id, &variant);
-	return true;
+	lua_State* L = model->L;
+	lua_rawgeti(L, LUA_REGISTRYINDEX, model->valuestore_ref);
+	lua_rawgeti(L, -1, ref);
+	lua_replace(L, -2);
 }
 
-bool LuaTableDef::Set(void* ptr, const Variant& variant)
+void SetValue(struct LuaDataModel* model, int ref)
 {
-	int id = (int)(intptr_t)ptr;
-	lua_State* L = model->dataL;
-	if (!L)
-		return false;
-	PushVariant(L, &variant);
-	lua_replace(L, id);
-	return true;
+	// -1 = value
+	lua_State* L = model->L;
+	lua_rawgeti(L, LUA_REGISTRYINDEX, model->valuestore_ref);
+	lua_pushvalue(L, -2);
+	lua_rawseti(L, -2, ref);
+	lua_pop(L, 2);
 }
 
-static int lLuaTableDefSize(lua_State* L)
+int ChildRef(struct LuaDataModel* model, int ref)
 {
-	lua_pushinteger(L, luaL_len(L, 1));
-	return 1;
-}
+	// -1 = key
+	lua_State* L = model->L;
+	lua_rawgeti(L, LUA_REGISTRYINDEX, model->tablestore_ref);
+	// -1 = tablestore, -2 = key
+	lua_rawgeti(L, -1, ref);
+	// -1 = tablestore entry / nil, -2 = tablestore, -3 = key
+	lua_replace(L, -2);
+	// -1 = tablestore entry / nil, -2 = key
 
-static int lLuaTableDefChild(lua_State* L)
-{
-	lua_gettable(L, 1);
-	return 1;
-}
-
-int LuaTableDef::Size(void* ptr)
-{
-	lua_State* L = model->dataL;
-	if (!L)
-		return 0;
-	int id = (int)(intptr_t)ptr;
-	if (lua_type(L, id) != LUA_TTABLE)
-	{
-		return 0;
-	}
-	if (!lua_checkstack(L, 4))
-	{
-		return 0;
-	}
-	lua_pushcfunction(L, lLuaTableDefSize);
-	lua_pushvalue(L, id);
-	if (LUA_OK != lua_pcall(L, 1, 1, 0))
+	if (lua_type(L, -1) != LUA_TTABLE)
 	{
 		lua_pop(L, 1);
-		return 0;
+		// -1 = key;
+		return LUA_REFNIL;
 	}
-	int size = (int)lua_tointeger(L, -1);
+
+	lua_pushvalue(L, -2);
+	// -1 = key, -2 = tablestore entry, -3 = key
+	lua_rawget(L, -2);
+	// -1 = child ref / nil, -2 = tablestore entry, -3 = key
+
+	if (lua_isnil(L, -1))
+	{
+		lua_pop(L, 2);
+		// -1 = key;
+		return LUA_REFNIL;
+	}
+
+	int child_ref = (int)lua_tonumber(L, -1);
+	lua_pop(L, 2);
+	// -1 = key;
+	return child_ref;
+}
+
+LuaObjectDef::LuaObjectDef(struct LuaDataModel* model) : VariableDefinition(DataVariableType::Scalar), model(model) {}
+
+bool LuaObjectDef::Get(void* ptr, Variant& variant)
+{
+	lua_State* L = model->L;
+	if (!L)
+		return false;
+	int ref = (int)(intptr_t)ptr;
+	PushValue(model, ref);
+	GetVariant(L, -1, &variant);
+	lua_pop(L, 1);
+	return true;
+}
+
+bool LuaObjectDef::Set(void* ptr, const Variant& variant)
+{
+	int ref = (int)(intptr_t)ptr;
+	lua_State* L = model->L;
+	if (!L || ref == LUA_REFNIL)
+		return false;
+	PushVariant(L, &variant);
+	SetValue(model, ref);
+	return true;
+}
+
+int LuaObjectDef::Size(void* ptr)
+{
+	lua_State* L = model->L;
+	if (!L)
+		return 0;
+	int ref = (int)(intptr_t)ptr;
+	PushValue(model, ref);
+
+	int size = lua_type(L, -1) == LUA_TTABLE ? (int)luaL_len(L, -1) : 1;
 	lua_pop(L, 1);
 	return size;
 }
 
-DataVariable LuaTableDef::Child(void* ptr, const DataAddressEntry& address)
+DataVariable LuaObjectDef::Child(void* ptr, const DataAddressEntry& address)
 {
-	lua_State* L = model->dataL;
+	lua_State* L = model->L;
 	if (!L)
 		return DataVariable{};
-	int id = (int)(intptr_t)ptr;
-	if (lua_type(L, id) != LUA_TTABLE)
-	{
-		return DataVariable{};
-	}
-	if (!lua_checkstack(L, 4))
-	{
-		return DataVariable{};
-	}
-	lua_pushcfunction(L, lLuaTableDefChild);
-	lua_pushvalue(L, id);
+	int ref = (int)(intptr_t)ptr;
+
 	if (address.index == -1)
-	{
 		lua_pushlstring(L, address.name.data(), address.name.size());
-	}
 	else
-	{
 		lua_pushinteger(L, (lua_Integer)address.index + 1);
+	// -1 = key
+
+	int child_ref = ChildRef(model, ref);
+
+	// FIXME: Need to swap tables for proxies to the tables which get and set
+	// values in the valuestore by child ref, rather than get and set nested
+	// values within the table in the valuestore by the table's ref, which is what
+	// happens in Lua (but not Rml) with both the current registry-based and
+	// previous thread-based implementations, so the Lua and Rml get out of sync.
+	// In the previous implementation, this problem wasn't visible in the
+	// lua_invaders sample because the Lua only writes to the data model when
+	// closing the options window and, on reopening, a new child value was copied
+	// to the stack. For now, imitate this behaviour by creating a new child ref
+	// even if one already exists.
+
+	// if (child_ref != LUA_REFNIL)
+	// {
+	// 	lua_pop(L, 1);
+	// 	return DataVariable(model->objectDef, (void*)(intptr_t)child_ref);
+	// }
+
+	PushValue(model, ref);
+	// -1 = this table, -2 = key
+
+	if (lua_type(L, -1) != LUA_TTABLE)
+	{
+		lua_pop(L, 2);
+		return DataVariable{};
 	}
-	if (LUA_OK != lua_pcall(L, 2, 1, 0))
+
+	lua_pushvalue(L, -2);
+	// -1 = key, -2 = this table, -3 = key
+	lua_gettable(L, -2);
+	// -1 = value, -2 = this table, -3 = key
+	lua_replace(L, -2);
+	// -1 = value, -2 = key
+
+	if (lua_isnil(L, -1))
+	{
+		lua_pop(L, 2);
+		return DataVariable{};
+	}
+
+	lua_rawgeti(L, LUA_REGISTRYINDEX, model->valuestore_ref);
+	// -1 = valuestore, -2 = value, -3 = key
+	lua_pushvalue(L, -2);
+	// -1 = value, -2 = valuestore, -3 = value, -4 = key
+	child_ref = luaL_ref(L, -2);
+	// -1 = valuestore, -2 = value, -3 = key
+	lua_pop(L, 2);
+	// -1 = key
+
+	lua_rawgeti(L, LUA_REGISTRYINDEX, model->tablestore_ref);
+	// -1 = tablestore, -2 = key
+	lua_rawgeti(L, -1, ref);
+	// -1 = tablestore entry / nil, -2 = tablestore, -3 = key
+
+	if (lua_type(L, -1) != LUA_TTABLE)
 	{
 		lua_pop(L, 1);
-		return DataVariable{};
+		// -1 = tablestore, -2 = key
+		lua_newtable(L);
+		// -1 = tablestore entry, -2 = tablestore, -3 = key
+		lua_pushvalue(L, -1);
+		// -1 = tablestore entry, -2 = tablestore entry, -3 = tablestore, -4 = key
+		lua_rawseti(L, -3, ref);
+		// -1 = tablestore entry, -2 = tablestore, -3 = key
 	}
-	return DataVariable(model->tableDef, (void*)(intptr_t)lua_gettop(L));
+
+	lua_replace(L, -2);
+	// -1 = tablestore entry, -2 = key
+
+	lua_pushvalue(L, -2);
+	// -1 = key, -2 = tablestore entry, -3 = key
+	lua_pushnumber(L, child_ref);
+	// -1 = child ref, -2 = key, -3 = tablestore entry, -4 = key
+	lua_rawset(L, -3);
+	// -1 = tablestore entry, -2 = key
+	lua_pop(L, 2);
+
+	return DataVariable(model->objectDef, (void*)(intptr_t)child_ref);
 }
 
-LuaScalarDef::LuaScalarDef(const struct LuaDataModel* model) : LuaTableDef(model) {}
-
-DataVariable LuaScalarDef::Child(void* ptr, const DataAddressEntry& address)
+static void BindVariable(struct LuaDataModel* model)
 {
-	lua_State* L = model->dataL;
-	if (!L)
-		return DataVariable{};
-	lua_settop(L, model->top);
-	return LuaTableDef::Child(ptr, address);
-}
+	// -1 = value, -2 = key
+	lua_State* L = model->L;
 
-static void BindVariable(struct LuaDataModel* D, lua_State* L)
-{
-	lua_State* dataL = D->dataL;
-	if (!lua_checkstack(dataL, 4))
-	{
-		luaL_error(L, "Memory Error");
-	}
-	int id = lua_gettop(dataL) + 1;
-	D->top = id;
-	// L top : key value
-	lua_xmove(L, dataL, 1); // move value to dataL with index(id)
-	lua_pushvalue(L, -1);   // dup key
-	lua_xmove(L, dataL, 1);
-	lua_pushinteger(dataL, id);
-	lua_rawset(dataL, 1);
+	lua_rawgeti(L, LUA_REGISTRYINDEX, model->valuestore_ref);
+	// -1 = valuestore, -2 = value, -3 = key
+	lua_pushvalue(L, -2);
+	// -1 = value, -2 = valuestore, -3 = value, -4 = key
+	int ref = luaL_ref(L, -2);
+	// -1 = valuestore, -2 = value, -3 = key
+	lua_pop(L, 1);
+	// -1 = value, -2 = key
+
+	lua_rawgeti(L, LUA_REGISTRYINDEX, model->tablestore_ref);
+	// -1 = tablestore, -2 = value, -3 = key
+	lua_rawgeti(L, -1, model->model_ref);
+	// -1 = tablestore entry, -2 = tablestore, -2 = value, -3 = key
+	lua_replace(L, -2);
+	// -1 = tablestore entry, -2 = value, -3 = key
+	lua_pushvalue(L, -3);
+	// -1 = key, -2 = tablestore entry, -3 = value, -4 = key
+	lua_pushnumber(L, ref);
+	// -1 = ref, -2 = key, -3 = tablestore entry, -4 = value, -5 = key
+	lua_rawset(L, -3);
+	// -1 = tablestore entry, -2 = value, -3 = key
+	lua_pop(L, 1);
+	// -1 = value, -2 = key
+
+	// Root data model variable names are assumed to be strings. But lua_tostring
+	// actually converts the value on the stack to a string, which can cause a
+	// problem for lua_next. So call it on a copy, just to be safe.
+	lua_pushvalue(L, -2);
 	const char* key = lua_tostring(L, -1);
-	if (lua_type(dataL, D->top) == LUA_TFUNCTION)
+	lua_pop(L, 1);
+
+	if (lua_type(L, -1) == LUA_TFUNCTION)
 	{
-		D->constructor.BindEventCallback(key, [=](DataModelHandle, Event& event, const VariantList& varlist) {
-			lua_pushvalue(dataL, id);
-			lua_xmove(dataL, L, 1);
+		model->constructor.BindEventCallback(key, [=](DataModelHandle, Event& event, const VariantList& varlist) {
+			PushValue(model, ref);
 			luabind::invoke(
 				L,
 				[&]() {
 					LuaType<Event>::push(L, &event, false);
-					for (auto const& variant : varlist)
+					for (const auto& variant : varlist)
 					{
 						PushVariant(L, &variant);
 					}
@@ -257,59 +352,63 @@ static void BindVariable(struct LuaDataModel* D, lua_State* L)
 	}
 	else
 	{
-		D->constructor.BindCustomDataVariable(key, DataVariable(D->scalarDef, (void*)(intptr_t)id));
+		model->constructor.BindCustomDataVariable(key, DataVariable(model->objectDef, (void*)(intptr_t)ref));
 	}
-}
-
-static int getId(lua_State* L, lua_State* dataL)
-{
-	lua_pushvalue(dataL, 1);
-	lua_xmove(dataL, L, 1);
-	lua_pushvalue(L, 2);
-	lua_rawget(L, -2);
-	if (lua_type(L, -1) != LUA_TNUMBER)
-	{
-		luaL_error(L, "DataModel has no key : %s", lua_tostring(L, 2));
-	}
-	int id = (int)lua_tointeger(L, -1);
-	lua_pop(L, 2);
-	return id;
 }
 
 static int lDataModelGet(lua_State* L)
 {
-	struct LuaDataModel* D = (struct LuaDataModel*)lua_touserdata(L, 1);
-	lua_State* dataL = D->dataL;
-	if (dataL == nullptr)
+	// 1 = data model, 2 = key
+	struct LuaDataModel* model = (struct LuaDataModel*)lua_touserdata(L, 1);
+	if (model->model_ref == LUA_NOREF)
+	{
 		luaL_error(L, "DataModel closed");
-	int id = getId(L, dataL);
-	lua_pushvalue(dataL, id);
-	lua_xmove(dataL, L, 1);
+		return 0;
+	}
+
+	lua_pushvalue(L, 2);
+	int child_ref = ChildRef(model, model->model_ref);
+	lua_pop(L, 1);
+
+	if (child_ref == LUA_REFNIL)
+	{
+		lua_pushnil(L);
+		return 1;
+	}
+
+	lua_rawgeti(L, LUA_REGISTRYINDEX, model->valuestore_ref);
+	lua_rawgeti(L, -1, child_ref);
+
 	return 1;
 }
 
 static int lDataModelSet(lua_State* L)
 {
-	struct LuaDataModel* D = (struct LuaDataModel*)lua_touserdata(L, 1);
-	lua_State* dataL = D->dataL;
-	if (dataL == NULL)
-		luaL_error(L, "DataModel released");
-	lua_settop(dataL, D->top);
-
-	lua_pushvalue(L, 2);
-	lua_xmove(L, dataL, 1);
-	lua_rawget(dataL, 1);
-	if (lua_type(dataL, -1) == LUA_TNUMBER)
+	// 1 = data model, 2 = key, 3 = value
+	struct LuaDataModel* model = (struct LuaDataModel*)lua_touserdata(L, 1);
+	if (model->model_ref == LUA_NOREF)
 	{
-		int id = (int)lua_tointeger(dataL, -1);
-		lua_pop(dataL, 1);
-		lua_xmove(L, dataL, 1);
-		lua_replace(dataL, id);
-		D->handle.DirtyVariable(lua_tostring(L, 2));
+		luaL_error(L, "DataModel closed");
 		return 0;
 	}
-	lua_pop(dataL, 1);
-	BindVariable(D, L);
+
+	lua_pushvalue(L, 2);
+	int child_ref = ChildRef(model, model->model_ref);
+	lua_pop(L, 1);
+
+	if (child_ref == LUA_REFNIL)
+	{
+		BindVariable(model);
+		return 0;
+	}
+
+	lua_pushvalue(L, 3);
+	SetValue(model, child_ref);
+
+	lua_pushvalue(L, 2);
+	model->handle.DirtyVariable(lua_tostring(L, -1));
+	lua_pop(L, 1);
+
 	return 0;
 }
 
@@ -328,24 +427,28 @@ bool OpenLuaDataModel(lua_State* L, Context* context, int name_index, int table_
 		}
 	}
 
-	struct LuaDataModel* D = (struct LuaDataModel*)lua_newuserdata(L, sizeof(*D));
-	D->dataL = nullptr;
-	D->scalarDef = nullptr;
-	D->tableDef = nullptr;
-	D->constructor = constructor;
-	D->handle = constructor.GetModelHandle();
+	struct LuaDataModel* model = (struct LuaDataModel*)lua_newuserdata(L, sizeof(*model));
+	model->L = L;
+	model->constructor = constructor;
+	model->handle = constructor.GetModelHandle();
+	model->objectDef = new LuaObjectDef(model);
 
-	D->scalarDef = new LuaScalarDef(D);
-	D->tableDef = new LuaTableDef(D);
-	D->dataL = lua_newthread(L);
-	D->top = 1;
-	lua_newtable(D->dataL);
+	lua_newtable(L);
+	lua_pushvalue(L, -2);
+	model->model_ref = luaL_ref(L, -2);
+	model->valuestore_ref = luaL_ref(L, LUA_REGISTRYINDEX);
+
+	lua_newtable(L);
+	lua_newtable(L);
+	lua_rawseti(L, -2, model->model_ref);
+	model->tablestore_ref = luaL_ref(L, LUA_REGISTRYINDEX);
+
 	lua_pushnil(L);
 	while (lua_next(L, table_index) != 0)
 	{
-		BindVariable(D, L);
+		BindVariable(model);
+		lua_pop(L, 1);
 	}
-	lua_setuservalue(L, -2);
 
 	if (luaL_newmetatable(L, RMLDATAMODEL))
 	{
@@ -368,15 +471,20 @@ bool OpenLuaDataModel(lua_State* L, Context* context, int name_index, int table_
 void CloseLuaDataModel(lua_State* L)
 {
 	luaL_checkudata(L, -1, RMLDATAMODEL);
-	struct LuaDataModel* D = (struct LuaDataModel*)lua_touserdata(L, -1);
-	D->dataL = nullptr;
-	D->top = 0;
-	delete D->scalarDef;
-	D->scalarDef = nullptr;
-	delete D->tableDef;
-	D->tableDef = nullptr;
+	struct LuaDataModel* model = (struct LuaDataModel*)lua_touserdata(L, -1);
+	model->L = nullptr;
+	delete model->objectDef;
+	model->objectDef = nullptr;
+
+	model->model_ref = LUA_NOREF;
+
 	lua_pushnil(L);
-	lua_setuservalue(L, -2);
+	lua_rawseti(L, LUA_REGISTRYINDEX, model->valuestore_ref);
+	model->valuestore_ref = LUA_NOREF;
+
+	lua_pushnil(L);
+	lua_rawseti(L, LUA_REGISTRYINDEX, model->tablestore_ref);
+	model->tablestore_ref = LUA_NOREF;
 }
 
 } // namespace Lua

--- a/Source/Lua/LuaDataModel.cpp
+++ b/Source/Lua/LuaDataModel.cpp
@@ -5,6 +5,7 @@
 #include <RmlUi/Lua/Utilities.h>
 
 #define RMLDATAMODEL "RMLDATAMODEL"
+#define RMLTABLEPROXY "RMLTABLEPROXY"
 
 namespace Rml {
 namespace Lua {
@@ -98,6 +99,17 @@ struct LuaDataModel {
 	int valuestore_ref = LUA_NOREF;
 	int tablestore_ref = LUA_NOREF;
 };
+
+struct TableProxy {
+	LuaDataModel* model;
+	int table_ref = LUA_NOREF;
+};
+
+static struct TableProxy* NewTableProxy(struct LuaDataModel* model);
+static struct TableProxy* ToTableProxy(lua_State* L, int index)
+{
+	return (struct TableProxy*)luaL_testudata(L, index, RMLTABLEPROXY);
+}
 
 class LuaObjectDef : public VariableDefinition {
 public:
@@ -198,7 +210,14 @@ int LuaObjectDef::Size(void* ptr)
 	int ref = (int)(intptr_t)ptr;
 	PushValue(model, ref);
 
-	int size = lua_type(L, -1) == LUA_TTABLE ? (int)luaL_len(L, -1) : 1;
+	struct TableProxy* proxy = ToTableProxy(L, -1);
+	lua_pop(L, 1);
+
+	if (proxy == nullptr || proxy->model != model)
+		return 1;
+
+	PushValue(model, proxy->table_ref);
+	int size = (int)luaL_len(L, -1);
 	lua_pop(L, 1);
 	return size;
 }
@@ -210,48 +229,41 @@ DataVariable LuaObjectDef::Child(void* ptr, const DataAddressEntry& address)
 		return DataVariable{};
 	int ref = (int)(intptr_t)ptr;
 
+	PushValue(model, ref);
+	// -1 = this table
+
+	struct TableProxy* proxy = ToTableProxy(L, -1);
+
+	if (proxy == nullptr || proxy->model != model)
+	{
+		lua_pop(L, 1);
+		return DataVariable{};
+	}
+
 	if (address.index == -1)
 		lua_pushlstring(L, address.name.data(), address.name.size());
 	else
 		lua_pushinteger(L, (lua_Integer)address.index + 1);
-	// -1 = key
+	// -1 = key, -2 = this table
 
-	int child_ref = ChildRef(model, ref);
+	int child_ref = ChildRef(model, proxy->table_ref);
 
-	// FIXME: Need to swap tables for proxies to the tables which get and set
-	// values in the valuestore by child ref, rather than get and set nested
-	// values within the table in the valuestore by the table's ref, which is what
-	// happens in Lua (but not Rml) with both the current registry-based and
-	// previous thread-based implementations, so the Lua and Rml get out of sync.
-	// In the previous implementation, this problem wasn't visible in the
-	// lua_invaders sample because the Lua only writes to the data model when
-	// closing the options window and, on reopening, a new child value was copied
-	// to the stack. For now, imitate this behaviour by creating a new child ref
-	// even if one already exists.
-
-	// if (child_ref != LUA_REFNIL)
-	// {
-	// 	lua_pop(L, 1);
-	// 	return DataVariable(model->objectDef, (void*)(intptr_t)child_ref);
-	// }
-
-	PushValue(model, ref);
-	// -1 = this table, -2 = key
-
-	if (lua_type(L, -1) != LUA_TTABLE)
+	if (child_ref != LUA_REFNIL)
 	{
 		lua_pop(L, 2);
-		return DataVariable{};
+		return DataVariable(model->objectDef, (void*)(intptr_t)child_ref);
 	}
 
-	lua_pushvalue(L, -2);
-	// -1 = key, -2 = this table, -3 = key
-	lua_gettable(L, -2);
-	// -1 = value, -2 = this table, -3 = key
-	lua_replace(L, -2);
+	lua_pushvalue(L, -1);
+	// -1 = key, -2 = key, -3 = this table
+	lua_gettable(L, -3);
+	// -1 = value, -2 = key, -3 = this table
+	lua_remove(L, -3);
 	// -1 = value, -2 = key
 
-	if (lua_isnil(L, -1))
+	if (lua_type(L, -1) == LUA_TTABLE)
+		NewTableProxy(model);
+	else if (lua_isnil(L, -1))
 	{
 		lua_pop(L, 2);
 		return DataVariable{};
@@ -268,7 +280,7 @@ DataVariable LuaObjectDef::Child(void* ptr, const DataAddressEntry& address)
 
 	lua_rawgeti(L, LUA_REGISTRYINDEX, model->tablestore_ref);
 	// -1 = tablestore, -2 = key
-	lua_rawgeti(L, -1, ref);
+	lua_rawgeti(L, -1, proxy->table_ref);
 	// -1 = tablestore entry / nil, -2 = tablestore, -3 = key
 
 	if (lua_type(L, -1) != LUA_TTABLE)
@@ -279,7 +291,7 @@ DataVariable LuaObjectDef::Child(void* ptr, const DataAddressEntry& address)
 		// -1 = tablestore entry, -2 = tablestore, -3 = key
 		lua_pushvalue(L, -1);
 		// -1 = tablestore entry, -2 = tablestore entry, -3 = tablestore, -4 = key
-		lua_rawseti(L, -3, ref);
+		lua_rawseti(L, -3, proxy->table_ref);
 		// -1 = tablestore entry, -2 = tablestore, -3 = key
 	}
 
@@ -297,15 +309,232 @@ DataVariable LuaObjectDef::Child(void* ptr, const DataAddressEntry& address)
 	return DataVariable(model->objectDef, (void*)(intptr_t)child_ref);
 }
 
+static int TableProxyGet(lua_State* L)
+{
+	// 1 = table proxy, 2 = key
+	struct TableProxy* proxy = (struct TableProxy*)lua_touserdata(L, 1);
+
+	lua_rawgeti(L, LUA_REGISTRYINDEX, proxy->model->tablestore_ref);
+	// -1 = tablestore
+	lua_rawgeti(L, -1, proxy->table_ref);
+	// -1 = tablestore entry, -2 = tablestore
+	lua_replace(L, -2);
+	// -1 = tablestore entry
+	lua_pushvalue(L, 2);
+	// -1 = key, -2 = tablestore entry
+	lua_rawget(L, -2);
+	// -1 = child ref / nil, -2 = tablestore entry
+
+	int child_ref = LUA_REFNIL;
+
+	if (lua_isnil(L, -1))
+	{
+		lua_pop(L, 1);
+		// -1 = tablestore entry
+		lua_rawgeti(L, LUA_REGISTRYINDEX, proxy->model->valuestore_ref);
+		// -1 = valuestore, -2 = tablestore entry
+		lua_rawgeti(L, -1, proxy->table_ref);
+		// -1 = table, -2 = valuestore, -3 = tablestore entry
+		lua_replace(L, -2);
+		// -1 = table, -2 = tablestore entry
+		lua_pushvalue(L, 2);
+		// -1 = key, -2 = table, -3 = tablestore entry
+		lua_gettable(L, -2);
+		// -1 = value, -2 = table, -3 = tablestore entry
+		lua_replace(L, -2);
+		// -1 = value, -2 = tablestore entry
+		if (lua_isnil(L, -1))
+			return 1; // Just return nil; avoid setting LUA_REFNIL
+
+		lua_rawgeti(L, LUA_REGISTRYINDEX, proxy->model->valuestore_ref);
+		// -1 = valuestore, -2 = value, -3 = tablestore entry
+		lua_pushvalue(L, -2);
+		// -1 = value, -2 = valuestore, -3 = value, -4 = tablestore entry
+		child_ref = luaL_ref(L, -2);
+		// -1 = valuestore, -2 = value, -3 = tablestore entry
+		lua_pushvalue(L, 2);
+		// -1 = key, -2 = valuestore, -3 = value, -4 = tablestore entry
+		lua_replace(L, -2);
+		// -1 = key, -2 = value, -3 = tablestore entry
+		lua_pushnumber(L, child_ref);
+		// -1 = child ref, -2 = key, -3 = value, -4 = tablestore entry
+		lua_rawset(L, -4);
+		// -1 = value, -2 = tablestore entry
+		lua_replace(L, -2);
+		// -1 = value
+	}
+	else
+	{
+		child_ref = (int)lua_tonumber(L, -1);
+		// -1 = child ref, -2 = tablestore entry
+		lua_pop(L, 2);
+
+		lua_rawgeti(L, LUA_REGISTRYINDEX, proxy->model->valuestore_ref);
+		// -1 = valuestore
+		lua_rawgeti(L, -1, child_ref);
+		// -1 = value, -2 = valuestore
+		lua_replace(L, -2);
+		// -1 = value
+	}
+
+	if (lua_type(L, -1) == LUA_TTABLE)
+	{
+		NewTableProxy(proxy->model);
+		// -1 = value
+		lua_pushvalue(L, -1);
+		// -1 = value, -2 = value
+		SetValue(proxy->model, child_ref);
+		// -1 = value
+	}
+
+	return 1;
+}
+
+static int TableProxySet(lua_State* L)
+{
+	// 1 = table proxy, 2 = key, 3 = value
+	struct TableProxy* proxy = (struct TableProxy*)lua_touserdata(L, 1);
+
+	struct TableProxy* value_proxy = ToTableProxy(L, 3);
+	if (value_proxy != nullptr)
+	{
+		PushValue(proxy->model, value_proxy->table_ref);
+		lua_replace(L, 3);
+	}
+
+	lua_rawgeti(L, LUA_REGISTRYINDEX, proxy->model->valuestore_ref);
+	// -1 = valuestore
+	lua_rawgeti(L, LUA_REGISTRYINDEX, proxy->model->tablestore_ref);
+	// -1 = tablestore, -2 = valuestore
+	lua_rawgeti(L, -1, proxy->table_ref);
+	// -1 = tablestore entry, -2 = tablestore, -3 = valuestore
+	lua_replace(L, -2);
+	// -1 = tablestore entry, -2 = valuestore
+	lua_pushvalue(L, 2);
+	// -1 = key, -2 = tablestore entry, -3 = valuestore
+	lua_rawget(L, -2);
+	// -1 = child ref, -2 = tablestore entry, -3 = valuestore
+
+	if (lua_isnil(L, -1))
+	{
+		if (lua_isnil(L, 3))
+			return 0;
+
+		lua_pop(L, 1);
+		// -1 = tablestore entry, -2 = valuestore
+		lua_pushvalue(L, 3);
+		// -1 = value, -2 = tablestore entry, -3 = valuestore
+		if (lua_type(L, -1) == LUA_TTABLE)
+			NewTableProxy(proxy->model);
+		int child_ref = luaL_ref(L, -3);
+		// -1 = tablestore entry, -2 = valuestore
+		lua_pushvalue(L, 2);
+		// -1 = key, -2 = tablestore entry, -3 = valuestore
+		lua_pushnumber(L, child_ref);
+		// -1 = child ref, -2 = key, -3 = tablestore entry, -4 = valuestore
+		lua_rawset(L, -3);
+		// -1 = tablestore entry, -2 = valuestore
+		return 0;
+	}
+
+	int child_ref = (int)lua_tonumber(L, -1);
+	lua_pop(L, 3);
+
+	PushValue(proxy->model, child_ref);
+	// -1 = prev value
+
+	if (lua_rawequal(L, -1, 3))
+		return 0;
+
+	lua_pop(L, 1);
+
+	lua_pushvalue(L, 3);
+	// -1 = value
+	if (lua_type(L, -1) == LUA_TTABLE)
+		NewTableProxy(proxy->model);
+	SetValue(proxy->model, child_ref);
+
+	return 0;
+}
+
+static int TableProxyGc(lua_State* L)
+{
+	struct TableProxy* proxy = (struct TableProxy*)lua_touserdata(L, 1);
+
+	if (proxy->model->valuestore_ref != LUA_NOREF)
+	{
+		lua_rawgeti(L, LUA_REGISTRYINDEX, proxy->model->valuestore_ref);
+		lua_pushnil(L);
+		lua_rawseti(L, -2, proxy->table_ref);
+		lua_pop(L, 1);
+	}
+
+	if (proxy->model->tablestore_ref != LUA_NOREF)
+	{
+		lua_rawgeti(L, LUA_REGISTRYINDEX, proxy->model->tablestore_ref);
+		lua_pushnil(L);
+		lua_rawseti(L, -2, proxy->table_ref);
+		lua_pop(L, 1);
+	}
+
+	proxy->table_ref = LUA_NOREF;
+
+	return 0;
+}
+
+static struct TableProxy* NewTableProxy(struct LuaDataModel* model)
+{
+	// -1 = table
+	lua_State* L = model->L;
+
+	lua_rawgeti(L, LUA_REGISTRYINDEX, model->valuestore_ref);
+	lua_pushvalue(L, -2);
+	int table_ref = luaL_ref(L, -2);
+	lua_pop(L, 2);
+
+	lua_rawgeti(L, LUA_REGISTRYINDEX, model->tablestore_ref);
+	lua_newtable(L);
+	lua_rawseti(L, -2, table_ref);
+	lua_pop(L, 1);
+
+	struct TableProxy* proxy = (struct TableProxy*)lua_newuserdata(L, sizeof(*proxy));
+	// -1 = proxy
+	proxy->model = model;
+	proxy->table_ref = table_ref;
+
+	if (luaL_newmetatable(L, RMLTABLEPROXY))
+	{
+		luaL_Reg l[] = {
+			{"__index", TableProxyGet},
+			{"__newindex", TableProxySet},
+			{"__gc", TableProxyGc},
+			{nullptr, nullptr},
+		};
+		luaL_setfuncs(L, l, 0);
+	}
+	lua_setmetatable(L, -2);
+
+	return proxy;
+}
+
 static void BindVariable(struct LuaDataModel* model)
 {
 	// -1 = value, -2 = key
 	lua_State* L = model->L;
 
+	struct TableProxy* value_proxy = ToTableProxy(L, -1);
+	if (value_proxy != nullptr)
+	{
+		lua_pop(L, 1);
+		PushValue(model, value_proxy->table_ref);
+	}
+
 	lua_rawgeti(L, LUA_REGISTRYINDEX, model->valuestore_ref);
 	// -1 = valuestore, -2 = value, -3 = key
 	lua_pushvalue(L, -2);
 	// -1 = value, -2 = valuestore, -3 = value, -4 = key
+	if (lua_type(L, -1) == LUA_TTABLE)
+		NewTableProxy(model);
 	int ref = luaL_ref(L, -2);
 	// -1 = valuestore, -2 = value, -3 = key
 	lua_pop(L, 1);
@@ -379,6 +608,13 @@ static int lDataModelGet(lua_State* L)
 	lua_rawgeti(L, LUA_REGISTRYINDEX, model->valuestore_ref);
 	lua_rawgeti(L, -1, child_ref);
 
+	if (lua_type(L, -1) == LUA_TTABLE)
+	{
+		NewTableProxy(model);
+		lua_pushvalue(L, -1);
+		lua_rawseti(L, -3, child_ref);
+	}
+
 	return 1;
 }
 
@@ -403,6 +639,15 @@ static int lDataModelSet(lua_State* L)
 	}
 
 	lua_pushvalue(L, 3);
+	struct TableProxy* value_proxy = ToTableProxy(L, -1);
+	if (value_proxy != nullptr)
+	{
+		lua_pop(L, 1);
+		PushValue(model, value_proxy->table_ref);
+	}
+
+	if (lua_type(L, -1) == LUA_TTABLE)
+		NewTableProxy(model);
 	SetValue(model, child_ref);
 
 	lua_pushvalue(L, 2);

--- a/Source/Lua/LuaDataModel.cpp
+++ b/Source/Lua/LuaDataModel.cpp
@@ -98,14 +98,16 @@ struct LuaDataModel {
 	int model_ref = LUA_NOREF;
 	int valuestore_ref = LUA_NOREF;
 	int tablestore_ref = LUA_NOREF;
+	int keystore_ref = LUA_NOREF;
 };
 
 struct TableProxy {
 	LuaDataModel* model;
 	int table_ref = LUA_NOREF;
+	int key_ref = LUA_NOREF;
 };
 
-static struct TableProxy* NewTableProxy(struct LuaDataModel* model);
+static struct TableProxy* NewTableProxy(struct LuaDataModel* model, int key_ref);
 static struct TableProxy* ToTableProxy(lua_State* L, int index)
 {
 	return (struct TableProxy*)luaL_testudata(L, index, RMLTABLEPROXY);
@@ -262,7 +264,7 @@ DataVariable LuaObjectDef::Child(void* ptr, const DataAddressEntry& address)
 	// -1 = value, -2 = key
 
 	if (lua_type(L, -1) == LUA_TTABLE)
-		NewTableProxy(model);
+		NewTableProxy(model, proxy->key_ref);
 	else if (lua_isnil(L, -1))
 	{
 		lua_pop(L, 2);
@@ -379,7 +381,7 @@ static int TableProxyGet(lua_State* L)
 
 	if (lua_type(L, -1) == LUA_TTABLE)
 	{
-		NewTableProxy(proxy->model);
+		NewTableProxy(proxy->model, proxy->key_ref);
 		// -1 = value
 		lua_pushvalue(L, -1);
 		// -1 = value, -2 = value
@@ -425,7 +427,7 @@ static int TableProxySet(lua_State* L)
 		lua_pushvalue(L, 3);
 		// -1 = value, -2 = tablestore entry, -3 = valuestore
 		if (lua_type(L, -1) == LUA_TTABLE)
-			NewTableProxy(proxy->model);
+			NewTableProxy(proxy->model, proxy->key_ref);
 		int child_ref = luaL_ref(L, -3);
 		// -1 = tablestore entry, -2 = valuestore
 		lua_pushvalue(L, 2);
@@ -451,8 +453,15 @@ static int TableProxySet(lua_State* L)
 	lua_pushvalue(L, 3);
 	// -1 = value
 	if (lua_type(L, -1) == LUA_TTABLE)
-		NewTableProxy(proxy->model);
+		NewTableProxy(proxy->model, proxy->key_ref);
 	SetValue(proxy->model, child_ref);
+
+	lua_rawgeti(L, LUA_REGISTRYINDEX, proxy->model->keystore_ref);
+	// -1 = keystore
+	lua_rawgeti(L, -1, proxy->key_ref);
+	// -1 = root key, -2 = keystore
+	proxy->model->handle.DirtyVariable(lua_tostring(L, -1));
+	lua_pop(L, 2);
 
 	return 0;
 }
@@ -482,7 +491,7 @@ static int TableProxyGc(lua_State* L)
 	return 0;
 }
 
-static struct TableProxy* NewTableProxy(struct LuaDataModel* model)
+static struct TableProxy* NewTableProxy(struct LuaDataModel* model, int key_ref)
 {
 	// -1 = table
 	lua_State* L = model->L;
@@ -501,6 +510,7 @@ static struct TableProxy* NewTableProxy(struct LuaDataModel* model)
 	// -1 = proxy
 	proxy->model = model;
 	proxy->table_ref = table_ref;
+	proxy->key_ref = key_ref;
 
 	if (luaL_newmetatable(L, RMLTABLEPROXY))
 	{
@@ -533,9 +543,10 @@ static void BindVariable(struct LuaDataModel* model)
 	// -1 = valuestore, -2 = value, -3 = key
 	lua_pushvalue(L, -2);
 	// -1 = value, -2 = valuestore, -3 = value, -4 = key
-	if (lua_type(L, -1) == LUA_TTABLE)
-		NewTableProxy(model);
+	value_proxy = lua_type(L, -1) == LUA_TTABLE ? NewTableProxy(model, LUA_REFNIL) : nullptr;
 	int ref = luaL_ref(L, -2);
+	if (value_proxy != nullptr)
+		value_proxy->key_ref = ref;
 	// -1 = valuestore, -2 = value, -3 = key
 	lua_pop(L, 1);
 	// -1 = value, -2 = key
@@ -552,6 +563,15 @@ static void BindVariable(struct LuaDataModel* model)
 	// -1 = ref, -2 = key, -3 = tablestore entry, -4 = value, -5 = key
 	lua_rawset(L, -3);
 	// -1 = tablestore entry, -2 = value, -3 = key
+	lua_pop(L, 1);
+	// -1 = value, -2 = key
+
+	lua_rawgeti(L, LUA_REGISTRYINDEX, model->keystore_ref);
+	// -1 = keystore, -2 = value, -3 = key
+	lua_pushvalue(L, -3);
+	// -1 = key, -2 = keystore, -3 = value, -4 = key
+	lua_rawseti(L, -2, ref);
+	// -1 = keystore, -2 = value, -3 = key
 	lua_pop(L, 1);
 	// -1 = value, -2 = key
 
@@ -610,7 +630,7 @@ static int lDataModelGet(lua_State* L)
 
 	if (lua_type(L, -1) == LUA_TTABLE)
 	{
-		NewTableProxy(model);
+		NewTableProxy(model, child_ref);
 		lua_pushvalue(L, -1);
 		lua_rawseti(L, -3, child_ref);
 	}
@@ -647,7 +667,7 @@ static int lDataModelSet(lua_State* L)
 	}
 
 	if (lua_type(L, -1) == LUA_TTABLE)
-		NewTableProxy(model);
+		NewTableProxy(model, child_ref);
 	SetValue(model, child_ref);
 
 	lua_pushvalue(L, 2);
@@ -687,6 +707,9 @@ bool OpenLuaDataModel(lua_State* L, Context* context, int name_index, int table_
 	lua_newtable(L);
 	lua_rawseti(L, -2, model->model_ref);
 	model->tablestore_ref = luaL_ref(L, LUA_REGISTRYINDEX);
+
+	lua_newtable(L);
+	model->keystore_ref = luaL_ref(L, LUA_REGISTRYINDEX);
 
 	lua_pushnil(L);
 	while (lua_next(L, table_index) != 0)
@@ -730,6 +753,10 @@ void CloseLuaDataModel(lua_State* L)
 	lua_pushnil(L);
 	lua_rawseti(L, LUA_REGISTRYINDEX, model->tablestore_ref);
 	model->tablestore_ref = LUA_NOREF;
+
+	lua_pushnil(L);
+	lua_rawseti(L, LUA_REGISTRYINDEX, model->keystore_ref);
+	model->keystore_ref = LUA_NOREF;
 }
 
 } // namespace Lua

--- a/Source/Lua/LuaDataModel.cpp
+++ b/Source/Lua/LuaDataModel.cpp
@@ -677,6 +677,23 @@ static int lDataModelSet(lua_State* L)
 	return 0;
 }
 
+void PushDataModelsTable(lua_State* L)
+{
+	static constexpr auto datamodels_key = "datamodels";
+
+	lua_pushstring(L, datamodels_key);
+	lua_rawget(L, LUA_REGISTRYINDEX);
+
+	if (lua_type(L, -1) == LUA_TTABLE)
+		return;
+
+	lua_pop(L, 1);
+	lua_newtable(L);
+	lua_pushstring(L, datamodels_key);
+	lua_pushvalue(L, -2);
+	lua_rawset(L, LUA_REGISTRYINDEX);
+}
+
 bool OpenLuaDataModel(lua_State* L, Context* context, int name_index, int table_index)
 {
 	String name = luaL_checkstring(L, name_index);
@@ -728,23 +745,37 @@ bool OpenLuaDataModel(lua_State* L, Context* context, int name_index, int table_
 		luaL_setfuncs(L, l, 0);
 	}
 	lua_setmetatable(L, -2);
+	// -1 = data model
+
+	PushDataModelsTable(L);
+	// -1 = data models table, -2 = data model
+	lua_pushvalue(L, name_index);
+	// -1 = name, -2 = data models table, -3 = data model
+	lua_pushvalue(L, -3);
+	// -1 = data model, -2 = name, -3 = data models table, -4 = data model
+	lua_rawset(L, -3);
+	// -1 = data models table, -2 = data model
+	lua_pop(L, 1);
+	// -1 = data model
 
 	return true;
 }
 
-// If you create all the Data Models from lua, you can store these LuaDataModel objects in a table,
-// and call CloseLuaDataModel for each after Context released.
-// We don't put it in __gc, becuase LuaDataModel can be free before DataModel if you are not careful.
-// scalarDef will free by CloseLuaDataModel, but DataModel need it.
-void CloseLuaDataModel(lua_State* L)
+void CloseLuaDataModel(lua_State* L, Context* context, int name_index)
 {
-	luaL_checkudata(L, -1, RMLDATAMODEL);
-	struct LuaDataModel* model = (struct LuaDataModel*)lua_touserdata(L, -1);
-	model->L = nullptr;
-	delete model->objectDef;
-	model->objectDef = nullptr;
+	String name = luaL_checkstring(L, name_index);
 
-	model->model_ref = LUA_NOREF;
+	PushDataModelsTable(L);
+	// -1 = data models table
+	lua_pushvalue(L, name_index);
+	// -1 = name, -2 = data models table
+	lua_rawget(L, -2);
+	// -1 = data model / nil, -2 = data models table
+	struct LuaDataModel* model = (struct LuaDataModel*)luaL_testudata(L, -1, RMLDATAMODEL);
+	lua_pop(L, 2);
+
+	if (model == nullptr)
+		return;
 
 	lua_pushnil(L);
 	lua_rawseti(L, LUA_REGISTRYINDEX, model->valuestore_ref);
@@ -757,6 +788,24 @@ void CloseLuaDataModel(lua_State* L)
 	lua_pushnil(L);
 	lua_rawseti(L, LUA_REGISTRYINDEX, model->keystore_ref);
 	model->keystore_ref = LUA_NOREF;
+
+	model->L = nullptr;
+	delete model->objectDef;
+	model->objectDef = nullptr;
+
+	model->model_ref = LUA_NOREF;
+
+	PushDataModelsTable(L);
+	// -1 = data models table
+	lua_pushvalue(L, name_index);
+	// -1 = name, -2 = data models table
+	lua_pushnil(L);
+	// -1 = nil, -2 = name, -3 = data models table
+	lua_rawset(L, -3);
+	// -1 = data models table
+	lua_pop(L, 1);
+
+	context->RemoveDataModel(name);
 }
 
 } // namespace Lua

--- a/Source/Lua/LuaDataModel.h
+++ b/Source/Lua/LuaDataModel.h
@@ -11,8 +11,8 @@ struct LuaDataModel;
 
 // Create or Get a DataModel in L, return false on fail
 bool OpenLuaDataModel(lua_State* L, Rml::Context* context, int name_index, int table_index);
-// Should Close object (on L top) after DataModel released (Context::RemoveDataModel)
-void CloseLuaDataModel(lua_State* L);
+// Close a DataModel
+void CloseLuaDataModel(lua_State* L, Rml::Context* context, int name_index);
 
 } // namespace Lua
 } // namespace Rml


### PR DESCRIPTION
I found some issues with the Lua data model. This should fix them.

The first issue I found was that the call to `lua_setuservalue` (on a thread) was broken when using the backported implementation on Lua 5.1 (including LuaJIT). I think this call was only there to prevent garbage collection on the thread, but there are other ways of achieving this (e.g. putting the thread in the Lua registry). This PR removes the thread anyway.

Another issue was that the data model values were being copied every time the `Child` method was called on the `VariableDefinition`. This meant that, for each time `Child` was called on the same variable, the Rml was actually getting a separate variable for the same child. As it happens, the Lua invaders sample manages to dodge this issue by reloading the options from a file when the options window opens. If it didn't, nested values (ie. the audio options) would revert to the values set via Lua after closing and then reopening the options window.

As the data model values were being copied, this meant that they were out of sync between Rml and Lua. It seems the only usable workflow was to set the values in Lua, then load the Rml, then submit the values back to Lua via an event and close the Rml document that was using them. This is what the Lua invaders sample does. It didn't seem possible to have the kind of two-way communication via the data model between Rml and Lua that you can have between Rml and C++.

In the previous implementation, data model values were copied to new positions on the stack of a thread. In the implementation in this PR, they're copied to a flat table (which I've named `valuestore`) instead which is stored in the Lua registry. The main commit is just a reimplementation and actually doesn't fix these issues (apart from removing `lua_setuservalue`). There is another commit which converts tables within the data model to table proxies, which ensures each value is only copied once and that this copied value is what's accessible via both Rml and Lua, which should mean that both are in sync. I added another commit to call `DirtyVariable` automatically when setting values in Lua, so that Rml is able to refresh.

There are some more technical explanations in my commit messages.

Fixes #921.
