### PR TITLE
Set keyboard_showed in WidgetTextInput::SetKeyboardActive

### DIFF
--- a/Source/Core/Elements/WidgetTextInput.cpp
+++ b/Source/Core/Elements/WidgetTextInput.cpp
@@ -1618,6 +1618,8 @@ void WidgetTextInput::SetKeyboardActive(bool active)
 	{
 		system->DeactivateKeyboard();
 	}
+
+	keyboard_showed = active;
 }
 
 float WidgetTextInput::GetLineHeight() const


### PR DESCRIPTION
Fixes a regression in bf244676 where `keyboard_showed` is never set, but still read by `SetKeyboardActive`. In practice, this makes the keyboard on mobile devices never hide after unfocusing an input.