### PR TITLE
Scale outer border radii against the outer box, fixes fully rounded shapes on bordered boxes

### DIFF
--- a/Source/Core/GeometryBackgroundBorder.cpp
+++ b/Source/Core/GeometryBackgroundBorder.cpp
@@ -42,12 +42,14 @@ BorderMetrics GeometryBackgroundBorder::ComputeBorderMetrics(Vector2f outer_posi
 		auto& outer_radii = metrics.outer_radii;
 		outer_radii = outer_radii_def;
 
-		// Scale the radii such that we have no overlapping curves.
+		// Scale the radii such that we have no overlapping curves. The outer radii lie on the border
+		// box, so they scale against the outer size (css corner-overlap rule); scaling them against
+		// the inner size makes a fully rounded shape impossible on any box with borders.
 		float scale_factor = FLT_MAX;
-		scale_factor = Math::Min(scale_factor, inner_size.x / (outer_radii[TOP_LEFT] + outer_radii[TOP_RIGHT]));       // Top
-		scale_factor = Math::Min(scale_factor, inner_size.y / (outer_radii[TOP_RIGHT] + outer_radii[BOTTOM_RIGHT]));   // Right
-		scale_factor = Math::Min(scale_factor, inner_size.x / (outer_radii[BOTTOM_RIGHT] + outer_radii[BOTTOM_LEFT])); // Bottom
-		scale_factor = Math::Min(scale_factor, inner_size.y / (outer_radii[BOTTOM_LEFT] + outer_radii[TOP_LEFT]));     // Left
+		scale_factor = Math::Min(scale_factor, outer_size.x / (outer_radii[TOP_LEFT] + outer_radii[TOP_RIGHT]));       // Top
+		scale_factor = Math::Min(scale_factor, outer_size.y / (outer_radii[TOP_RIGHT] + outer_radii[BOTTOM_RIGHT]));   // Right
+		scale_factor = Math::Min(scale_factor, outer_size.x / (outer_radii[BOTTOM_RIGHT] + outer_radii[BOTTOM_LEFT])); // Bottom
+		scale_factor = Math::Min(scale_factor, outer_size.y / (outer_radii[BOTTOM_LEFT] + outer_radii[TOP_LEFT]));     // Left
 		scale_factor = Math::Min(1.0f, scale_factor);
 
 		for (float& radius : outer_radii)


### PR DESCRIPTION
While styling a slider thumb (16px box, 2px border ring, border-radius at half the border box) I noticed you can never get a fully round shape on an element that has a border. The overlap clamp in `GeometryBackgroundBorder::ComputeBorderMetrics` scales the outer radii against `inner_size`, so on a bordered box the outer radius always ends up short of half the border box and you keep flat sections on every edge, no matter how big you make the radius.

The outer radii live on the border box though, so the overlap should be resolved against the outer size. That is also what CSS specifies for corner overlap: https://www.w3.org/TR/css-backgrounds-3/#corner-overlap ("If the sum of any two adjacent border radii exceeds the size of the border box..."). The spec even spells out the reduction as a formula: f = min(Li/Si), with Ltop = Lbottom = the width of the box and Lleft = Lright = the height of the box, the box being the border box. That is exactly what `scale_factor` computes here, just with the inner size as L.

This cannot introduce overlapping inner curves: the inner radii still derive as outer minus edge, and if `r1 + r2 <= outer_edge` then `(r1 - e1) + (r2 - e2) <= outer_edge - e1 - e2 = inner_edge`, so whenever the outer radii fit the outer box the inner radii fit the inner box by construction.

Repro:

```html
<div style="width: 16px; height: 16px; border: 2px #818cf8; border-radius: 10px; background-color: #020617;"/>
```

Border box is 20px, radius 10px, so this should render as a circle. Before it renders with radius 8 (scaled by 16 / 20) and visible straight edges, after the fix it is a circle:

| before | after |
| --- | --- |
| ![before](https://raw.githubusercontent.com/geforcefan/RmlUi/screenshots-border-radius/before.png) | ![after](https://raw.githubusercontent.com/geforcefan/RmlUi/screenshots-border-radius/after.png) |

@mikke89 would be great if you could take a look when you find the time.
