### PR TITLE
Fix transitions that use var()

### DIFF
--- a/Source/Core/ElementStyle.cpp
+++ b/Source/Core/ElementStyle.cpp
@@ -389,6 +389,17 @@ void ElementStyle::TransitionPropertyChanges(const PropertySources& sources, Pro
 	const Property* transition_property = GetLocalProperty(PropertyId::Transition, sources.inline_properties, new_definition);
 	if (!transition_property)
 		return;
+	Property transition_property_storage;
+	if (transition_property->unit == Unit::VAR_EXPRESSION)
+	{
+		SmallUnorderedSet<String> transition_variable_dependencies;
+		std::optional<PropertyDictionary> transition_substituted_shorthands;
+		PropertySources transition_sources{sources.element, new_definition, sources.inline_properties};
+		transition_property = ResolveVariablesWithShorthandExpansion(transition_sources, PropertyId::Transition, transition_property,
+			transition_substituted_shorthands, transition_variable_dependencies, transition_property_storage);
+		if (!transition_property)
+			return;
+	}
 	if (transition_property->value.GetType() != Variant::TRANSITIONLIST)
 		return;
 


### PR DESCRIPTION
Transitions never start when the transition property uses a variable:

```css
body { --fast: 0.3s cubic-out; }
button { transition: background-color var(--fast); }
```

The same rule with a plain `0.3s cubic-out` animates, the `var()` version does not.

`TransitionPropertyChanges` reads the local transition property before variables are resolved, so the value is still a var expression instead of a `TRANSITIONLIST` and the function returns early. Resolve the variables there the same way other properties do, then run the existing type check.