### PR TITLE
Fix var() properties not updating when the dp ratio changes

### DIFF
--- a/Source/Core/ElementStyle.cpp
+++ b/Source/Core/ElementStyle.cpp
@@ -814,7 +814,7 @@ void ElementStyle::DirtyPropertiesWithUnits(Units units)
 		auto name_property_pair = *it;
 		PropertyId id = name_property_pair.first;
 		const Property& property = name_property_pair.second;
-		if (Any(property.unit & units))
+		if (Any(property.unit & units) || property.unit == Unit::VAR_EXPRESSION || property.unit == Unit::SHORTHAND_PLACEHOLDER)
 			DirtyProperty(id);
 	}
 }


### PR DESCRIPTION
Properties that take a dp length from a variable keep their old size when the dp ratio changes after loading:

```css
body { --size: 13dp; }
div { font-size: var(--size); }
```

The same rule with a plain `13dp` follows the new ratio, the `var()` version does not. The same happens for every other dp length behind a variable (`top`, `width`, shorthands like `padding`), and for everything that inherits from such a property.

`Element::OnDpRatioChangeRecursive` dirties properties through `ElementStyle::DirtyPropertiesWithUnits(Unit::DP_SCALABLE_LENGTH)`, which matches the unit of the stored property. A `var()` declaration is stored as `Unit::VAR_EXPRESSION` and only substituted and parsed later in `ComputeValues`, so at dirty time its unit is unknown and it never matches. Dirty var expressions and var shorthand placeholders unconditionally: they can resolve to any unit, and the recompute this triggers is the same one any definition change runs. That also covers the other two callers, `vw`/`vh` on viewport resizes and `rem` on document font-size changes, for values behind a variable.

Repro, load at the default ratio, then call `context->SetDensityIndependentPixelRatio(2.0f)` and update:

```html
<rml>
<head>
<style>
  body { --size: 13dp; }
  #root { font-size: var(--size); }
  .literal { font-size: 13dp; }
</style>
</head>
<body>
  <div id="root">
    <div class="literal">literal</div>
    <span>inherits</span>
  </div>
</body>
</rml>
```

`.literal` computes to 26px, `#root` and the span inheriting from it stay at 13px.

This is how it looked in our UI, which sets the dp ratio on the first frame after loading. All lengths and font sizes come from variables. The controls with a local `font-size` were recomputed later for unrelated reasons and picked up the ratio, the segmented control and the labels inherit from the root and kept the ratio-1 value, as did the root's own `var()` top and width:

| before | after |
| --- | --- |
| ![before](https://raw.githubusercontent.com/geforcefan/RmlUi/screenshots-var-dp-ratio/before.png) | ![after](https://raw.githubusercontent.com/geforcefan/RmlUi/screenshots-var-dp-ratio/after.png) |
