### PR TITLE
Add type_traits include

### DIFF
--- a/Include/RmlUi/Core/Colour.h
+++ b/Include/RmlUi/Core/Colour.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Header.h"
+#include <type_traits>
 
 namespace Rml {
 

--- a/Include/RmlUi/Core/Variant.h
+++ b/Include/RmlUi/Core/Variant.h
@@ -4,6 +4,7 @@
 #include "Header.h"
 #include "TypeConverter.h"
 #include "Types.h"
+#include <type_traits>
 
 namespace Rml {
 


### PR DESCRIPTION
I had issues related to missing type_traits includes while trying to compile for macOS using latest clang.