### PR TITLE
Memoize content-based size measurements to avoid exponential formatting in nested flexboxes

### DIFF
--- a/Source/Core/Layout/CMakeLists.txt
+++ b/Source/Core/Layout/CMakeLists.txt
@@ -27,6 +27,8 @@ target_sources(rmlui_core PRIVATE
 	"${CMAKE_CURRENT_SOURCE_DIR}/LayoutDetails.h"
 	"${CMAKE_CURRENT_SOURCE_DIR}/LayoutEngine.cpp"
 	"${CMAKE_CURRENT_SOURCE_DIR}/LayoutEngine.h"
+	"${CMAKE_CURRENT_SOURCE_DIR}/LayoutMeasureCache.cpp"
+	"${CMAKE_CURRENT_SOURCE_DIR}/LayoutMeasureCache.h"
 	"${CMAKE_CURRENT_SOURCE_DIR}/LayoutPools.cpp"
 	"${CMAKE_CURRENT_SOURCE_DIR}/LayoutPools.h"
 	"${CMAKE_CURRENT_SOURCE_DIR}/LineBox.cpp"

--- a/Source/Core/Layout/FlexFormattingContext.cpp
+++ b/Source/Core/Layout/FlexFormattingContext.cpp
@@ -6,6 +6,7 @@
 #include "../../../Include/RmlUi/Core/Types.h"
 #include "ContainerBox.h"
 #include "LayoutDetails.h"
+#include "LayoutMeasureCache.h"
 #include <algorithm>
 #include <float.h>
 #include <numeric>
@@ -89,6 +90,11 @@ UniquePtr<LayoutBox> FlexFormattingContext::Format(ContainerBox* parent_containe
 
 Vector2f FlexFormattingContext::GetMaxContentSize(Element* element)
 {
+	LayoutMeasureCache* measure_cache = LayoutMeasureCache::GetActiveCache();
+	Vector2f max_content_size;
+	if (measure_cache && measure_cache->FindMaxContentSize(element, max_content_size))
+		return max_content_size;
+
 	// A large but finite number is used here, since layouting doesn't always work well with infinities.
 	const Vector2f infinity(10000.0f, 10000.0f);
 	RootBox root(infinity);
@@ -105,6 +111,10 @@ Vector2f FlexFormattingContext::GetMaxContentSize(Element* element)
 	Vector2f flex_resulting_content_size, content_overflow_size;
 	float flex_baseline = 0.f;
 	context.Format(flex_resulting_content_size, content_overflow_size, flex_baseline);
+
+	if (measure_cache)
+		measure_cache->StoreMaxContentSize(element, flex_resulting_content_size);
+
 	return flex_resulting_content_size;
 }
 
@@ -206,6 +216,24 @@ static float GetInnerUsedMainSize(const FlexItem& item)
 static float GetInnerUsedCrossSize(const FlexItem& item)
 {
 	return Math::Max(item.used_cross_size - item.cross.sum_edges, 0.f);
+}
+
+// Formats the element as a block box to determine its content height, memoized on the content width of the measure box.
+static float GetFormattedContentHeight(ContainerBox* parent_container, Element* element, const Box* measure_box)
+{
+	const float content_width = (measure_box ? measure_box->GetSize().x : -1.f);
+	LayoutMeasureCache* measure_cache = LayoutMeasureCache::GetActiveCache();
+	float formatted_content_height = 0.f;
+	if (measure_cache && content_width >= 0.f && measure_cache->FindFormattedContentHeight(element, content_width, formatted_content_height))
+		return formatted_content_height;
+
+	FormattingContext::FormatIndependent(parent_container, element, measure_box, FormattingContextType::Block);
+	formatted_content_height = element->GetBox().GetSize().y;
+
+	if (measure_cache && content_width >= 0.f)
+		measure_cache->StoreFormattedContentHeight(element, content_width, formatted_content_height);
+
+	return formatted_content_height;
 }
 
 void FlexFormattingContext::Format(Vector2f& flex_resulting_content_size, Vector2f& flex_content_overflow_size, float& flex_baseline) const
@@ -331,9 +359,8 @@ void FlexFormattingContext::Format(Vector2f& flex_resulting_content_size, Vector
 			if (initial_box_size.x < 0.f && flex_available_content_size.x >= 0.f)
 				format_box.SetContent(Vector2f(flex_available_content_size.x - item.cross.sum_edges, initial_box_size.y));
 
-			FormattingContext::FormatIndependent(flex_container_box, element, (format_box.GetSize().x >= 0 ? &format_box : nullptr),
-				FormattingContextType::Block);
-			item.inner_flex_base_size = element->GetBox().GetSize().y;
+			item.inner_flex_base_size =
+				GetFormattedContentHeight(flex_container_box, element, (format_box.GetSize().x >= 0 ? &format_box : nullptr));
 
 			// Apply the automatic block size as minimum size (§4.5). Strictly speaking, we should also apply this to
 			// the other branches in column mode (and inline min-content size in row mode). However, the formatting step
@@ -674,8 +701,7 @@ void FlexFormattingContext::Format(Vector2f& flex_resulting_content_size, Vector
 				if (content_size.y < 0.0f)
 				{
 					item.box.SetContent(Vector2f(GetInnerUsedMainSize(item), content_size.y));
-					FormattingContext::FormatIndependent(flex_container_box, item.element, &item.box, FormattingContextType::Block);
-					item.hypothetical_cross_size = item.element->GetBox().GetSize().y + item.cross.sum_edges;
+					item.hypothetical_cross_size = GetFormattedContentHeight(flex_container_box, item.element, &item.box) + item.cross.sum_edges;
 				}
 				else
 				{

--- a/Source/Core/Layout/LayoutDetails.cpp
+++ b/Source/Core/Layout/LayoutDetails.cpp
@@ -6,8 +6,10 @@
 #include "../../../Include/RmlUi/Core/Math.h"
 #include "../../../Include/RmlUi/Core/Profiling.h"
 #include "ContainerBox.h"
+#include "FlexFormattingContext.h"
 #include "FormattingContext.h"
 #include "LayoutEngine.h"
+#include "LayoutMeasureCache.h"
 #include <float.h>
 
 namespace Rml {
@@ -238,26 +240,48 @@ float LayoutDetails::GetShrinkToFitWidth(Element* element, Vector2f containing_b
 		return 0.f;
 	}
 
-	// Use a large size for the box content width, so that it is practically unconstrained. This makes the formatting
-	// procedure act as if under a maximum content constraint. Children with percentage sizing values may be scaled
-	// based on this width (such as 'width' or 'margin'), if so, the layout is considered undefined like in CSS 2.
-	const float max_content_constraint_width = containing_block.x + 10000.f;
-	box.SetContent({max_content_constraint_width, box.GetSize().y});
+	LayoutMeasureCache* measure_cache = LayoutMeasureCache::GetActiveCache();
+	float shrink_to_fit_width = 0.f;
+	if (measure_cache && measure_cache->FindShrinkToFitWidth(element, containing_block, shrink_to_fit_width))
+		return shrink_to_fit_width;
 
-	// First, format the element under the above generated box. Then we ask the resulting box for its shrink-to-fit
-	// width. For block containers, this is essentially its largest line or child box.
-	// @performance. Some formatting can be simplified, e.g. absolute elements do not contribute to the shrink-to-fit
-	// width. Also, children of elements with a fixed width and height don't need to be formatted further.
-	RootBox root(Math::Max(containing_block, Vector2f(0.f)));
-	UniquePtr<LayoutBox> layout_box = FormattingContext::FormatIndependent(&root, element, &box, FormattingContextType::Block);
+	auto ClampToAvailableWidth = [containing_block, &box](float width) {
+		if (containing_block.x >= 0)
+		{
+			const float available_width =
+				Math::Max(0.f, containing_block.x - box.GetSizeAcross(BoxDirection::Horizontal, BoxArea::Margin, BoxArea::Padding));
+			width = Math::Min(width, available_width);
+		}
+		return width;
+	};
 
-	float shrink_to_fit_width = layout_box->GetShrinkToFitWidth();
-	if (containing_block.x >= 0)
+	if (!element->IsReplaced() && (display == Style::Display::Flex || display == Style::Display::InlineFlex))
 	{
-		const float available_width =
-			Math::Max(0.f, containing_block.x - box.GetSizeAcross(BoxDirection::Horizontal, BoxArea::Margin, BoxArea::Padding));
-		shrink_to_fit_width = Math::Min(shrink_to_fit_width, available_width);
+		// A formatted flex container determines its shrink-to-fit width from its max-content size, so measure that
+		// directly instead of formatting the element first, which would repeat the same measurement.
+		shrink_to_fit_width = ClampToAvailableWidth(FlexFormattingContext::GetMaxContentSize(element).x);
 	}
+	else
+	{
+		// Use a large size for the box content width, so that it is practically unconstrained. This makes the formatting
+		// procedure act as if under a maximum content constraint. Children with percentage sizing values may be scaled
+		// based on this width (such as 'width' or 'margin'), if so, the layout is considered undefined like in CSS 2.
+		const float max_content_constraint_width = containing_block.x + 10000.f;
+		box.SetContent({max_content_constraint_width, box.GetSize().y});
+
+		// First, format the element under the above generated box. Then we ask the resulting box for its shrink-to-fit
+		// width. For block containers, this is essentially its largest line or child box.
+		// @performance. Some formatting can be simplified, e.g. absolute elements do not contribute to the shrink-to-fit
+		// width. Also, children of elements with a fixed width and height don't need to be formatted further.
+		RootBox root(Math::Max(containing_block, Vector2f(0.f)));
+		UniquePtr<LayoutBox> layout_box = FormattingContext::FormatIndependent(&root, element, &box, FormattingContextType::Block);
+
+		shrink_to_fit_width = ClampToAvailableWidth(layout_box->GetShrinkToFitWidth());
+	}
+
+	if (measure_cache)
+		measure_cache->StoreShrinkToFitWidth(element, containing_block, shrink_to_fit_width);
+
 	return shrink_to_fit_width;
 }
 

--- a/Source/Core/Layout/LayoutEngine.cpp
+++ b/Source/Core/Layout/LayoutEngine.cpp
@@ -4,6 +4,7 @@
 #include "../../../Include/RmlUi/Core/Profiling.h"
 #include "ContainerBox.h"
 #include "FormattingContext.h"
+#include "LayoutMeasureCache.h"
 
 namespace Rml {
 
@@ -12,6 +13,7 @@ void LayoutEngine::FormatElement(Element* element, Vector2f containing_block)
 	RMLUI_ASSERT(element && containing_block.x >= 0 && containing_block.y >= 0);
 
 	RootBox root(containing_block);
+	LayoutMeasureCache measure_cache;
 
 	auto layout_box = FormattingContext::FormatIndependent(&root, element, nullptr, FormattingContextType::Block);
 	if (!layout_box)

--- a/Source/Core/Layout/LayoutMeasureCache.cpp
+++ b/Source/Core/Layout/LayoutMeasureCache.cpp
@@ -1,0 +1,78 @@
+#include "LayoutMeasureCache.h"
+#include <algorithm>
+
+namespace Rml {
+
+static LayoutMeasureCache* active_measure_cache = nullptr;
+
+LayoutMeasureCache::LayoutMeasureCache() : previous_active_cache(active_measure_cache)
+{
+	active_measure_cache = this;
+}
+
+LayoutMeasureCache::~LayoutMeasureCache()
+{
+	active_measure_cache = previous_active_cache;
+}
+
+LayoutMeasureCache* LayoutMeasureCache::GetActiveCache()
+{
+	return active_measure_cache;
+}
+
+bool LayoutMeasureCache::FindShrinkToFitWidth(Element* element, Vector2f containing_block, float& shrink_to_fit_width) const
+{
+	auto it = shrink_to_fit_widths.find(element);
+	if (it == shrink_to_fit_widths.end())
+		return false;
+
+	auto it_entry = std::find_if(it->second.begin(), it->second.end(),
+		[containing_block](const ShrinkToFitWidthEntry& entry) { return entry.containing_block == containing_block; });
+	if (it_entry == it->second.end())
+		return false;
+
+	shrink_to_fit_width = it_entry->shrink_to_fit_width;
+	return true;
+}
+
+void LayoutMeasureCache::StoreShrinkToFitWidth(Element* element, Vector2f containing_block, float shrink_to_fit_width)
+{
+	shrink_to_fit_widths[element].push_back(ShrinkToFitWidthEntry{containing_block, shrink_to_fit_width});
+}
+
+bool LayoutMeasureCache::FindMaxContentSize(Element* element, Vector2f& max_content_size) const
+{
+	auto it = max_content_sizes.find(element);
+	if (it == max_content_sizes.end())
+		return false;
+
+	max_content_size = it->second;
+	return true;
+}
+
+void LayoutMeasureCache::StoreMaxContentSize(Element* element, Vector2f max_content_size)
+{
+	max_content_sizes[element] = max_content_size;
+}
+
+bool LayoutMeasureCache::FindFormattedContentHeight(Element* element, float content_width, float& formatted_content_height) const
+{
+	auto it = formatted_content_heights.find(element);
+	if (it == formatted_content_heights.end())
+		return false;
+
+	auto it_entry = std::find_if(it->second.begin(), it->second.end(),
+		[content_width](const FormattedContentHeightEntry& entry) { return entry.content_width == content_width; });
+	if (it_entry == it->second.end())
+		return false;
+
+	formatted_content_height = it_entry->formatted_content_height;
+	return true;
+}
+
+void LayoutMeasureCache::StoreFormattedContentHeight(Element* element, float content_width, float formatted_content_height)
+{
+	formatted_content_heights[element].push_back(FormattedContentHeightEntry{content_width, formatted_content_height});
+}
+
+} // namespace Rml

--- a/Source/Core/Layout/LayoutMeasureCache.h
+++ b/Source/Core/Layout/LayoutMeasureCache.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include "../../../Include/RmlUi/Core/Types.h"
+
+namespace Rml {
+
+class Element;
+
+/*
+    Memoizes content-based size measurements for the duration of a single layout pass.
+
+    Nested flex containers repeat the measurements of all their descendants, which makes the number of formatting
+    calls grow exponentially with the nesting depth. The measured values only depend on the element's subtree and the
+    given size constraints, both of which are fixed during a layout pass, so they can safely be reused until the pass
+    is completed. The cache registers itself as active during its lifetime and is instantiated at the root of each
+    layout pass.
+*/
+class LayoutMeasureCache final {
+public:
+	LayoutMeasureCache();
+	~LayoutMeasureCache();
+
+	/// Returns the currently active cache, or nullptr if no layout pass is in progress.
+	static LayoutMeasureCache* GetActiveCache();
+
+	/// Retrieves the shrink-to-fit width of an element, as previously measured under the same containing block.
+	bool FindShrinkToFitWidth(Element* element, Vector2f containing_block, float& shrink_to_fit_width) const;
+	void StoreShrinkToFitWidth(Element* element, Vector2f containing_block, float shrink_to_fit_width);
+
+	/// Retrieves the max-content size of a flex container, as previously measured.
+	bool FindMaxContentSize(Element* element, Vector2f& max_content_size) const;
+	void StoreMaxContentSize(Element* element, Vector2f max_content_size);
+
+	/// Retrieves the content height of an element, as previously formatted under the same content width.
+	bool FindFormattedContentHeight(Element* element, float content_width, float& formatted_content_height) const;
+	void StoreFormattedContentHeight(Element* element, float content_width, float formatted_content_height);
+
+private:
+	struct ShrinkToFitWidthEntry {
+		Vector2f containing_block;
+		float shrink_to_fit_width;
+	};
+	struct FormattedContentHeightEntry {
+		float content_width;
+		float formatted_content_height;
+	};
+
+	UnorderedMap<Element*, Vector<ShrinkToFitWidthEntry>> shrink_to_fit_widths;
+	UnorderedMap<Element*, Vector2f> max_content_sizes;
+	UnorderedMap<Element*, Vector<FormattedContentHeightEntry>> formatted_content_heights;
+
+	LayoutMeasureCache* previous_active_cache;
+};
+
+} // namespace Rml


### PR DESCRIPTION
One `ElementText::SetText` in a document with nested flex containers costs hundreds of milliseconds, because the document layout pass that follows formats the same elements over and over.

Counted with temporary counters in `FormattingContext::FormatIndependent`, on a document with 877 elements and 8 levels of nested flex:

* flex sizing measures every auto-sized item by formatting its whole subtree: once for the flex base size via `GetShrinkToFitWidth`, once for the hypothetical cross size, plus the final format
* `GetShrinkToFitWidth` on a flex container formats the subtree under a max width constraint, throws the result away and calls `GetMaxContentSize`, which formats everything again
* nothing is reused, each flex level multiplies the formats of everything below it
* 868446 `FormatIndependent` calls in a single layout pass
* one single text element is formatted 2880 times in that pass
* only 13929 of the 868446 calls have distinct (element, box, containing block) inputs

The fix is a cache with the lifetime of one layout pass:

* memoizes shrink-to-fit width (keyed on element and containing block), max-content size (keyed on element) and formatted content height (keyed on element and content width)
* lives on the stack in `LayoutEngine::FormatElement`, the measurement functions look it up themselves, the flex algorithm and its call sites stay as they are
* `GetShrinkToFitWidth` now goes straight to `GetMaxContentSize` for flex containers instead of formatting them first
* final formats are not cached, they have side effects

Repro: https://github.com/geforcefan/RmlUi/tree/layout-repro. Check out the branch and run `cmake -S . -B build && cmake --build build -j`. It builds the same document once against upstream master and once against this branch, both binaries print the time for 100 text mutations at startup, after that you can drag a slider and watch the update times live.

|  | 100 text mutations at startup | `FormatIndependent` calls per pass |
| --- | --- | --- |
| upstream master | 201.7 ms per mutation | 868446 |
| this branch | 3.1 ms per mutation | 10431 |

* Apple M2 Pro, Release, a wasm build of the same document behaves alike
* layout output unchanged: dump of every element's border box offset and size, byte identical between master and this branch
* unit tests pass, 140 cases, 8244 assertions
