### PR TITLE
Fix selection colors and progress fill-image that use var()

### DIFF
--- a/Source/Core/Elements/ElementProgress.cpp
+++ b/Source/Core/Elements/ElementProgress.cpp
@@ -8,6 +8,7 @@
 #include "../../../Include/RmlUi/Core/PropertyIdSet.h"
 #include "../../../Include/RmlUi/Core/StyleSheet.h"
 #include "../../../Include/RmlUi/Core/URL.h"
+#include "../ElementStyle.h"
 #include <algorithm>
 
 namespace Rml {
@@ -316,7 +317,7 @@ bool ElementProgress::LoadTexture()
 
 	String name;
 
-	if (const Property* property = GetLocalProperty(PropertyId::FillImage))
+	if (const Property* property = GetStyle()->GetLocalPropertyWithResolvedVariables(PropertyId::FillImage))
 		name = property->Get<String>();
 
 	RenderManager* render_manager = GetRenderManager();

--- a/Source/Core/Elements/WidgetTextInput.cpp
+++ b/Source/Core/Elements/WidgetTextInput.cpp
@@ -16,6 +16,7 @@
 #include "../../../Include/RmlUi/Core/TextInputContext.h"
 #include "../../../Include/RmlUi/Core/TextInputHandler.h"
 #include "../Clock.h"
+#include "../ElementStyle.h"
 #include "ElementTextSelection.h"
 #include <algorithm>
 #include <limits.h>
@@ -398,7 +399,7 @@ void WidgetTextInput::UpdateSelectionColours()
 	// Determine what the colour of the selected text is. If our 'selection' element has the 'color'
 	// attribute set, then use that. Otherwise, use the inverse of our own text colour.
 	Colourb colour;
-	const Property* colour_property = selection_element->GetLocalProperty(PropertyId::Color);
+	const Property* colour_property = selection_element->GetStyle()->GetLocalPropertyWithResolvedVariables(PropertyId::Color);
 	if (colour_property)
 		colour = colour_property->Get<Colourb>();
 	else
@@ -415,7 +416,7 @@ void WidgetTextInput::UpdateSelectionColours()
 	// If the 'background-color' property has been set on the 'selection' element, use that as the
 	// background colour for the selected text. Otherwise, use the inverse of the selected text
 	// colour.
-	colour_property = selection_element->GetLocalProperty(PropertyId::BackgroundColor);
+	colour_property = selection_element->GetStyle()->GetLocalPropertyWithResolvedVariables(PropertyId::BackgroundColor);
 	if (colour_property)
 		colour = colour_property->Get<Colourb>();
 	else


### PR DESCRIPTION
The selection colors of a text input are ignored when they come from variables:

```css
input.text selection { background-color: var(--selection); color: var(--foreground); }
```

The same rule with plain colors works, the var() version falls back to the inverted text color.

`WidgetTextInput::UpdateSelectionColours` reads the local properties of the selection element before variables are resolved, so the values are still var expressions instead of colors. `ElementProgress::LoadTexture` reads `fill-image` the same way and ends up with the raw expression as its texture name. Switch both to `GetLocalPropertyWithResolvedVariables`, like 95c6fc15 did for the other direct local property reads (see #951).