### PR TITLE
Unified and extended custom RTTI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
           - cmake_options: -DRMLUI_BACKEND=GLFW_GL3 -DBUILD_TESTING=ON
             enable_testing: true
           - cmake_options: -DRMLUI_BACKEND=X11_GL2 -DRMLUI_LOTTIE_PLUGIN=ON
-          - cmake_options: -DRMLUI_BACKEND=SDL_GL2 -DRMLUI_CUSTOM_RTTI=ON -DCMAKE_CXX_FLAGS="-fno-exceptions -fno-rtti"
+          - cmake_options: -DRMLUI_BACKEND=SDL_GL2 -DCMAKE_CXX_FLAGS="-fno-exceptions -fno-rtti"
           - cmake_options: -DRMLUI_BACKEND=SFML_GL2 -DRMLUI_THIRDPARTY_CONTAINERS=OFF
           - cmake_options: -DRMLUI_BACKEND=GLFW_VK -DCMAKE_BUILD_TYPE=Debug -DRMLUI_VK_DEBUG=ON -DRMLUI_PRECOMPILED_HEADERS=OFF
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,8 +73,6 @@ option(RMLUI_THIRDPARTY_CONTAINERS "Enable integrated third-party containers for
 
 option(RMLUI_MATRIX_ROW_MAJOR "Use row-major matrices. Column-major matrices are used by default." OFF)
 
-option(RMLUI_CUSTOM_RTTI "Build RmlUi with a custom implementation of run-time type information (RTTI). When enabled, all usage of language RTTI features such as dynamic_cast will be disabled." OFF)
-
 option(RMLUI_PRECOMPILED_HEADERS "Enable precompiled headers for RmlUi." ON)
 
 option(RMLUI_COMPILER_OPTIONS "Enable recommended compiler-specific options for the project, such as for supported warning level, standards conformance, and multiprocess builds. Turn off for full control over compiler flags." ON)

--- a/Include/RmlUi/Core/Element.h
+++ b/Include/RmlUi/Core/Element.h
@@ -46,7 +46,7 @@ struct StackingContextChild;
 
 class RMLUICORE_API Element : public ScriptInterface, public EnableObserverPtr<Element> {
 public:
-	RMLUI_RTTI_DefineWithParent(Element, ScriptInterface)
+	RMLUI_RTTI_DeclareWithParent(Element, ScriptInterface)
 
 	/// Constructs a new RmlUi element. This should not be called directly; use the Factory instead.
 	/// @param[in] tag The tag the element was declared as in RML.

--- a/Include/RmlUi/Core/ElementDocument.h
+++ b/Include/RmlUi/Core/ElementDocument.h
@@ -37,7 +37,7 @@ enum class ScrollFlag {
 
 class RMLUICORE_API ElementDocument : public Element {
 public:
-	RMLUI_RTTI_DefineWithParent(ElementDocument, Element)
+	RMLUI_RTTI_DeclareWithParent(ElementDocument, Element)
 
 	ElementDocument(const String& tag);
 	virtual ~ElementDocument();

--- a/Include/RmlUi/Core/ElementText.h
+++ b/Include/RmlUi/Core/ElementText.h
@@ -8,7 +8,7 @@ namespace Rml {
 
 class RMLUICORE_API ElementText final : public Element {
 public:
-	RMLUI_RTTI_DefineWithParent(ElementText, Element)
+	RMLUI_RTTI_DeclareWithParent(ElementText, Element)
 
 	ElementText(const String& tag);
 	virtual ~ElementText();

--- a/Include/RmlUi/Core/Elements/ElementForm.h
+++ b/Include/RmlUi/Core/Elements/ElementForm.h
@@ -11,7 +11,7 @@ namespace Rml {
 
 class RMLUICORE_API ElementForm : public Element {
 public:
-	RMLUI_RTTI_DefineWithParent(ElementForm, Element)
+	RMLUI_RTTI_DeclareWithParent(ElementForm, Element)
 
 	/// Constructs a new ElementForm. This should not be called directly; use the Factory instead.
 	/// @param[in] tag The tag the element was declared as in RML.

--- a/Include/RmlUi/Core/Elements/ElementFormControl.h
+++ b/Include/RmlUi/Core/Elements/ElementFormControl.h
@@ -11,7 +11,7 @@ namespace Rml {
 
 class RMLUICORE_API ElementFormControl : public Element {
 public:
-	RMLUI_RTTI_DefineWithParent(ElementFormControl, Element)
+	RMLUI_RTTI_DeclareWithParent(ElementFormControl, Element)
 
 	/// Constructs a new ElementFormControl. This should not be called directly; use the Factory
 	/// instead.

--- a/Include/RmlUi/Core/Elements/ElementFormControlInput.h
+++ b/Include/RmlUi/Core/Elements/ElementFormControlInput.h
@@ -13,7 +13,7 @@ class InputType;
 
 class RMLUICORE_API ElementFormControlInput : public ElementFormControl {
 public:
-	RMLUI_RTTI_DefineWithParent(ElementFormControlInput, ElementFormControl)
+	RMLUI_RTTI_DeclareWithParent(ElementFormControlInput, ElementFormControl)
 
 	/// Constructs a new ElementFormControlInput. This should not be called directly; use the
 	/// Factory instead.

--- a/Include/RmlUi/Core/Elements/ElementFormControlSelect.h
+++ b/Include/RmlUi/Core/Elements/ElementFormControlSelect.h
@@ -13,7 +13,7 @@ class WidgetDropDown;
 
 class RMLUICORE_API ElementFormControlSelect : public ElementFormControl {
 public:
-	RMLUI_RTTI_DefineWithParent(ElementFormControlSelect, ElementFormControl)
+	RMLUI_RTTI_DeclareWithParent(ElementFormControlSelect, ElementFormControl)
 
 	/// Constructs a new ElementFormControlSelect. This should not be called directly; use the
 	/// Factory instead.

--- a/Include/RmlUi/Core/Elements/ElementFormControlTextArea.h
+++ b/Include/RmlUi/Core/Elements/ElementFormControlTextArea.h
@@ -13,7 +13,7 @@ class WidgetTextInputMultiLine;
 
 class RMLUICORE_API ElementFormControlTextArea : public ElementFormControl {
 public:
-	RMLUI_RTTI_DefineWithParent(ElementFormControlTextArea, ElementFormControl)
+	RMLUI_RTTI_DeclareWithParent(ElementFormControlTextArea, ElementFormControl)
 
 	/// Constructs a new ElementFormControlTextArea. This should not be called directly; use the
 	/// Factory instead.

--- a/Include/RmlUi/Core/Elements/ElementProgress.h
+++ b/Include/RmlUi/Core/Elements/ElementProgress.h
@@ -30,7 +30,7 @@ namespace Rml {
 
 class RMLUICORE_API ElementProgress : public Element {
 public:
-	RMLUI_RTTI_DefineWithParent(ElementProgress, Element)
+	RMLUI_RTTI_DeclareWithParent(ElementProgress, Element)
 
 	/// Constructs a new ElementProgress. This should not be called directly; use the Factory instead.
 	/// @param[in] tag The tag the element was declared as in RML.

--- a/Include/RmlUi/Core/Elements/ElementTabSet.h
+++ b/Include/RmlUi/Core/Elements/ElementTabSet.h
@@ -11,7 +11,7 @@ namespace Rml {
 
 class RMLUICORE_API ElementTabSet : public Element {
 public:
-	RMLUI_RTTI_DefineWithParent(ElementTabSet, Element)
+	RMLUI_RTTI_DeclareWithParent(ElementTabSet, Element)
 
 	ElementTabSet(const String& tag);
 	~ElementTabSet();

--- a/Include/RmlUi/Core/Platform.h
+++ b/Include/RmlUi/Core/Platform.h
@@ -48,3 +48,11 @@
 #else
 	#define RMLUI_ATTRIBUTE_FORMAT_PRINTF(i, f)
 #endif
+
+#ifdef __has_feature
+#if __has_feature(cxx_rtti)
+#define RMLUI_HAS_RTTI
+#endif
+#elif defined(__GXX_RTTI) || defined(_CPPRTTI)
+#define RMLUI_HAS_RTTI
+#endif

--- a/Include/RmlUi/Core/ScriptInterface.h
+++ b/Include/RmlUi/Core/ScriptInterface.h
@@ -12,7 +12,7 @@ namespace Rml {
 
 class RMLUICORE_API ScriptInterface : public Releasable {
 public:
-	RMLUI_RTTI_Define(ScriptInterface)
+	RMLUI_RTTI_Declare(ScriptInterface)
 
 	virtual ~ScriptInterface() {}
 

--- a/Include/RmlUi/Core/Traits.h
+++ b/Include/RmlUi/Core/Traits.h
@@ -73,6 +73,10 @@ public:
 	{                                                         \
 		return #_NAME_;                                       \
 	}                                                         \
+	virtual void* GetClassIdentifier() const                  \
+	{                                                         \
+		return GetStaticClassIdentifier();                    \
+	}                                                         \
 	virtual bool IsClass(void* type_identifier) const         \
 	{                                                         \
 		return type_identifier == GetStaticClassIdentifier(); \
@@ -92,6 +96,10 @@ public:
 	static const char* GetStaticClassName()                                                         \
 	{                                                                                               \
 		return #_NAME_;                                                                             \
+	}                                                                                               \
+	void* GetClassIdentifier() const override                                                       \
+	{                                                                                               \
+		return GetStaticClassIdentifier();                                                          \
 	}                                                                                               \
 	bool IsClass(void* type_identifier) const override                                              \
 	{                                                                                               \

--- a/Include/RmlUi/Core/Traits.h
+++ b/Include/RmlUi/Core/Traits.h
@@ -75,48 +75,41 @@ struct has_custom_rtti {
 
 } // namespace Rml
  
-#define RMLUI_RTTI_Define(_NAME_)                             \
-	using RttiClassType = _NAME_;                             \
+#define RMLUI_RTTI_Declare(NAME)                              \
+	using RttiClassType = NAME;                               \
+	using RttiParentClassType = NAME;                         \
 	static Rml::ClassId GetStaticClassIdentifier();           \
 	virtual Rml::ClassId GetClassIdentifier() const;          \
 	virtual bool IsClass(Rml::ClassId type_identifier) const;
 
-#define RMLUI_RTTI_DefineWithParent(_NAME_, _PARENT_)                                               \
-	using RttiClassType = _NAME_;                                                                   \
-	static_assert(std::is_same<typename _PARENT_::RttiClassType, _PARENT_>::value,                  \
-		"Parent does not implement RMLUI_RTTI_Define or RMLUI_RTTI_DefineWithParent");              \
+#define RMLUI_RTTI_DeclareWithParent(NAME, PARENT)                                                  \
+	using RttiClassType = NAME;                                                                     \
+	using RttiParentClassType = PARENT;                                                             \
+	static_assert(std::is_same<typename PARENT::RttiClassType, PARENT>::value,                      \
+		"Parent does not implement RMLUI_RTTI_Declare or RMLUI_RTTI_DeclareWithParent");            \
 	static Rml::ClassId GetStaticClassIdentifier();                                                 \
 	Rml::ClassId GetClassIdentifier() const override;                                               \
 	bool IsClass(Rml::ClassId type_identifier) const override;
 
-#define RMLUI_RTTI_Define_Implementation(_NAME_)              \
-	Rml::ClassId _NAME_::GetStaticClassIdentifier()           \
-	{                                                         \
-		static int dummy;                                     \
-		return &dummy;                                        \
-	}                                                         \
-	Rml::ClassId _NAME_::GetClassIdentifier() const           \
-	{                                                         \
-		return GetStaticClassIdentifier();                    \
-	}                                                         \
-	bool _NAME_::IsClass(Rml::ClassId type_identifier) const  \
-	{                                                         \
-		return type_identifier == GetStaticClassIdentifier(); \
-	}
-
-#define RMLUI_RTTI_Define_Implementation_WithParent(_NAME_, _PARENT_)                               \
-	Rml::ClassId _NAME_::GetStaticClassIdentifier()                                                 \
-	{                                                                                               \
-			static int dummy;                                                                       \
-			return &dummy;                                                                          \
-	}                                                                                               \
-	Rml::ClassId _NAME_::GetClassIdentifier() const                                                 \
-	{                                                                                               \
-		return GetStaticClassIdentifier();                                                          \
-	}                                                                                               \
-	bool _NAME_::IsClass(Rml::ClassId type_identifier) const                                        \
-	{                                                                                               \
-		return type_identifier == GetStaticClassIdentifier() || _PARENT_::IsClass(type_identifier); \
+#define RMLUI_RTTI_Define(NAME)                                           \
+	Rml::ClassId NAME::GetStaticClassIdentifier()                         \
+	{                                                                     \
+		static int dummy;                                                 \
+		return &dummy;                                                    \
+	}                                                                     \
+	Rml::ClassId NAME::GetClassIdentifier() const                         \
+	{                                                                     \
+		return GetStaticClassIdentifier();                                \
+	}                                                                     \
+	bool NAME::IsClass(Rml::ClassId type_identifier) const                \
+	{                                                                     \
+		if constexpr (!std::is_same_v<NAME, NAME::RttiParentClassType>) { \
+			return type_identifier == GetStaticClassIdentifier()          \
+					|| RttiParentClassType::IsClass(type_identifier);     \
+		}                                                                 \
+		else {                                                            \
+			return type_identifier == GetStaticClassIdentifier();         \
+		}                                                                 \
 	}
 
 #ifndef RMLUI_HAS_RTTI

--- a/Include/RmlUi/Core/Traits.h
+++ b/Include/RmlUi/Core/Traits.h
@@ -62,6 +62,17 @@ public:
 
 using ClassId = void*;
 
+template <typename T>
+struct has_custom_rtti {
+	template <typename U>
+	static auto test(int) -> decltype(U::GetClassIdentifier(), std::true_type());
+
+	template <typename U>
+	static std::false_type test(...);
+
+	static constexpr bool value = decltype(test<T>(0))::value;
+};
+
 } // namespace Rml
  
 #define RMLUI_RTTI_Define(_NAME_)                             \

--- a/Include/RmlUi/Core/Traits.h
+++ b/Include/RmlUi/Core/Traits.h
@@ -60,17 +60,6 @@ public:
 	}
 };
 
-template <typename T>
-struct has_custom_rtti {
-	template <typename U>
-	static auto test(int) -> decltype(U::GetStaticClassIdentifier(), std::true_type());
-
-	template <typename U>
-	static std::false_type test(...);
-
-	static constexpr bool value = decltype(test<T>(0))::value;
-};
-
 } // namespace Rml
  
 #define RMLUI_RTTI_Define(_NAME_)                             \
@@ -80,17 +69,9 @@ struct has_custom_rtti {
 		static int dummy;                                     \
 		return &dummy;                                        \
 	}                                                         \
-	static constexpr const char* GetStaticClassName()         \
-	{                                                         \
-		return #_NAME_;                                       \
-	}                                                         \
 	virtual bool IsClass(void* type_identifier) const         \
 	{                                                         \
 		return type_identifier == GetStaticClassIdentifier(); \
-	}                                                         \
-	virtual const char* GetClassName() const                  \
-	{                                                         \
-		return #_NAME_;                                       \
 	}
 
 #define RMLUI_RTTI_DefineWithParent(_NAME_, _PARENT_)                                               \
@@ -100,44 +81,14 @@ struct has_custom_rtti {
 		static int dummy;                                                                           \
 		return &dummy;                                                                              \
 	}                                                                                               \
-	static constexpr const char* GetStaticClassName()                                               \
-	{                                                                                               \
-		return #_NAME_;                                                                             \
-	}                                                                                               \
 	bool IsClass(void* type_identifier) const override                                              \
 	{                                                                                               \
 		static_assert(std::is_same<typename _PARENT_::RttiClassType, _PARENT_>::value,              \
 			"Parent does not implement RMLUI_RTTI_Define or RMLUI_RTTI_DefineWithParent");          \
 		return type_identifier == GetStaticClassIdentifier() || _PARENT_::IsClass(type_identifier); \
-	}                                                                                               \
-	const char* GetClassName() const override                                                       \
-	{                                                                                               \
-		return #_NAME_;                                                                             \
 	}
-
 
 #ifdef RMLUI_CUSTOM_RTTI
-
-template <typename, typename = void>
-struct RTTITypeNameGetter;
-
-template <typename T>
-struct RTTITypeNameGetter<T, typename std::enable_if<Rml::has_custom_rtti<T>::value>::type> {
-	static constexpr const char* name = T::GetStaticClassName();
-
-	const char* operator()(const T& var) const {
-		return var.GetClassName();
-	}
-};
-
-template <typename T>
-struct RTTITypeNameGetter<T, typename std::enable_if<!Rml::has_custom_rtti<T>::value>::type> {
-	static constexpr const char* name = "(type name unavailable)";
-
-	const char* operator()(const T& /*var*/) const {
-		return "(type name unavailable)";
-	}
-};
 
 template <class Derived, class Base>
 Derived rmlui_dynamic_cast(Base base_instance)
@@ -161,15 +112,15 @@ Derived rmlui_static_cast(Base base_instance)
 }
 
 template <class T>
-const char* rmlui_type_name(const T& var)
+const char* rmlui_type_name(const T& /*var*/)
 {
-	return RTTITypeNameGetter<T>{}(var);
+	return "(type name unavailable)";
 }
 
 template <class T>
 const char* rmlui_type_name()
 {
-	return RTTITypeNameGetter<T>::name;
+	return "(type name unavailable)";
 }
 
 #else

--- a/Include/RmlUi/Core/Traits.h
+++ b/Include/RmlUi/Core/Traits.h
@@ -60,8 +60,19 @@ public:
 	}
 };
 
-} // namespace Rml
+template <typename T>
+struct has_custom_rtti {
+	template <typename U>
+	static auto test(int) -> decltype(U::GetStaticClassIdentifier(), std::true_type());
 
+	template <typename U>
+	static std::false_type test(...);
+
+	static constexpr bool value = decltype(test<T>(0))::value;
+};
+
+} // namespace Rml
+ 
 #define RMLUI_RTTI_Define(_NAME_)                             \
 	using RttiClassType = _NAME_;                             \
 	static void* GetStaticClassIdentifier()                   \
@@ -69,13 +80,9 @@ public:
 		static int dummy;                                     \
 		return &dummy;                                        \
 	}                                                         \
-	static const char* GetStaticClassName()                   \
+	static constexpr const char* GetStaticClassName()         \
 	{                                                         \
 		return #_NAME_;                                       \
-	}                                                         \
-	virtual void* GetClassIdentifier() const                  \
-	{                                                         \
-		return GetStaticClassIdentifier();                    \
 	}                                                         \
 	virtual bool IsClass(void* type_identifier) const         \
 	{                                                         \
@@ -93,13 +100,9 @@ public:
 		static int dummy;                                                                           \
 		return &dummy;                                                                              \
 	}                                                                                               \
-	static const char* GetStaticClassName()                                                         \
+	static constexpr const char* GetStaticClassName()                                               \
 	{                                                                                               \
 		return #_NAME_;                                                                             \
-	}                                                                                               \
-	void* GetClassIdentifier() const override                                                       \
-	{                                                                                               \
-		return GetStaticClassIdentifier();                                                          \
 	}                                                                                               \
 	bool IsClass(void* type_identifier) const override                                              \
 	{                                                                                               \
@@ -111,6 +114,30 @@ public:
 	{                                                                                               \
 		return #_NAME_;                                                                             \
 	}
+
+
+#ifdef RMLUI_CUSTOM_RTTI
+
+template <typename, typename = void>
+struct RTTITypeNameGetter;
+
+template <typename T>
+struct RTTITypeNameGetter<T, typename std::enable_if<Rml::has_custom_rtti<T>::value>::type> {
+	static constexpr const char* name = T::GetStaticClassName();
+
+	const char* operator()(const T& var) const {
+		return var.GetClassName();
+	}
+};
+
+template <typename T>
+struct RTTITypeNameGetter<T, typename std::enable_if<!Rml::has_custom_rtti<T>::value>::type> {
+	static constexpr const char* name = "(type name unavailable)";
+
+	const char* operator()(const T& /*var*/) const {
+		return "(type name unavailable)";
+	}
+};
 
 template <class Derived, class Base>
 Derived rmlui_dynamic_cast(Base base_instance)
@@ -136,11 +163,44 @@ Derived rmlui_static_cast(Base base_instance)
 template <class T>
 const char* rmlui_type_name(const T& var)
 {
-	return var.GetClassName();
+	return RTTITypeNameGetter<T>{}(var);
 }
 
 template <class T>
 const char* rmlui_type_name()
 {
-	return T::GetStaticClassName();
+	return RTTITypeNameGetter<T>::name;
 }
+
+#else
+
+	#include <typeinfo>
+
+template <class Derived, class Base>
+Derived rmlui_dynamic_cast(Base base_instance)
+{
+	static_assert(std::is_pointer<Derived>::value && std::is_pointer<Base>::value, "rmlui_dynamic_cast can only cast pointer types");
+	return dynamic_cast<Derived>(base_instance);
+}
+
+template <class Derived, class Base>
+Derived rmlui_static_cast(Base base_instance)
+{
+	static_assert(std::is_pointer<Derived>::value && std::is_pointer<Base>::value, "rmlui_static_cast can only cast pointer types");
+	RMLUI_ASSERT(dynamic_cast<Derived>(base_instance));
+	return static_cast<Derived>(base_instance);
+}
+
+template <class T>
+const char* rmlui_type_name(const T& var)
+{
+	return typeid(var).name();
+}
+
+template <class T>
+const char* rmlui_type_name()
+{
+	return typeid(T).name();
+}
+
+#endif // RMLUI_CUSTOM_RTTI

--- a/Include/RmlUi/Core/Traits.h
+++ b/Include/RmlUi/Core/Traits.h
@@ -62,33 +62,47 @@ public:
 
 } // namespace Rml
 
-#ifdef RMLUI_CUSTOM_RTTI
+#define RMLUI_RTTI_Define(_NAME_)                             \
+	using RttiClassType = _NAME_;                             \
+	static void* GetStaticClassIdentifier()                   \
+	{                                                         \
+		static int dummy;                                     \
+		return &dummy;                                        \
+	}                                                         \
+	static const char* GetStaticClassName()                   \
+	{                                                         \
+		return #_NAME_;                                       \
+	}                                                         \
+	virtual bool IsClass(void* type_identifier) const         \
+	{                                                         \
+		return type_identifier == GetStaticClassIdentifier(); \
+	}                                                         \
+	virtual const char* GetClassName() const                  \
+	{                                                         \
+		return #_NAME_;                                       \
+	}
 
-	#define RMLUI_RTTI_Define(_NAME_)                             \
-		using RttiClassType = _NAME_;                             \
-		static void* GetStaticClassIdentifier()                   \
-		{                                                         \
-			static int dummy;                                     \
-			return &dummy;                                        \
-		}                                                         \
-		virtual bool IsClass(void* type_identifier) const         \
-		{                                                         \
-			return type_identifier == GetStaticClassIdentifier(); \
-		}
-
-	#define RMLUI_RTTI_DefineWithParent(_NAME_, _PARENT_)                                               \
-		using RttiClassType = _NAME_;                                                                   \
-		static void* GetStaticClassIdentifier()                                                         \
-		{                                                                                               \
-			static int dummy;                                                                           \
-			return &dummy;                                                                              \
-		}                                                                                               \
-		bool IsClass(void* type_identifier) const override                                              \
-		{                                                                                               \
-			static_assert(std::is_same<typename _PARENT_::RttiClassType, _PARENT_>::value,              \
-				"Parent does not implement RMLUI_RTTI_Define or RMLUI_RTTI_DefineWithParent");          \
-			return type_identifier == GetStaticClassIdentifier() || _PARENT_::IsClass(type_identifier); \
-		}
+#define RMLUI_RTTI_DefineWithParent(_NAME_, _PARENT_)                                               \
+	using RttiClassType = _NAME_;                                                                   \
+	static void* GetStaticClassIdentifier()                                                         \
+	{                                                                                               \
+		static int dummy;                                                                           \
+		return &dummy;                                                                              \
+	}                                                                                               \
+	static const char* GetStaticClassName()                                                         \
+	{                                                                                               \
+		return #_NAME_;                                                                             \
+	}                                                                                               \
+	bool IsClass(void* type_identifier) const override                                              \
+	{                                                                                               \
+		static_assert(std::is_same<typename _PARENT_::RttiClassType, _PARENT_>::value,              \
+			"Parent does not implement RMLUI_RTTI_Define or RMLUI_RTTI_DefineWithParent");          \
+		return type_identifier == GetStaticClassIdentifier() || _PARENT_::IsClass(type_identifier); \
+	}                                                                                               \
+	const char* GetClassName() const override                                                       \
+	{                                                                                               \
+		return #_NAME_;                                                                             \
+	}
 
 template <class Derived, class Base>
 Derived rmlui_dynamic_cast(Base base_instance)
@@ -112,49 +126,13 @@ Derived rmlui_static_cast(Base base_instance)
 }
 
 template <class T>
-const char* rmlui_type_name(const T& /*var*/)
-{
-	return "(type name unavailable)";
-}
-
-template <class T>
-const char* rmlui_type_name()
-{
-	return "(type name unavailable)";
-}
-
-#else
-
-	#include <typeinfo>
-
-	#define RMLUI_RTTI_Define(_NAME_)
-	#define RMLUI_RTTI_DefineWithParent(_NAME_, _PARENT_)
-
-template <class Derived, class Base>
-Derived rmlui_dynamic_cast(Base base_instance)
-{
-	static_assert(std::is_pointer<Derived>::value && std::is_pointer<Base>::value, "rmlui_dynamic_cast can only cast pointer types");
-	return dynamic_cast<Derived>(base_instance);
-}
-
-template <class Derived, class Base>
-Derived rmlui_static_cast(Base base_instance)
-{
-	static_assert(std::is_pointer<Derived>::value && std::is_pointer<Base>::value, "rmlui_static_cast can only cast pointer types");
-	RMLUI_ASSERT(dynamic_cast<Derived>(base_instance));
-	return static_cast<Derived>(base_instance);
-}
-
-template <class T>
 const char* rmlui_type_name(const T& var)
 {
-	return typeid(var).name();
+	return var.GetClassName();
 }
 
 template <class T>
 const char* rmlui_type_name()
 {
-	return typeid(T).name();
+	return T::GetStaticClassName();
 }
-
-#endif // RMLUI_CUSTOM_RTTI

--- a/Include/RmlUi/Core/Traits.h
+++ b/Include/RmlUi/Core/Traits.h
@@ -108,7 +108,7 @@ using ClassId = void*;
 		return type_identifier == GetStaticClassIdentifier() || _PARENT_::IsClass(type_identifier); \
 	}
 
-#ifdef RMLUI_CUSTOM_RTTI
+#ifndef RMLUI_HAS_RTTI
 
 template <class Derived, class Base>
 Derived rmlui_dynamic_cast(Base base_instance)
@@ -174,4 +174,4 @@ const char* rmlui_type_name()
 	return typeid(T).name();
 }
 
-#endif // RMLUI_CUSTOM_RTTI
+#endif // !RMLUI_HAS_RTTI

--- a/Include/RmlUi/Core/Traits.h
+++ b/Include/RmlUi/Core/Traits.h
@@ -65,7 +65,7 @@ using ClassId = void*;
 template <typename T>
 struct has_custom_rtti {
 	template <typename U>
-	static auto test(int) -> decltype(U::GetClassIdentifier(), std::true_type());
+	static auto test(int) -> decltype(U::GetStaticClassIdentifier(), std::true_type());
 
 	template <typename U>
 	static std::false_type test(...);

--- a/Include/RmlUi/Core/Traits.h
+++ b/Include/RmlUi/Core/Traits.h
@@ -60,31 +60,51 @@ public:
 	}
 };
 
+using ClassId = void*;
+
 } // namespace Rml
  
 #define RMLUI_RTTI_Define(_NAME_)                             \
 	using RttiClassType = _NAME_;                             \
-	static void* GetStaticClassIdentifier()                   \
+	static Rml::ClassId GetStaticClassIdentifier();           \
+	virtual Rml::ClassId GetClassIdentifier() const;          \
+	virtual bool IsClass(Rml::ClassId type_identifier) const;
+
+#define RMLUI_RTTI_DefineWithParent(_NAME_, _PARENT_)                                               \
+	using RttiClassType = _NAME_;                                                                   \
+	static_assert(std::is_same<typename _PARENT_::RttiClassType, _PARENT_>::value,                  \
+		"Parent does not implement RMLUI_RTTI_Define or RMLUI_RTTI_DefineWithParent");              \
+	static Rml::ClassId GetStaticClassIdentifier();                                                 \
+	Rml::ClassId GetClassIdentifier() const override;                                               \
+	bool IsClass(Rml::ClassId type_identifier) const override;
+
+#define RMLUI_RTTI_Define_Implementation(_NAME_)              \
+	Rml::ClassId _NAME_::GetStaticClassIdentifier()           \
 	{                                                         \
 		static int dummy;                                     \
 		return &dummy;                                        \
 	}                                                         \
-	virtual bool IsClass(void* type_identifier) const         \
+	Rml::ClassId _NAME_::GetClassIdentifier() const           \
+	{                                                         \
+		return GetStaticClassIdentifier();                    \
+	}                                                         \
+	bool _NAME_::IsClass(Rml::ClassId type_identifier) const  \
 	{                                                         \
 		return type_identifier == GetStaticClassIdentifier(); \
 	}
 
-#define RMLUI_RTTI_DefineWithParent(_NAME_, _PARENT_)                                               \
-	using RttiClassType = _NAME_;                                                                   \
-	static void* GetStaticClassIdentifier()                                                         \
+#define RMLUI_RTTI_Define_Implementation_WithParent(_NAME_, _PARENT_)                               \
+	Rml::ClassId _NAME_::GetStaticClassIdentifier()                                                 \
 	{                                                                                               \
-		static int dummy;                                                                           \
-		return &dummy;                                                                              \
+			static int dummy;                                                                       \
+			return &dummy;                                                                          \
 	}                                                                                               \
-	bool IsClass(void* type_identifier) const override                                              \
+	Rml::ClassId _NAME_::GetClassIdentifier() const                                                 \
 	{                                                                                               \
-		static_assert(std::is_same<typename _PARENT_::RttiClassType, _PARENT_>::value,              \
-			"Parent does not implement RMLUI_RTTI_Define or RMLUI_RTTI_DefineWithParent");          \
+		return GetStaticClassIdentifier();                                                          \
+	}                                                                                               \
+	bool _NAME_::IsClass(Rml::ClassId type_identifier) const                                        \
+	{                                                                                               \
 		return type_identifier == GetStaticClassIdentifier() || _PARENT_::IsClass(type_identifier); \
 	}
 

--- a/Include/RmlUi/Lottie/ElementLottie.h
+++ b/Include/RmlUi/Lottie/ElementLottie.h
@@ -13,7 +13,7 @@ namespace Rml {
 
 class RMLUICORE_API ElementLottie : public Element {
 public:
-	RMLUI_RTTI_DefineWithParent(ElementLottie, Element)
+	RMLUI_RTTI_DeclareWithParent(ElementLottie, Element)
 
 	ElementLottie(const String& tag);
 	virtual ~ElementLottie();

--- a/Include/RmlUi/SVG/ElementSVG.h
+++ b/Include/RmlUi/SVG/ElementSVG.h
@@ -10,7 +10,7 @@ namespace SVG {
 
 class RMLUICORE_API ElementSVG : public Element {
 public:
-	RMLUI_RTTI_DefineWithParent(ElementSVG, Element)
+	RMLUI_RTTI_DeclareWithParent(ElementSVG, Element)
 
 	explicit ElementSVG(const String& tag);
 	~ElementSVG() override;

--- a/Source/Core/CMakeLists.txt
+++ b/Source/Core/CMakeLists.txt
@@ -167,6 +167,7 @@ add_library(rmlui_core
 	RenderManager.cpp
 	RenderManagerAccess.cpp
 	RenderManagerAccess.h
+	ScriptInterface.cpp
 	ScrollController.cpp
 	ScrollController.h
 	Spritesheet.cpp

--- a/Source/Core/CMakeLists.txt
+++ b/Source/Core/CMakeLists.txt
@@ -438,11 +438,6 @@ if(NOT RMLUI_THIRDPARTY_CONTAINERS)
 	message(STATUS "Disabling third-party containers for RmlUi.")
 endif()
 
-if(RMLUI_CUSTOM_RTTI)
-	target_compile_definitions(rmlui_core PUBLIC "RMLUI_CUSTOM_RTTI")
-	message(STATUS "Enabling custom RTTI for RmlUi.")
-endif()
-
 if(RMLUI_MATRIX_ROW_MAJOR)
 	target_compile_definitions(rmlui_core PUBLIC "RMLUI_MATRIX_ROW_MAJOR")
 	message(STATUS "Configuring RmlUi to use row-major matrix types.")

--- a/Source/Core/CMakeLists.txt
+++ b/Source/Core/CMakeLists.txt
@@ -437,11 +437,6 @@ if(NOT RMLUI_THIRDPARTY_CONTAINERS)
 	message(STATUS "Disabling third-party containers for RmlUi.")
 endif()
 
-if(RMLUI_CUSTOM_RTTI)
-	target_compile_definitions(rmlui_core PUBLIC "RMLUI_CUSTOM_RTTI")
-	message(STATUS "Enabling custom RTTI for RmlUi.")
-endif()
-
 if(RMLUI_MATRIX_ROW_MAJOR)
 	target_compile_definitions(rmlui_core PUBLIC "RMLUI_MATRIX_ROW_MAJOR")
 	message(STATUS "Configuring RmlUi to use row-major matrix types.")

--- a/Source/Core/CMakeLists.txt
+++ b/Source/Core/CMakeLists.txt
@@ -437,6 +437,11 @@ if(NOT RMLUI_THIRDPARTY_CONTAINERS)
 	message(STATUS "Disabling third-party containers for RmlUi.")
 endif()
 
+if(RMLUI_CUSTOM_RTTI)
+	target_compile_definitions(rmlui_core PUBLIC "RMLUI_CUSTOM_RTTI")
+	message(STATUS "Enabling custom RTTI for RmlUi.")
+endif()
+
 if(RMLUI_MATRIX_ROW_MAJOR)
 	target_compile_definitions(rmlui_core PUBLIC "RMLUI_MATRIX_ROW_MAJOR")
 	message(STATUS "Configuring RmlUi to use row-major matrix types.")

--- a/Source/Core/Element.cpp
+++ b/Source/Core/Element.cpp
@@ -67,7 +67,7 @@ static float GetScrollOffsetDelta(ScrollAlignment alignment, float begin_offset,
 	return 0.f;
 }
 
-RMLUI_RTTI_Define_Implementation_WithParent(Element, ScriptInterface)
+RMLUI_RTTI_Define(Element)
 
 Element::Element(const String& tag) :
 	local_stacking_context(false), local_stacking_context_forced(false), stacking_context_dirty(false), computed_values_are_default_initialized(true),

--- a/Source/Core/Element.cpp
+++ b/Source/Core/Element.cpp
@@ -67,6 +67,8 @@ static float GetScrollOffsetDelta(ScrollAlignment alignment, float begin_offset,
 	return 0.f;
 }
 
+RMLUI_RTTI_Define_Implementation_WithParent(Element, ScriptInterface)
+
 Element::Element(const String& tag) :
 	local_stacking_context(false), local_stacking_context_forced(false), stacking_context_dirty(false), computed_values_are_default_initialized(true),
 	visible(true), offset_fixed(false), absolute_offset_dirty(true), rounded_main_padding_size_dirty(true), dirty_definition(false),

--- a/Source/Core/ElementDocument.cpp
+++ b/Source/Core/ElementDocument.cpp
@@ -121,6 +121,8 @@ namespace {
 
 } // namespace
 
+RMLUI_RTTI_Define_Implementation_WithParent(ElementDocument, Element)
+
 ElementDocument::ElementDocument(const String& tag) : Element(tag)
 {
 	context = nullptr;

--- a/Source/Core/ElementDocument.cpp
+++ b/Source/Core/ElementDocument.cpp
@@ -121,7 +121,7 @@ namespace {
 
 } // namespace
 
-RMLUI_RTTI_Define_Implementation_WithParent(ElementDocument, Element)
+RMLUI_RTTI_Define(ElementDocument)
 
 ElementDocument::ElementDocument(const String& tag) : Element(tag)
 {

--- a/Source/Core/ElementHandle.cpp
+++ b/Source/Core/ElementHandle.cpp
@@ -224,6 +224,8 @@ public:
 	}
 };
 
+RMLUI_RTTI_Define_Implementation_WithParent(ElementHandle, Element)
+
 ElementHandle::ElementHandle(const String& tag) : Element(tag), drag_start(0, 0)
 {
 	// Make sure we can be dragged!

--- a/Source/Core/ElementHandle.cpp
+++ b/Source/Core/ElementHandle.cpp
@@ -224,7 +224,7 @@ public:
 	}
 };
 
-RMLUI_RTTI_Define_Implementation_WithParent(ElementHandle, Element)
+RMLUI_RTTI_Define(ElementHandle)
 
 ElementHandle::ElementHandle(const String& tag) : Element(tag), drag_start(0, 0)
 {

--- a/Source/Core/ElementHandle.h
+++ b/Source/Core/ElementHandle.h
@@ -12,7 +12,7 @@ namespace Rml {
 
 class RMLUICORE_API ElementHandle : public Element {
 public:
-	RMLUI_RTTI_DefineWithParent(ElementHandle, Element)
+	RMLUI_RTTI_DeclareWithParent(ElementHandle, Element)
 
 	ElementHandle(const String& tag);
 	virtual ~ElementHandle();

--- a/Source/Core/ElementText.cpp
+++ b/Source/Core/ElementText.cpp
@@ -97,7 +97,7 @@ void LogMissingFontFace(Element* element)
 	}
 }
 
-RMLUI_RTTI_Define_Implementation_WithParent(ElementText, Element)
+RMLUI_RTTI_Define(ElementText)
 
 ElementText::ElementText(const String& tag) :
 	Element(tag), colour(255, 255, 255), opacity(1), font_handle_version(0), geometry_dirty(true), dirty_layout_on_change(true),

--- a/Source/Core/ElementText.cpp
+++ b/Source/Core/ElementText.cpp
@@ -97,6 +97,8 @@ void LogMissingFontFace(Element* element)
 	}
 }
 
+RMLUI_RTTI_Define_Implementation_WithParent(ElementText, Element)
+
 ElementText::ElementText(const String& tag) :
 	Element(tag), colour(255, 255, 255), opacity(1), font_handle_version(0), geometry_dirty(true), dirty_layout_on_change(true),
 	generated_decoration(Style::TextDecoration::None), decoration_property(Style::TextDecoration::None), font_effects_dirty(true),

--- a/Source/Core/Elements/ElementForm.cpp
+++ b/Source/Core/Elements/ElementForm.cpp
@@ -5,6 +5,8 @@
 
 namespace Rml {
 
+RMLUI_RTTI_Define_Implementation_WithParent(ElementForm, Element)
+
 ElementForm::ElementForm(const String& tag) : Element(tag) {}
 
 ElementForm::~ElementForm() {}

--- a/Source/Core/Elements/ElementForm.cpp
+++ b/Source/Core/Elements/ElementForm.cpp
@@ -5,7 +5,7 @@
 
 namespace Rml {
 
-RMLUI_RTTI_Define_Implementation_WithParent(ElementForm, Element)
+RMLUI_RTTI_Define(ElementForm)
 
 ElementForm::ElementForm(const String& tag) : Element(tag) {}
 

--- a/Source/Core/Elements/ElementFormControl.cpp
+++ b/Source/Core/Elements/ElementFormControl.cpp
@@ -3,7 +3,7 @@
 
 namespace Rml {
 
-RMLUI_RTTI_Define_Implementation_WithParent(ElementFormControl, Element)
+RMLUI_RTTI_Define(ElementFormControl)
 
 ElementFormControl::ElementFormControl(const String& tag) : Element(tag)
 {

--- a/Source/Core/Elements/ElementFormControl.cpp
+++ b/Source/Core/Elements/ElementFormControl.cpp
@@ -3,6 +3,8 @@
 
 namespace Rml {
 
+RMLUI_RTTI_Define_Implementation_WithParent(ElementFormControl, Element)
+
 ElementFormControl::ElementFormControl(const String& tag) : Element(tag)
 {
 	SetProperty(PropertyId::TabIndex, Property(Style::TabIndex::Auto));

--- a/Source/Core/Elements/ElementFormControlInput.cpp
+++ b/Source/Core/Elements/ElementFormControlInput.cpp
@@ -9,7 +9,7 @@
 
 namespace Rml {
 
-RMLUI_RTTI_Define_Implementation_WithParent(ElementFormControlInput, Element)
+RMLUI_RTTI_Define(ElementFormControlInput)
 
 ElementFormControlInput::ElementFormControlInput(const String& tag) : ElementFormControl(tag)
 {

--- a/Source/Core/Elements/ElementFormControlInput.cpp
+++ b/Source/Core/Elements/ElementFormControlInput.cpp
@@ -9,6 +9,8 @@
 
 namespace Rml {
 
+RMLUI_RTTI_Define_Implementation_WithParent(ElementFormControlInput, Element)
+
 ElementFormControlInput::ElementFormControlInput(const String& tag) : ElementFormControl(tag)
 {
 	// OnAttributeChange will be called right after this, possible with a non-default type. Thus,

--- a/Source/Core/Elements/ElementFormControlSelect.cpp
+++ b/Source/Core/Elements/ElementFormControlSelect.cpp
@@ -6,6 +6,8 @@
 
 namespace Rml {
 
+RMLUI_RTTI_Define_Implementation_WithParent(ElementFormControlSelect, Element)
+
 ElementFormControlSelect::ElementFormControlSelect(const String& tag) : ElementFormControl(tag), widget(nullptr)
 {
 	widget = new WidgetDropDown(this);

--- a/Source/Core/Elements/ElementFormControlSelect.cpp
+++ b/Source/Core/Elements/ElementFormControlSelect.cpp
@@ -6,7 +6,7 @@
 
 namespace Rml {
 
-RMLUI_RTTI_Define_Implementation_WithParent(ElementFormControlSelect, Element)
+RMLUI_RTTI_Define(ElementFormControlSelect)
 
 ElementFormControlSelect::ElementFormControlSelect(const String& tag) : ElementFormControl(tag), widget(nullptr)
 {

--- a/Source/Core/Elements/ElementFormControlTextArea.cpp
+++ b/Source/Core/Elements/ElementFormControlTextArea.cpp
@@ -8,6 +8,8 @@
 
 namespace Rml {
 
+RMLUI_RTTI_Define_Implementation_WithParent(ElementFormControlTextArea, Element)
+
 ElementFormControlTextArea::ElementFormControlTextArea(const String& tag) : ElementFormControl(tag)
 {
 	widget = MakeUnique<WidgetTextInputMultiLine>(this);

--- a/Source/Core/Elements/ElementFormControlTextArea.cpp
+++ b/Source/Core/Elements/ElementFormControlTextArea.cpp
@@ -8,7 +8,7 @@
 
 namespace Rml {
 
-RMLUI_RTTI_Define_Implementation_WithParent(ElementFormControlTextArea, Element)
+RMLUI_RTTI_Define(ElementFormControlTextArea)
 
 ElementFormControlTextArea::ElementFormControlTextArea(const String& tag) : ElementFormControl(tag)
 {

--- a/Source/Core/Elements/ElementImage.cpp
+++ b/Source/Core/Elements/ElementImage.cpp
@@ -11,6 +11,8 @@
 
 namespace Rml {
 
+RMLUI_RTTI_Define_Implementation_WithParent(ElementImage, Element)
+
 ElementImage::ElementImage(const String& tag) : Element(tag), dimensions(-1, -1), rect_source(RectSource::None)
 {
 	dimensions_scale = 1.0f;

--- a/Source/Core/Elements/ElementImage.cpp
+++ b/Source/Core/Elements/ElementImage.cpp
@@ -11,7 +11,7 @@
 
 namespace Rml {
 
-RMLUI_RTTI_Define_Implementation_WithParent(ElementImage, Element)
+RMLUI_RTTI_Define(ElementImage)
 
 ElementImage::ElementImage(const String& tag) : Element(tag), dimensions(-1, -1), rect_source(RectSource::None)
 {

--- a/Source/Core/Elements/ElementImage.h
+++ b/Source/Core/Elements/ElementImage.h
@@ -33,7 +33,7 @@ namespace Rml {
 
 class RMLUICORE_API ElementImage : public Element {
 public:
-	RMLUI_RTTI_DefineWithParent(ElementImage, Element)
+	RMLUI_RTTI_DeclareWithParent(ElementImage, Element)
 
 	/// Constructs a new ElementImage. This should not be called directly; use the Factory instead.
 	/// @param[in] tag The tag the element was declared as in RML.

--- a/Source/Core/Elements/ElementLabel.cpp
+++ b/Source/Core/Elements/ElementLabel.cpp
@@ -2,6 +2,8 @@
 
 namespace Rml {
 
+RMLUI_RTTI_Define_Implementation_WithParent(ElementLabel, Element)
+
 ElementLabel::ElementLabel(const String& tag) : Element(tag)
 {
 	AddEventListener(EventId::Click, this, true);

--- a/Source/Core/Elements/ElementLabel.cpp
+++ b/Source/Core/Elements/ElementLabel.cpp
@@ -2,7 +2,7 @@
 
 namespace Rml {
 
-RMLUI_RTTI_Define_Implementation_WithParent(ElementLabel, Element)
+RMLUI_RTTI_Define(ElementLabel)
 
 ElementLabel::ElementLabel(const String& tag) : Element(tag)
 {

--- a/Source/Core/Elements/ElementLabel.h
+++ b/Source/Core/Elements/ElementLabel.h
@@ -13,7 +13,7 @@ namespace Rml {
 
 class ElementLabel : public Element, public EventListener {
 public:
-	RMLUI_RTTI_DefineWithParent(ElementLabel, Element)
+	RMLUI_RTTI_DeclareWithParent(ElementLabel, Element)
 
 	ElementLabel(const String& tag);
 	virtual ~ElementLabel();

--- a/Source/Core/Elements/ElementProgress.cpp
+++ b/Source/Core/Elements/ElementProgress.cpp
@@ -13,7 +13,7 @@
 
 namespace Rml {
 
-RMLUI_RTTI_Define_Implementation_WithParent(ElementProgress, Element)
+RMLUI_RTTI_Define(ElementProgress)
 
 ElementProgress::ElementProgress(const String& tag) :
 	Element(tag), direction(DefaultDirection), start_edge(DefaultStartEdge), fill(nullptr), rect_set(false)

--- a/Source/Core/Elements/ElementProgress.cpp
+++ b/Source/Core/Elements/ElementProgress.cpp
@@ -13,6 +13,8 @@
 
 namespace Rml {
 
+RMLUI_RTTI_Define_Implementation_WithParent(ElementProgress, Element)
+
 ElementProgress::ElementProgress(const String& tag) :
 	Element(tag), direction(DefaultDirection), start_edge(DefaultStartEdge), fill(nullptr), rect_set(false)
 {

--- a/Source/Core/Elements/ElementTabSet.cpp
+++ b/Source/Core/Elements/ElementTabSet.cpp
@@ -4,6 +4,8 @@
 
 namespace Rml {
 
+RMLUI_RTTI_Define_Implementation_WithParent(ElementTabSet, Element)
+
 ElementTabSet::ElementTabSet(const String& tag) : Element(tag)
 {
 	active_tab = 0;

--- a/Source/Core/Elements/ElementTabSet.cpp
+++ b/Source/Core/Elements/ElementTabSet.cpp
@@ -4,7 +4,7 @@
 
 namespace Rml {
 
-RMLUI_RTTI_Define_Implementation_WithParent(ElementTabSet, Element)
+RMLUI_RTTI_Define(ElementTabSet)
 
 ElementTabSet::ElementTabSet(const String& tag) : Element(tag)
 {

--- a/Source/Core/Elements/ElementTextSelection.cpp
+++ b/Source/Core/Elements/ElementTextSelection.cpp
@@ -4,6 +4,8 @@
 
 namespace Rml {
 
+RMLUI_RTTI_Define_Implementation_WithParent(ElementTextSelection, Element)
+
 ElementTextSelection::ElementTextSelection(const String& tag) : Element(tag)
 {
 	widget = nullptr;

--- a/Source/Core/Elements/ElementTextSelection.cpp
+++ b/Source/Core/Elements/ElementTextSelection.cpp
@@ -4,7 +4,7 @@
 
 namespace Rml {
 
-RMLUI_RTTI_Define_Implementation_WithParent(ElementTextSelection, Element)
+RMLUI_RTTI_Define(ElementTextSelection)
 
 ElementTextSelection::ElementTextSelection(const String& tag) : Element(tag)
 {

--- a/Source/Core/Elements/ElementTextSelection.h
+++ b/Source/Core/Elements/ElementTextSelection.h
@@ -13,7 +13,7 @@ class WidgetTextInput;
 
 class ElementTextSelection : public Element {
 public:
-	RMLUI_RTTI_DefineWithParent(ElementTextSelection, Element)
+	RMLUI_RTTI_DeclareWithParent(ElementTextSelection, Element)
 
 	ElementTextSelection(const String& tag);
 	virtual ~ElementTextSelection();

--- a/Source/Core/ScriptInterface.cpp
+++ b/Source/Core/ScriptInterface.cpp
@@ -1,0 +1,7 @@
+#include "../../Include/RmlUi/Core/ScriptInterface.h"
+
+namespace Rml {
+
+RMLUI_RTTI_Define_Implementation(ScriptInterface)
+
+}

--- a/Source/Core/ScriptInterface.cpp
+++ b/Source/Core/ScriptInterface.cpp
@@ -2,6 +2,6 @@
 
 namespace Rml {
 
-RMLUI_RTTI_Define_Implementation(ScriptInterface)
+RMLUI_RTTI_Define(ScriptInterface)
 
 }

--- a/Source/Debugger/ElementContextHook.cpp
+++ b/Source/Debugger/ElementContextHook.cpp
@@ -4,7 +4,7 @@
 namespace Rml {
 namespace Debugger {
 
-RMLUI_RTTI_Define_Implementation_WithParent(ElementContextHook, ElementDebugDocument)
+RMLUI_RTTI_Define(ElementContextHook)
 
 ElementContextHook::ElementContextHook(const String& tag) : ElementDebugDocument(tag)
 {

--- a/Source/Debugger/ElementContextHook.cpp
+++ b/Source/Debugger/ElementContextHook.cpp
@@ -4,6 +4,8 @@
 namespace Rml {
 namespace Debugger {
 
+RMLUI_RTTI_Define_Implementation_WithParent(ElementContextHook, ElementDebugDocument)
+
 ElementContextHook::ElementContextHook(const String& tag) : ElementDebugDocument(tag)
 {
 	debugger = nullptr;

--- a/Source/Debugger/ElementContextHook.h
+++ b/Source/Debugger/ElementContextHook.h
@@ -14,7 +14,7 @@ class DebuggerPlugin;
 
 class ElementContextHook : public ElementDebugDocument {
 public:
-	RMLUI_RTTI_DefineWithParent(ElementContextHook, ElementDebugDocument)
+	RMLUI_RTTI_DeclareWithParent(ElementContextHook, ElementDebugDocument)
 
 	ElementContextHook(const String& tag);
 	virtual ~ElementContextHook();

--- a/Source/Debugger/ElementDataModels.cpp
+++ b/Source/Debugger/ElementDataModels.cpp
@@ -76,6 +76,8 @@ static void ReadDataVariableRecursive(String& out_rml, const int indent_level, c
 	}
 }
 
+RMLUI_RTTI_Define_Implementation_WithParent(ElementDataModels, ElementDebugDocument)
+
 ElementDataModels::ElementDataModels(const String& tag) : ElementDebugDocument(tag) {}
 
 ElementDataModels::~ElementDataModels()

--- a/Source/Debugger/ElementDataModels.cpp
+++ b/Source/Debugger/ElementDataModels.cpp
@@ -76,7 +76,7 @@ static void ReadDataVariableRecursive(String& out_rml, const int indent_level, c
 	}
 }
 
-RMLUI_RTTI_Define_Implementation_WithParent(ElementDataModels, ElementDebugDocument)
+RMLUI_RTTI_Define(ElementDataModels)
 
 ElementDataModels::ElementDataModels(const String& tag) : ElementDebugDocument(tag) {}
 

--- a/Source/Debugger/ElementDataModels.h
+++ b/Source/Debugger/ElementDataModels.h
@@ -9,7 +9,7 @@ namespace Debugger {
 
 class ElementDataModels : public ElementDebugDocument, public EventListener {
 public:
-	RMLUI_RTTI_DefineWithParent(ElementDataModels, ElementDebugDocument)
+	RMLUI_RTTI_DeclareWithParent(ElementDataModels, ElementDebugDocument)
 
 	ElementDataModels(const String& tag);
 	~ElementDataModels();

--- a/Source/Debugger/ElementDebugDocument.cpp
+++ b/Source/Debugger/ElementDebugDocument.cpp
@@ -3,7 +3,7 @@
 namespace Rml {
 namespace Debugger {
 
-RMLUI_RTTI_Define_Implementation_WithParent(ElementDebugDocument, ElementDocument)
+RMLUI_RTTI_Define(ElementDebugDocument)
 
 ElementDebugDocument::ElementDebugDocument(const String& tag) : ElementDocument(tag)
 {

--- a/Source/Debugger/ElementDebugDocument.cpp
+++ b/Source/Debugger/ElementDebugDocument.cpp
@@ -3,6 +3,8 @@
 namespace Rml {
 namespace Debugger {
 
+RMLUI_RTTI_Define_Implementation_WithParent(ElementDebugDocument, ElementDocument)
+
 ElementDebugDocument::ElementDebugDocument(const String& tag) : ElementDocument(tag)
 {
 	SetFocusableFromModal(true);

--- a/Source/Debugger/ElementDebugDocument.h
+++ b/Source/Debugger/ElementDebugDocument.h
@@ -7,7 +7,7 @@ namespace Debugger {
 
 class ElementDebugDocument : public ElementDocument {
 public:
-	RMLUI_RTTI_DefineWithParent(ElementDebugDocument, ElementDocument)
+	RMLUI_RTTI_DeclareWithParent(ElementDebugDocument, ElementDocument)
 
 	ElementDebugDocument(const String& tag);
 };

--- a/Source/Debugger/ElementInfo.cpp
+++ b/Source/Debugger/ElementInfo.cpp
@@ -19,6 +19,8 @@
 namespace Rml {
 namespace Debugger {
 
+RMLUI_RTTI_Define_Implementation_WithParent(ElementInfo, ElementDebugDocument)
+
 ElementInfo::ElementInfo(const String& tag) : ElementDebugDocument(tag)
 {
 	hover_element = nullptr;

--- a/Source/Debugger/ElementInfo.cpp
+++ b/Source/Debugger/ElementInfo.cpp
@@ -19,7 +19,7 @@
 namespace Rml {
 namespace Debugger {
 
-RMLUI_RTTI_Define_Implementation_WithParent(ElementInfo, ElementDebugDocument)
+RMLUI_RTTI_Define(ElementInfo)
 
 ElementInfo::ElementInfo(const String& tag) : ElementDebugDocument(tag)
 {

--- a/Source/Debugger/ElementInfo.h
+++ b/Source/Debugger/ElementInfo.h
@@ -12,7 +12,7 @@ typedef Vector<NamedProperty> NamedPropertyList;
 
 class ElementInfo : public ElementDebugDocument, public EventListener {
 public:
-	RMLUI_RTTI_DefineWithParent(ElementInfo, ElementDebugDocument)
+	RMLUI_RTTI_DeclareWithParent(ElementInfo, ElementDebugDocument)
 
 	ElementInfo(const String& tag);
 	~ElementInfo();

--- a/Source/Debugger/ElementLog.cpp
+++ b/Source/Debugger/ElementLog.cpp
@@ -11,6 +11,8 @@ namespace Debugger {
 
 const int MAX_LOG_MESSAGES = 50;
 
+RMLUI_RTTI_Define_Implementation_WithParent(ElementLog, ElementDebugDocument)
+
 ElementLog::ElementLog(const String& tag) : ElementDebugDocument(tag)
 {
 	dirty_logs = false;

--- a/Source/Debugger/ElementLog.cpp
+++ b/Source/Debugger/ElementLog.cpp
@@ -11,7 +11,7 @@ namespace Debugger {
 
 const int MAX_LOG_MESSAGES = 50;
 
-RMLUI_RTTI_Define_Implementation_WithParent(ElementLog, ElementDebugDocument)
+RMLUI_RTTI_Define(ElementLog)
 
 ElementLog::ElementLog(const String& tag) : ElementDebugDocument(tag)
 {

--- a/Source/Debugger/ElementLog.h
+++ b/Source/Debugger/ElementLog.h
@@ -12,7 +12,7 @@ class DebuggerSystemInterface;
 
 class ElementLog : public ElementDebugDocument, public Rml::EventListener {
 public:
-	RMLUI_RTTI_DefineWithParent(ElementLog, ElementDebugDocument)
+	RMLUI_RTTI_DeclareWithParent(ElementLog, ElementDebugDocument)
 
 	ElementLog(const String& tag);
 	~ElementLog();

--- a/Source/Lottie/ElementLottie.cpp
+++ b/Source/Lottie/ElementLottie.cpp
@@ -14,7 +14,7 @@
 
 namespace Rml {
 
-RMLUI_RTTI_Define_Implementation_WithParent(ElementLottie, Element)
+RMLUI_RTTI_Define(ElementLottie)
 
 ElementLottie::ElementLottie(const String& tag) : Element(tag) {}
 

--- a/Source/Lottie/ElementLottie.cpp
+++ b/Source/Lottie/ElementLottie.cpp
@@ -14,6 +14,8 @@
 
 namespace Rml {
 
+RMLUI_RTTI_Define_Implementation_WithParent(ElementLottie, Element)
+
 ElementLottie::ElementLottie(const String& tag) : Element(tag) {}
 
 ElementLottie::~ElementLottie() {}

--- a/Source/SVG/ElementSVG.cpp
+++ b/Source/SVG/ElementSVG.cpp
@@ -6,7 +6,7 @@
 
 namespace Rml {
 
-RMLUI_RTTI_Define_Implementation_WithParent(ElementSVG, Element)
+RMLUI_RTTI_Define(ElementSVG)
 
 unsigned long ElementSVG::internal_id_counter = 0;
 

--- a/Source/SVG/ElementSVG.cpp
+++ b/Source/SVG/ElementSVG.cpp
@@ -6,6 +6,8 @@
 
 namespace Rml {
 
+RMLUI_RTTI_Define_Implementation_WithParent(ElementSVG, Element)
+
 unsigned long ElementSVG::internal_id_counter = 0;
 
 ElementSVG::ElementSVG(const String& tag) : Element(tag) {}


### PR DESCRIPTION
This PR makes the following changes:
1. Moves the custom RTTI declaration out of the `RMLUI_CUSTOM_RTTI` define check. This should have no impact on library users regardless on their RTTI choice, but allows for convenient usage of the type identifiers to build an improved Lua API.
2. Improves feature parity with the `<typeinfo>` path, namely with `rmlui_type_name`, allowing it to correctly deduce the type name of all types with custom RTTI enabled instead of defaulting to type name unavailable.
3. Adds a custom type trait `Rml::has_custom_rtti<T>` to detect if a type has been configured with RmlUi's custom RTTI system.
4. Adds an extra virtual method `GetClassIdentifier` to facilitate building mappings against the type identifier.

These features are all oriented towards another PR I am currently developing related to improving the Lua binding setup.

In the future, it may make sense to remove the `RMLUI_CUSTOM_RTTI` option entirely, and silently switch capabilities based on whether RTTI is detected using `__has_feature(cxx_rtti)`, `__GXX_RTTI`, and `_CPPRTTI`, however with some quick checks in Godbolt I found that these don't work on gcc 4.x. It's a pretty ancient compiler but I don't know what RmlUi guarantees support for, and I did not check how far back clang or MSVC go.