### PR TITLE
Add CSS math expressions (`calc()`, `min()`, `max()`, `clamp()`)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,10 @@ jobs:
             cmake_options: -DRMLUI_BACKEND=SDL_VK -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTING=ON
           - cmake_options: -DRMLUI_BACKEND=GLFW_GL3 -DBUILD_TESTING=ON
             enable_testing: true
+          - cc: clang
+            cxx: clang++
+            cmake_options: -DRMLUI_BACKEND=GLFW_GL3 -DBUILD_TESTING=ON -DBUILD_SHARED_LIBS=OFF -DRMLUI_MATH_EXPRESSIONS=ON
+            enable_testing: true
           - cmake_options: -DRMLUI_BACKEND=X11_GL2 -DRMLUI_LOTTIE_PLUGIN=ON
           - cmake_options: -DRMLUI_BACKEND=SDL_GL2 -DCMAKE_CXX_FLAGS="-fno-exceptions -fno-rtti"
           - cmake_options: -DRMLUI_BACKEND=SFML_GL2 -DRMLUI_THIRDPARTY_CONTAINERS=OFF

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,6 +75,12 @@ option(RMLUI_MATRIX_ROW_MAJOR "Use row-major matrices. Column-major matrices are
 
 option(RMLUI_PRECOMPILED_HEADERS "Enable precompiled headers for RmlUi." ON)
 
+option(
+	RMLUI_MATH_EXPRESSIONS
+	"Enable CSS mathematical expressions such as calc(), min(), max(), and clamp()."
+	OFF
+)
+
 option(RMLUI_COMPILER_OPTIONS "Enable recommended compiler-specific options for the project, such as for supported warning level, standards conformance, and multiprocess builds. Turn off for full control over compiler flags." ON)
 
 option(RMLUI_WARNINGS_AS_ERRORS "Treat compiler warnings as errors." OFF)

--- a/Include/RmlUi/Core/ComputedValues.h
+++ b/Include/RmlUi/Core/ComputedValues.h
@@ -10,6 +10,10 @@
 namespace Rml {
 namespace Style {
 
+#ifdef RMLUI_MATH_EXPRESSIONS
+	struct ComputedCalculationStore;
+#endif
+
 	/*
 	    A computed value is a value resolved as far as possible :before: introducing layouting. See CSS specs for details of each property.
 
@@ -50,7 +54,11 @@ namespace Style {
 		LengthPercentageAuto::Type width_type : 2, height_type : 2;
 
 		LengthPercentageAuto::Type margin_top_type : 2, margin_right_type : 2, margin_bottom_type : 2, margin_left_type : 2;
+#ifdef RMLUI_MATH_EXPRESSIONS
+		LengthPercentage::Type padding_top_type : 2, padding_right_type : 2, padding_bottom_type : 2, padding_left_type : 2;
+#else
 		LengthPercentage::Type padding_top_type : 1, padding_right_type : 1, padding_bottom_type : 1, padding_left_type : 1;
+#endif
 		LengthPercentageAuto::Type top_type : 2, right_type : 2, bottom_type : 2, left_type : 2;
 
 		NumberAuto::Type z_index_type : 1;
@@ -140,15 +148,27 @@ namespace Style {
 			has_mask_image(false), has_filter(false), has_backdrop_filter(false), has_box_shadow(false), text_overflow(TextOverflow::Clip)
 		{}
 
+#ifdef RMLUI_MATH_EXPRESSIONS
+		LengthPercentage::Type min_width_type : 2, max_width_type : 2;
+		LengthPercentage::Type min_height_type : 2, max_height_type : 2;
+
+		LengthPercentage::Type perspective_origin_x_type : 2, perspective_origin_y_type : 2;
+		LengthPercentage::Type transform_origin_x_type : 2, transform_origin_y_type : 2;
+#else
 		LengthPercentage::Type min_width_type : 1, max_width_type : 1;
 		LengthPercentage::Type min_height_type : 1, max_height_type : 1;
 
 		LengthPercentage::Type perspective_origin_x_type : 1, perspective_origin_y_type : 1;
 		LengthPercentage::Type transform_origin_x_type : 1, transform_origin_y_type : 1;
+#endif
 		bool has_local_transform : 1, has_local_perspective : 1;
 
 		LengthPercentageAuto::Type flex_basis_type : 2;
+#ifdef RMLUI_MATH_EXPRESSIONS
+		LengthPercentage::Type row_gap_type : 2, column_gap_type : 2;
+#else
 		LengthPercentage::Type row_gap_type : 1, column_gap_type : 1;
+#endif
 
 		VerticalAlign::Type vertical_align_type : 4;
 		Drag drag : 3;
@@ -186,25 +206,30 @@ namespace Style {
 
 	class ComputedValues : NonCopyMoveable {
 	public:
+#ifdef RMLUI_MATH_EXPRESSIONS
+		explicit ComputedValues(Element* element);
+		~ComputedValues();
+#else
 		explicit ComputedValues(Element* element) : element(element) {}
+#endif
 
 		// clang-format off
 
 		// -- Common --
-		LengthPercentageAuto width()               const { return LengthPercentageAuto(common.width_type, common.width_value); }
-		LengthPercentageAuto height()              const { return LengthPercentageAuto(common.height_type, common.height_value); }
-		LengthPercentageAuto margin_top()          const { return LengthPercentageAuto(common.margin_top_type, common.margin_top_value); }
-		LengthPercentageAuto margin_right()        const { return LengthPercentageAuto(common.margin_right_type, common.margin_right_value); }
-		LengthPercentageAuto margin_bottom()       const { return LengthPercentageAuto(common.margin_bottom_type, common.margin_bottom_value); }
-		LengthPercentageAuto margin_left()         const { return LengthPercentageAuto(common.margin_left_type, common.margin_left_value); }
-		LengthPercentage     padding_top()         const { return LengthPercentage(common.padding_top_type, common.padding_top_value); }
-		LengthPercentage     padding_right()       const { return LengthPercentage(common.padding_right_type, common.padding_right_value); }
-		LengthPercentage     padding_bottom()      const { return LengthPercentage(common.padding_bottom_type, common.padding_bottom_value); }
-		LengthPercentage     padding_left()        const { return LengthPercentage(common.padding_left_type, common.padding_left_value); }
-		LengthPercentageAuto top()                 const { return LengthPercentageAuto(common.top_type, common.top_value); }
-		LengthPercentageAuto right()               const { return LengthPercentageAuto(common.right_type, common.right_value); }
-		LengthPercentageAuto bottom()              const { return LengthPercentageAuto(common.bottom_type, common.bottom_value); }
-		LengthPercentageAuto left()                const { return LengthPercentageAuto(common.left_type, common.left_value); }
+		LengthPercentageAuto width()               const { return GetLengthPercentageAuto(common.width_type, common.width_value, ComputedCalculationSlot::Width); }
+		LengthPercentageAuto height()              const { return GetLengthPercentageAuto(common.height_type, common.height_value, ComputedCalculationSlot::Height); }
+		LengthPercentageAuto margin_top()          const { return GetLengthPercentageAuto(common.margin_top_type, common.margin_top_value, ComputedCalculationSlot::MarginTop); }
+		LengthPercentageAuto margin_right()        const { return GetLengthPercentageAuto(common.margin_right_type, common.margin_right_value, ComputedCalculationSlot::MarginRight); }
+		LengthPercentageAuto margin_bottom()       const { return GetLengthPercentageAuto(common.margin_bottom_type, common.margin_bottom_value, ComputedCalculationSlot::MarginBottom); }
+		LengthPercentageAuto margin_left()         const { return GetLengthPercentageAuto(common.margin_left_type, common.margin_left_value, ComputedCalculationSlot::MarginLeft); }
+		LengthPercentage     padding_top()         const { return GetLengthPercentage(common.padding_top_type, common.padding_top_value, ComputedCalculationSlot::PaddingTop); }
+		LengthPercentage     padding_right()       const { return GetLengthPercentage(common.padding_right_type, common.padding_right_value, ComputedCalculationSlot::PaddingRight); }
+		LengthPercentage     padding_bottom()      const { return GetLengthPercentage(common.padding_bottom_type, common.padding_bottom_value, ComputedCalculationSlot::PaddingBottom); }
+		LengthPercentage     padding_left()        const { return GetLengthPercentage(common.padding_left_type, common.padding_left_value, ComputedCalculationSlot::PaddingLeft); }
+		LengthPercentageAuto top()                 const { return GetLengthPercentageAuto(common.top_type, common.top_value, ComputedCalculationSlot::Top); }
+		LengthPercentageAuto right()               const { return GetLengthPercentageAuto(common.right_type, common.right_value, ComputedCalculationSlot::Right); }
+		LengthPercentageAuto bottom()              const { return GetLengthPercentageAuto(common.bottom_type, common.bottom_value, ComputedCalculationSlot::Bottom); }
+		LengthPercentageAuto left()                const { return GetLengthPercentageAuto(common.left_type, common.left_value, ComputedCalculationSlot::Left); }
 		NumberAuto           z_index()             const { return NumberAuto(common.z_index_type, common.z_index_value); }
 		float                border_top_width()    const { return (float)common.border_top_width; }
 		float                border_right_width()  const { return (float)common.border_right_width; }
@@ -249,19 +274,19 @@ namespace Style {
 		Direction      direction()        const { return inherited.direction; }
 
 		// -- Rare --
-		MinWidth          min_width()                  const { return LengthPercentage(rare.min_width_type, rare.min_width); }
-		MaxWidth          max_width()                  const { return LengthPercentage(rare.max_width_type, rare.max_width); }
-		MinHeight         min_height()                 const { return LengthPercentage(rare.min_height_type, rare.min_height); }
-		MaxHeight         max_height()                 const { return LengthPercentage(rare.max_height_type, rare.max_height); }
+		MinWidth          min_width()                  const { return GetLengthPercentage(rare.min_width_type, rare.min_width, ComputedCalculationSlot::MinWidth); }
+		MaxWidth          max_width()                  const { return GetLengthPercentage(rare.max_width_type, rare.max_width, ComputedCalculationSlot::MaxWidth); }
+		MinHeight         min_height()                 const { return GetLengthPercentage(rare.min_height_type, rare.min_height, ComputedCalculationSlot::MinHeight); }
+		MaxHeight         max_height()                 const { return GetLengthPercentage(rare.max_height_type, rare.max_height, ComputedCalculationSlot::MaxHeight); }
 		VerticalAlign     vertical_align()             const { return VerticalAlign(rare.vertical_align_type, rare.vertical_align_length); }
 		const             AnimationList* animation()   const;
 		const             TransitionList* transition() const;
 		float             perspective()                const { return rare.perspective; }
-		PerspectiveOrigin perspective_origin_x()       const { return LengthPercentage(rare.perspective_origin_x_type, rare.perspective_origin_x); }
-		PerspectiveOrigin perspective_origin_y()       const { return LengthPercentage(rare.perspective_origin_y_type, rare.perspective_origin_y); }
+		PerspectiveOrigin perspective_origin_x()       const { return GetLengthPercentage(rare.perspective_origin_x_type, rare.perspective_origin_x, ComputedCalculationSlot::PerspectiveOriginX); }
+		PerspectiveOrigin perspective_origin_y()       const { return GetLengthPercentage(rare.perspective_origin_y_type, rare.perspective_origin_y, ComputedCalculationSlot::PerspectiveOriginY); }
 		TransformPtr      transform()                  const { return GetLocalProperty(PropertyId::Transform, TransformPtr()); }
-		TransformOrigin   transform_origin_x()         const { return LengthPercentage(rare.transform_origin_x_type, rare.transform_origin_x); }
-		TransformOrigin   transform_origin_y()         const { return LengthPercentage(rare.transform_origin_y_type, rare.transform_origin_y); }
+		TransformOrigin   transform_origin_x()         const { return GetLengthPercentage(rare.transform_origin_x_type, rare.transform_origin_x, ComputedCalculationSlot::TransformOriginX); }
+		TransformOrigin   transform_origin_y()         const { return GetLengthPercentage(rare.transform_origin_y_type, rare.transform_origin_y, ComputedCalculationSlot::TransformOriginY); }
 		float             transform_origin_z()         const { return rare.transform_origin_z; }
 		bool              has_local_transform()        const { return rare.has_local_transform; }
 		bool              has_local_perspective()      const { return rare.has_local_perspective; }
@@ -271,9 +296,9 @@ namespace Style {
 		FlexDirection     flex_direction()             const { return GetLocalPropertyKeyword(PropertyId::FlexDirection, FlexDirection::Row); }
 		FlexWrap          flex_wrap()                  const { return GetLocalPropertyKeyword(PropertyId::FlexWrap, FlexWrap::Nowrap); }
 		JustifyContent    justify_content()            const { return GetLocalPropertyKeyword(PropertyId::JustifyContent, JustifyContent::FlexStart); }
-		float             flex_grow()                  const { return GetLocalProperty(PropertyId::FlexGrow, 0.f); }
-		float             flex_shrink()                const { return GetLocalProperty(PropertyId::FlexShrink, 1.f); }
-		FlexBasis         flex_basis()                 const { return LengthPercentageAuto(rare.flex_basis_type, rare.flex_basis); }
+		float             flex_grow()                  const { return GetLocalNumericProperty(PropertyId::FlexGrow, 0.f); }
+		float             flex_shrink()                const { return GetLocalNumericProperty(PropertyId::FlexShrink, 1.f); }
+		FlexBasis         flex_basis()                 const { return GetLengthPercentageAuto(rare.flex_basis_type, rare.flex_basis, ComputedCalculationSlot::FlexBasis); }
 		float             border_top_left_radius()     const { return (float)rare.border_top_left_radius; }
 		float             border_top_right_radius()    const { return (float)rare.border_top_right_radius; }
 		float             border_bottom_right_radius() const { return (float)rare.border_bottom_right_radius; }
@@ -286,8 +311,8 @@ namespace Style {
 		Drag              drag()                       const { return rare.drag; }
 		TabIndex          tab_index()                  const { return rare.tab_index; }
 		Colourb           image_color()                const { return rare.image_color; }
-		LengthPercentage  row_gap()                    const { return LengthPercentage(rare.row_gap_type, rare.row_gap); }
-		LengthPercentage  column_gap()                 const { return LengthPercentage(rare.column_gap_type, rare.column_gap); }
+		LengthPercentage  row_gap()                    const { return GetLengthPercentage(rare.row_gap_type, rare.row_gap, ComputedCalculationSlot::RowGap); }
+		LengthPercentage  column_gap()                 const { return GetLengthPercentage(rare.column_gap_type, rare.column_gap, ComputedCalculationSlot::ColumnGap); }
 		OverscrollBehavior overscroll_behavior()       const { return rare.overscroll_behavior; }
 		float             scrollbar_margin()           const { return rare.scrollbar_margin; }
 		bool              has_mask_image()             const { return rare.has_mask_image; }
@@ -297,20 +322,20 @@ namespace Style {
 
 		// -- Assignment --
 		// Common
-		void width              (LengthPercentageAuto value) { common.width_type          = value.type; common.width_value          = value.value; }
-		void height             (LengthPercentageAuto value) { common.height_type         = value.type; common.height_value         = value.value; }
-		void margin_top         (LengthPercentageAuto value) { common.margin_top_type     = value.type; common.margin_top_value     = value.value; }
-		void margin_right       (LengthPercentageAuto value) { common.margin_right_type   = value.type; common.margin_right_value   = value.value; }
-		void margin_bottom      (LengthPercentageAuto value) { common.margin_bottom_type  = value.type; common.margin_bottom_value  = value.value; }
-		void margin_left        (LengthPercentageAuto value) { common.margin_left_type    = value.type; common.margin_left_value    = value.value; }
-		void padding_top        (LengthPercentage value)     { common.padding_top_type    = value.type; common.padding_top_value    = value.value; }
-		void padding_right      (LengthPercentage value)     { common.padding_right_type  = value.type; common.padding_right_value  = value.value; }
-		void padding_bottom     (LengthPercentage value)     { common.padding_bottom_type = value.type; common.padding_bottom_value = value.value; }
-		void padding_left       (LengthPercentage value)     { common.padding_left_type   = value.type; common.padding_left_value   = value.value; }
-		void top                (LengthPercentageAuto value) { common.top_type            = value.type; common.top_value            = value.value; }
-		void right              (LengthPercentageAuto value) { common.right_type          = value.type; common.right_value          = value.value; }
-		void bottom             (LengthPercentageAuto value) { common.bottom_type         = value.type; common.bottom_value         = value.value; }
-		void left               (LengthPercentageAuto value) { common.left_type           = value.type; common.left_value           = value.value; }
+		void width              (LengthPercentageAuto value) { StoreLengthPercentageAuto(ComputedCalculationSlot::Width, value); common.width_type = value.type; common.width_value = value.value; }
+		void height             (LengthPercentageAuto value) { StoreLengthPercentageAuto(ComputedCalculationSlot::Height, value); common.height_type = value.type; common.height_value = value.value; }
+		void margin_top         (LengthPercentageAuto value) { StoreLengthPercentageAuto(ComputedCalculationSlot::MarginTop, value); common.margin_top_type = value.type; common.margin_top_value = value.value; }
+		void margin_right       (LengthPercentageAuto value) { StoreLengthPercentageAuto(ComputedCalculationSlot::MarginRight, value); common.margin_right_type = value.type; common.margin_right_value = value.value; }
+		void margin_bottom      (LengthPercentageAuto value) { StoreLengthPercentageAuto(ComputedCalculationSlot::MarginBottom, value); common.margin_bottom_type = value.type; common.margin_bottom_value = value.value; }
+		void margin_left        (LengthPercentageAuto value) { StoreLengthPercentageAuto(ComputedCalculationSlot::MarginLeft, value); common.margin_left_type = value.type; common.margin_left_value = value.value; }
+		void padding_top        (LengthPercentage value)     { StoreLengthPercentage(ComputedCalculationSlot::PaddingTop, value); common.padding_top_type = value.type; common.padding_top_value = value.value; }
+		void padding_right      (LengthPercentage value)     { StoreLengthPercentage(ComputedCalculationSlot::PaddingRight, value); common.padding_right_type = value.type; common.padding_right_value = value.value; }
+		void padding_bottom     (LengthPercentage value)     { StoreLengthPercentage(ComputedCalculationSlot::PaddingBottom, value); common.padding_bottom_type = value.type; common.padding_bottom_value = value.value; }
+		void padding_left       (LengthPercentage value)     { StoreLengthPercentage(ComputedCalculationSlot::PaddingLeft, value); common.padding_left_type = value.type; common.padding_left_value = value.value; }
+		void top                (LengthPercentageAuto value) { StoreLengthPercentageAuto(ComputedCalculationSlot::Top, value); common.top_type = value.type; common.top_value = value.value; }
+		void right              (LengthPercentageAuto value) { StoreLengthPercentageAuto(ComputedCalculationSlot::Right, value); common.right_type = value.type; common.right_value = value.value; }
+		void bottom             (LengthPercentageAuto value) { StoreLengthPercentageAuto(ComputedCalculationSlot::Bottom, value); common.bottom_type = value.type; common.bottom_value = value.value; }
+		void left               (LengthPercentageAuto value) { StoreLengthPercentageAuto(ComputedCalculationSlot::Left, value); common.left_type = value.type; common.left_value = value.value; }
 		void z_index            (NumberAuto value)           { common.z_index_type        = value.type; common.z_index_value        = value.value; }
 		void border_top_width   (int16_t value)              { common.border_top_width    = value; }
 		void border_right_width (int16_t value)              { common.border_right_width  = value; }
@@ -351,18 +376,18 @@ namespace Style {
 		void language          (const String& value)  { inherited.language           = value; }
 		void direction         (Direction value)      { inherited.direction          = value; }
 		// Rare
-		void min_width                 (MinWidth value)          { rare.min_width_type             = value.type; rare.min_width                  = value.value; }
-		void max_width                 (MaxWidth value)          { rare.max_width_type             = value.type; rare.max_width                  = value.value; }
-		void min_height                (MinHeight value)         { rare.min_height_type            = value.type; rare.min_height                 = value.value; }
-		void max_height                (MaxHeight value)         { rare.max_height_type            = value.type; rare.max_height                 = value.value; }
+		void min_width                 (MinWidth value)          { StoreLengthPercentage(ComputedCalculationSlot::MinWidth, value); rare.min_width_type = value.type; rare.min_width = value.value; }
+		void max_width                 (MaxWidth value)          { StoreLengthPercentage(ComputedCalculationSlot::MaxWidth, value); rare.max_width_type = value.type; rare.max_width = value.value; }
+		void min_height                (MinHeight value)         { StoreLengthPercentage(ComputedCalculationSlot::MinHeight, value); rare.min_height_type = value.type; rare.min_height = value.value; }
+		void max_height                (MaxHeight value)         { StoreLengthPercentage(ComputedCalculationSlot::MaxHeight, value); rare.max_height_type = value.type; rare.max_height = value.value; }
 		void vertical_align            (VerticalAlign value)     { rare.vertical_align_type        = value.type; rare.vertical_align_length      = value.value; }
-		void perspective_origin_x      (PerspectiveOrigin value) { rare.perspective_origin_x_type  = value.type; rare.perspective_origin_x       = value.value; }
-		void perspective_origin_y      (PerspectiveOrigin value) { rare.perspective_origin_y_type  = value.type; rare.perspective_origin_y       = value.value; }
-		void transform_origin_x        (TransformOrigin value)   { rare.transform_origin_x_type    = value.type; rare.transform_origin_x         = value.value; }
-		void transform_origin_y        (TransformOrigin value)   { rare.transform_origin_y_type    = value.type; rare.transform_origin_y         = value.value; }
-		void row_gap                   (LengthPercentage value)  { rare.row_gap_type               = value.type; rare.row_gap                    = value.value; }
-		void column_gap                (LengthPercentage value)  { rare.column_gap_type            = value.type; rare.column_gap                 = value.value; }
-		void flex_basis                (FlexBasis value)         { rare.flex_basis_type            = value.type; rare.flex_basis                 = value.value; }
+		void perspective_origin_x      (PerspectiveOrigin value) { StoreLengthPercentage(ComputedCalculationSlot::PerspectiveOriginX, value); rare.perspective_origin_x_type = value.type; rare.perspective_origin_x = value.value; }
+		void perspective_origin_y      (PerspectiveOrigin value) { StoreLengthPercentage(ComputedCalculationSlot::PerspectiveOriginY, value); rare.perspective_origin_y_type = value.type; rare.perspective_origin_y = value.value; }
+		void transform_origin_x        (TransformOrigin value)   { StoreLengthPercentage(ComputedCalculationSlot::TransformOriginX, value); rare.transform_origin_x_type = value.type; rare.transform_origin_x = value.value; }
+		void transform_origin_y        (TransformOrigin value)   { StoreLengthPercentage(ComputedCalculationSlot::TransformOriginY, value); rare.transform_origin_y_type = value.type; rare.transform_origin_y = value.value; }
+		void row_gap                   (LengthPercentage value)  { StoreLengthPercentage(ComputedCalculationSlot::RowGap, value); rare.row_gap_type = value.type; rare.row_gap = value.value; }
+		void column_gap                (LengthPercentage value)  { StoreLengthPercentage(ComputedCalculationSlot::ColumnGap, value); rare.column_gap_type = value.type; rare.column_gap = value.value; }
+		void flex_basis                (FlexBasis value)         { StoreLengthPercentageAuto(ComputedCalculationSlot::FlexBasis, value); rare.flex_basis_type = value.type; rare.flex_basis = value.value; }
 		void transform_origin_z        (float value)             { rare.transform_origin_z         = value; }
 		void perspective               (float value)             { rare.perspective                = value; }
 		void has_local_perspective     (bool value)              { rare.has_local_perspective      = value; }
@@ -390,10 +415,91 @@ namespace Style {
 		{
 			common = other.common;
 			rare = other.rare;
+#ifdef RMLUI_MATH_EXPRESSIONS
+			if (calculations || other.calculations)
+				CopyNonInheritedCalculations(other);
+#endif
 		}
 		void CopyInherited(const ComputedValues& parent) { inherited = parent.inherited; }
 
 	private:
+		enum class ComputedCalculationSlot : uint8_t {
+			Width,
+			Height,
+			MarginTop,
+			MarginRight,
+			MarginBottom,
+			MarginLeft,
+			PaddingTop,
+			PaddingRight,
+			PaddingBottom,
+			PaddingLeft,
+			Top,
+			Right,
+			Bottom,
+			Left,
+			MinWidth,
+			MaxWidth,
+			MinHeight,
+			MaxHeight,
+			PerspectiveOriginX,
+			PerspectiveOriginY,
+			TransformOriginX,
+			TransformOriginY,
+			FlexBasis,
+			RowGap,
+			ColumnGap
+		};
+#ifdef RMLUI_MATH_EXPRESSIONS
+		LengthPercentage GetLengthPercentage(LengthPercentage::Type type, float value, ComputedCalculationSlot slot) const
+		{
+			if (type == LengthPercentage::Calculation)
+				return LengthPercentage(GetCalculation(slot));
+			return LengthPercentage(type, value);
+		}
+		LengthPercentageAuto GetLengthPercentageAuto(LengthPercentageAuto::Type type, float value, ComputedCalculationSlot slot) const
+		{
+			if (type == LengthPercentageAuto::Calculation)
+				return LengthPercentageAuto(GetCalculation(slot));
+			return LengthPercentageAuto(type, value);
+		}
+		void StoreLengthPercentage(ComputedCalculationSlot slot, LengthPercentage& value)
+		{
+			if (value.type == LengthPercentage::Calculation)
+			{
+				RMLUI_ASSERT(value.calculation);
+				SetCalculation(slot, value.calculation);
+				value.value = 0;
+			}
+			else if (calculations)
+				SetCalculation(slot, nullptr);
+		}
+		void StoreLengthPercentageAuto(ComputedCalculationSlot slot, LengthPercentageAuto& value)
+		{
+			if (value.type == LengthPercentageAuto::Calculation)
+			{
+				RMLUI_ASSERT(value.calculation);
+				SetCalculation(slot, value.calculation);
+				value.value = 0;
+			}
+			else if (calculations)
+				SetCalculation(slot, nullptr);
+		}
+		CalculationPtr GetCalculation(ComputedCalculationSlot slot) const;
+		void SetCalculation(ComputedCalculationSlot slot, CalculationPtr calculation);
+		void CopyNonInheritedCalculations(const ComputedValues& other);
+#else
+		LengthPercentage GetLengthPercentage(LengthPercentage::Type type, float value, ComputedCalculationSlot) const
+		{
+			return LengthPercentage(type, value);
+		}
+		LengthPercentageAuto GetLengthPercentageAuto(LengthPercentageAuto::Type type, float value, ComputedCalculationSlot) const
+		{
+			return LengthPercentageAuto(type, value);
+		}
+		void StoreLengthPercentage(ComputedCalculationSlot, LengthPercentage&) {}
+		void StoreLengthPercentageAuto(ComputedCalculationSlot, LengthPercentageAuto&) {}
+#endif
 		template <typename T>
 		inline T GetLocalPropertyKeyword(PropertyId id, T default_value) const
 		{
@@ -408,6 +514,7 @@ namespace Style {
 				return p->Get<T>();
 			return default_value;
 		}
+		float GetLocalNumericProperty(PropertyId id, float default_value) const;
 
 		const Property* GetLocalPropertyWithResolvedVariables(PropertyId id) const;
 
@@ -416,6 +523,9 @@ namespace Style {
 		CommonValues common;
 		InheritedValues inherited;
 		RareValues rare;
+#ifdef RMLUI_MATH_EXPRESSIONS
+		UniquePtr<ComputedCalculationStore> calculations;
+#endif
 	};
 
 } // namespace Style
@@ -428,10 +538,27 @@ RMLUICORE_API float ResolveValueOr(Style::LengthPercentage length, float base_va
 
 RMLUICORE_API_INLINE float ResolveValue(Style::LengthPercentageAuto length, float base_value)
 {
+#ifdef RMLUI_MATH_EXPRESSIONS
+	// Keep ordinary used values entirely inline when calculations are enabled. This avoids routing
+	// the larger calculation-capable value object through the out-of-line fallback on the dominant
+	// Length/Percentage/Auto paths.
+	if (length.type == Style::LengthPercentageAuto::Length)
+		return length.value;
+	if (length.type == Style::LengthPercentageAuto::Percentage)
+		return base_value >= 0.f ? length.value * 0.01f * base_value : 0.f;
+	if (length.type == Style::LengthPercentageAuto::Auto)
+		return 0.f;
+#endif
 	return ResolveValueOr(length, base_value, 0.f);
 }
 RMLUICORE_API_INLINE float ResolveValue(Style::LengthPercentage length, float base_value)
 {
+#ifdef RMLUI_MATH_EXPRESSIONS
+	if (length.type == Style::LengthPercentage::Length)
+		return length.value;
+	if (length.type == Style::LengthPercentage::Percentage)
+		return base_value >= 0.f ? length.value * 0.01f * base_value : 0.f;
+#endif
 	return ResolveValueOr(length, base_value, 0.f);
 }
 

--- a/Include/RmlUi/Core/DecorationTypes.h
+++ b/Include/RmlUi/Core/DecorationTypes.h
@@ -8,10 +8,17 @@ namespace Rml {
 struct ColorStop {
 	ColourbPremultiplied color;
 	NumericValue position;
+#ifdef RMLUI_MATH_EXPRESSIONS
+	CalculationPtr position_calculation;
+#endif
 };
 inline bool operator==(const ColorStop& a, const ColorStop& b)
 {
-	return a.color == b.color && a.position == b.position;
+	return a.color == b.color && a.position == b.position
+#ifdef RMLUI_MATH_EXPRESSIONS
+		&& a.position_calculation == b.position_calculation
+#endif
+		;
 }
 inline bool operator!=(const ColorStop& a, const ColorStop& b)
 {
@@ -24,11 +31,20 @@ struct BoxShadow {
 	NumericValue blur_radius;
 	NumericValue spread_distance;
 	bool inset = false;
+#ifdef RMLUI_MATH_EXPRESSIONS
+	CalculationPtr offset_x_calculation, offset_y_calculation;
+	CalculationPtr blur_radius_calculation, spread_distance_calculation;
+#endif
 };
 inline bool operator==(const BoxShadow& a, const BoxShadow& b)
 {
 	return a.color == b.color && a.offset_x == b.offset_x && a.offset_y == b.offset_y && a.blur_radius == b.blur_radius &&
-		a.spread_distance == b.spread_distance && a.inset == b.inset;
+		a.spread_distance == b.spread_distance
+#ifdef RMLUI_MATH_EXPRESSIONS
+		&& a.offset_x_calculation == b.offset_x_calculation && a.offset_y_calculation == b.offset_y_calculation &&
+		a.blur_radius_calculation == b.blur_radius_calculation && a.spread_distance_calculation == b.spread_distance_calculation
+#endif
+		&& a.inset == b.inset;
 }
 inline bool operator!=(const BoxShadow& a, const BoxShadow& b)
 {

--- a/Include/RmlUi/Core/DecorationTypes.h
+++ b/Include/RmlUi/Core/DecorationTypes.h
@@ -9,7 +9,7 @@ struct ColorStop {
 	ColourbPremultiplied color;
 	NumericValue position;
 #ifdef RMLUI_MATH_EXPRESSIONS
-	CalculationPtr position_calculation;
+	CalculationPtr position_calculation = nullptr;
 #endif
 };
 inline bool operator==(const ColorStop& a, const ColorStop& b)
@@ -32,8 +32,8 @@ struct BoxShadow {
 	NumericValue spread_distance;
 	bool inset = false;
 #ifdef RMLUI_MATH_EXPRESSIONS
-	CalculationPtr offset_x_calculation, offset_y_calculation;
-	CalculationPtr blur_radius_calculation, spread_distance_calculation;
+	CalculationPtr offset_x_calculation = nullptr, offset_y_calculation = nullptr;
+	CalculationPtr blur_radius_calculation = nullptr, spread_distance_calculation = nullptr;
 #endif
 };
 inline bool operator==(const BoxShadow& a, const BoxShadow& b)

--- a/Include/RmlUi/Core/StyleTypes.h
+++ b/Include/RmlUi/Core/StyleTypes.h
@@ -6,16 +6,41 @@ namespace Rml {
 namespace Style {
 
 	struct LengthPercentageAuto {
-		enum Type : uint8_t { Auto, Length, Percentage } type = Length;
+		enum Type : uint8_t {
+			Auto,
+			Length,
+			Percentage,
+#ifdef RMLUI_MATH_EXPRESSIONS
+			Calculation,
+#endif
+		} type = Length;
 		float value = 0;
+#ifdef RMLUI_MATH_EXPRESSIONS
+		CalculationPtr calculation;
+#endif
 		LengthPercentageAuto() {}
 		LengthPercentageAuto(Type type, float value = 0) : type(type), value(value) {}
+#ifdef RMLUI_MATH_EXPRESSIONS
+		explicit LengthPercentageAuto(CalculationPtr calculation) : type(Calculation), calculation(std::move(calculation)) {}
+#endif
 	};
 	struct LengthPercentage {
-		enum Type : uint8_t { Length, Percentage } type = Length;
+		enum Type : uint8_t {
+			Length,
+			Percentage,
+#ifdef RMLUI_MATH_EXPRESSIONS
+			Calculation,
+#endif
+		} type = Length;
 		float value = 0;
+#ifdef RMLUI_MATH_EXPRESSIONS
+		CalculationPtr calculation;
+#endif
 		LengthPercentage() {}
 		LengthPercentage(Type type, float value = 0) : type(type), value(value) {}
+#ifdef RMLUI_MATH_EXPRESSIONS
+		explicit LengthPercentage(CalculationPtr calculation) : type(Calculation), calculation(std::move(calculation)) {}
+#endif
 	};
 
 	struct NumberAuto {

--- a/Include/RmlUi/Core/Transform.h
+++ b/Include/RmlUi/Core/Transform.h
@@ -6,6 +6,7 @@
 
 namespace Rml {
 
+class Element;
 class Property;
 
 /**
@@ -37,6 +38,15 @@ public:
 	/// Add a Primitive to this Transform
 	void AddPrimitive(const TransformPrimitive& p);
 
+#ifdef RMLUI_MATH_EXPRESSIONS
+	/// Associate a lazily resolved calculation with a primitive argument.
+	void AddCalculation(int primitive_index, int argument_index, CalculationPtr calculation);
+	bool HasCalculations() const noexcept { return !calculations.empty(); }
+
+	/// Return a primitive with any calculation-backed arguments resolved against the current element state.
+	TransformPrimitive ResolvePrimitive(int primitive_index, Element& element) const;
+#endif
+
 	/// Return the number of Primitives in this Transform
 	int GetNumPrimitives() const noexcept;
 
@@ -48,6 +58,14 @@ public:
 
 private:
 	PrimitiveList primitives;
+#ifdef RMLUI_MATH_EXPRESSIONS
+	struct CalculationEntry {
+		int primitive_index = 0;
+		int argument_index = 0;
+		CalculationPtr calculation;
+	};
+	Vector<CalculationEntry> calculations;
+#endif
 };
 
 } // namespace Rml

--- a/Include/RmlUi/Core/TypeConverter.h
+++ b/Include/RmlUi/Core/TypeConverter.h
@@ -71,6 +71,19 @@ public:
 	RMLUICORE_API static bool Convert(const TransformPtr& src, String& dest);
 };
 
+#ifdef RMLUI_MATH_EXPRESSIONS
+template <>
+class TypeConverter<CalculationPtr, CalculationPtr> {
+public:
+	RMLUICORE_API static bool Convert(const CalculationPtr& src, CalculationPtr& dest);
+};
+template <>
+class TypeConverter<CalculationPtr, String> {
+public:
+	RMLUICORE_API static bool Convert(const CalculationPtr& src, String& dest);
+};
+#endif
+
 template <>
 class TypeConverter<TransitionList, TransitionList> {
 public:

--- a/Include/RmlUi/Core/Types.h
+++ b/Include/RmlUi/Core/Types.h
@@ -57,6 +57,10 @@ class Event;
 class Property;
 class Variant;
 class Transform;
+#ifdef RMLUI_MATH_EXPRESSIONS
+class Calculation;
+using CalculationPtr = SharedPtr<const Calculation>;
+#endif
 class PropertyIdSet;
 class Decorator;
 class FontEffect;

--- a/Include/RmlUi/Core/Unit.h
+++ b/Include/RmlUi/Core/Unit.h
@@ -55,6 +55,10 @@ enum class Unit {
 	VAR_EXPRESSION = 1 << 28,        // substituted and resolved at compute time; fetch as <String>
 	SHORTHAND_PLACEHOLDER = 1 << 29, // dependent on a shorthand that must be substituted and resolved at compute time; always empty
 
+#ifdef RMLUI_MATH_EXPRESSIONS
+	CALCULATION = 1 << 30, // CSS mathematical expression; fetch as <CalculationPtr>
+#endif
+
 	LENGTH = PX | DP | VW | VH | EM | REM | PPI_UNIT,
 	LENGTH_PERCENT = LENGTH | PERCENT,
 	NUMBER_PERCENT = NUMBER | PERCENT,

--- a/Include/RmlUi/Core/Variant.h
+++ b/Include/RmlUi/Core/Variant.h
@@ -37,6 +37,9 @@ public:
 		COLOURB = 'h',
 		SCRIPTINTERFACE = 'p',
 		TRANSFORMPTR = 't',
+#ifdef RMLUI_MATH_EXPRESSIONS
+		CALCULATIONPTR = 'M',
+#endif
 		TRANSITIONLIST = 'T',
 		ANIMATIONLIST = 'A',
 		DECORATORSPTR = 'D',
@@ -117,6 +120,10 @@ private:
 	void Set(String&& value);
 	void Set(const TransformPtr& value);
 	void Set(TransformPtr&& value);
+#ifdef RMLUI_MATH_EXPRESSIONS
+	void Set(const CalculationPtr& value);
+	void Set(CalculationPtr&& value);
+#endif
 	void Set(const TransitionList& value);
 	void Set(TransitionList&& value);
 	void Set(const AnimationList& value);

--- a/Include/RmlUi/Core/Variant.inl
+++ b/Include/RmlUi/Core/Variant.inl
@@ -54,6 +54,9 @@ bool Variant::GetInto(T& value) const
 		case SCRIPTINTERFACE: return TypeConverter<ScriptInterface*, T>::Convert(*reinterpret_cast<ScriptInterface* const*>(data), value);
 		case VOIDPTR: return TypeConverter<void*, T>::Convert(*reinterpret_cast<void* const*>(data), value);
 		case TRANSFORMPTR: return TypeConverter<TransformPtr, T>::Convert(*reinterpret_cast<const TransformPtr*>(data), value);
+#ifdef RMLUI_MATH_EXPRESSIONS
+		case CALCULATIONPTR: return TypeConverter<CalculationPtr, T>::Convert(*reinterpret_cast<const CalculationPtr*>(data), value);
+#endif
 		case TRANSITIONLIST: return TypeConverter<TransitionList, T>::Convert(*reinterpret_cast<const TransitionList*>(data), value);
 		case ANIMATIONLIST: return TypeConverter<AnimationList, T>::Convert(*reinterpret_cast<const AnimationList*>(data), value);
 		case DECORATORSPTR: return TypeConverter<DecoratorsPtr, T>::Convert(*reinterpret_cast<const DecoratorsPtr*>(data), value);

--- a/Source/Core/CMakeLists.txt
+++ b/Source/Core/CMakeLists.txt
@@ -230,6 +230,18 @@ add_library(rmlui_core
 	XMLParseTools.h
 )
 
+if(RMLUI_MATH_EXPRESSIONS)
+	target_sources(rmlui_core PRIVATE
+		Calculation.cpp
+		Calculation.h
+		CalculationParser.cpp
+		CalculationParser.h
+		CalculationResolver.cpp
+		CalculationResolver.h
+	)
+	target_compile_definitions(rmlui_core PUBLIC "RMLUI_MATH_EXPRESSIONS")
+endif()
+
 # Add public headers as files in the project (it's not necessary but convenient for IDE integration)
 # Setting them as PRIVATE so that it's addition doesn't propagate, it won't affect availability since
 # the entire include directory has already been declared as public

--- a/Source/Core/Calculation.cpp
+++ b/Source/Core/Calculation.cpp
@@ -1,5 +1,6 @@
 #include "Calculation.h"
 #include "../../Include/RmlUi/Core/StringUtilities.h"
+#include "../../Include/RmlUi/Core/TypeConverter.h"
 #include <cmath>
 
 namespace Rml {

--- a/Source/Core/Calculation.cpp
+++ b/Source/Core/Calculation.cpp
@@ -1,0 +1,149 @@
+#include "Calculation.h"
+#include "../../Include/RmlUi/Core/StringUtilities.h"
+#include <cmath>
+
+namespace Rml {
+namespace {
+
+	bool EqualNodes(const Calculation::Node& lhs, const Calculation::Node& rhs)
+	{
+		if (lhs.kind != rhs.kind || lhs.value != rhs.value || lhs.unit != rhs.unit || lhs.value_unit != rhs.value_unit || lhs.type != rhs.type ||
+			lhs.children.size() != rhs.children.size())
+			return false;
+		for (size_t i = 0; i < lhs.children.size(); ++i)
+		{
+			if (bool(lhs.children[i]) != bool(rhs.children[i]))
+				return false;
+			if (lhs.children[i] && !EqualNodes(*lhs.children[i], *rhs.children[i]))
+				return false;
+		}
+		return true;
+	}
+
+	int Precedence(Calculation::Kind kind)
+	{
+		switch (kind)
+		{
+		case Calculation::Kind::Sum: return 1;
+		case Calculation::Kind::Product: return 2;
+		case Calculation::Kind::Negate:
+		case Calculation::Kind::Invert: return 3;
+		default: return 4;
+		}
+	}
+
+	String ValueToString(const Calculation::Node& node)
+	{
+		if (node.value_unit == Calculation::ValueUnit::Seconds)
+			return CreateString("%.9g", node.value) + "s";
+		return CreateString("%.9g", node.value) + Rml::ToString(node.unit);
+	}
+
+	String NodeToString(const Calculation::Node& node, int parent_precedence = 0)
+	{
+		if (node.kind == Calculation::Kind::Value)
+			return ValueToString(node);
+
+		if (node.kind == Calculation::Kind::Min || node.kind == Calculation::Kind::Max || node.kind == Calculation::Kind::Clamp)
+		{
+			const char* name = node.kind == Calculation::Kind::Min ? "min" : node.kind == Calculation::Kind::Max ? "max" : "clamp";
+			String result = String(name) + "(";
+			for (size_t i = 0; i < node.children.size(); ++i)
+			{
+				if (i)
+					result += ", ";
+				result += node.children[i] ? NodeToString(*node.children[i]) : "none";
+			}
+			return result + ')';
+		}
+
+		if (node.kind == Calculation::Kind::Negate)
+		{
+			RMLUI_ASSERT(node.children.size() == 1 && node.children[0]);
+			return String("-") + NodeToString(*node.children[0], Precedence(node.kind));
+		}
+
+		if (node.kind == Calculation::Kind::Invert)
+		{
+			RMLUI_ASSERT(node.children.size() == 1 && node.children[0]);
+			return String("1 / ") + NodeToString(*node.children[0], Precedence(node.kind));
+		}
+
+		const int precedence = Precedence(node.kind);
+		String result;
+		for (size_t i = 0; i < node.children.size(); ++i)
+		{
+			const auto& child = node.children[i];
+			RMLUI_ASSERT(child);
+			if (i)
+			{
+				if (node.kind == Calculation::Kind::Sum && child->kind == Calculation::Kind::Negate)
+				{
+					result += " - ";
+					result += NodeToString(*child->children[0], precedence + 1);
+					continue;
+				}
+				if (node.kind == Calculation::Kind::Product && child->kind == Calculation::Kind::Invert)
+				{
+					result += " / ";
+					result += NodeToString(*child->children[0], precedence + 1);
+					continue;
+				}
+				result += node.kind == Calculation::Kind::Sum ? " + " : " * ";
+			}
+			result += NodeToString(*child, precedence);
+		}
+		if (precedence < parent_precedence)
+			return String("(") + result + ')';
+		return result;
+	}
+
+	CalculationNumericType TypeForUnit(Unit unit)
+	{
+		CalculationNumericType type;
+		if (Any(unit & Unit::LENGTH))
+			type.exponents[size_t(CalculationDimension::Length)] = 1;
+		else if (Any(unit & Unit::ANGLE))
+			type.exponents[size_t(CalculationDimension::Angle)] = 1;
+		else if (unit == Unit::X)
+			type.exponents[size_t(CalculationDimension::Resolution)] = 1;
+		else if (unit == Unit::PERCENT)
+			type.exponents[size_t(CalculationDimension::Percent)] = 1;
+		return type;
+	}
+
+} // namespace
+
+bool Calculation::operator==(const Calculation& other) const
+{
+	if (root == other.root)
+		return true;
+	if (!root || !other.root)
+		return false;
+	return EqualNodes(*root, *other.root);
+}
+
+String Calculation::ToString() const
+{
+	return root ? String("calc(") + NodeToString(*root) + ')' : String();
+}
+
+CalculationPtr Calculation::MakeValue(float value, Unit unit)
+{
+	auto node = MakeShared<Node>();
+	node->value = value;
+	node->unit = unit;
+	node->type = TypeForUnit(unit);
+	return MakeShared<Calculation>(std::move(node));
+}
+
+CalculationPtr Calculation::MakeOperation(Kind kind, Vector<CalculationPtr> operands)
+{
+	auto node = MakeShared<Node>();
+	node->kind = kind;
+	for (const CalculationPtr& operand : operands)
+		node->children.push_back(operand ? operand->GetRoot() : nullptr);
+	return MakeShared<Calculation>(std::move(node));
+}
+
+} // namespace Rml

--- a/Source/Core/Calculation.h
+++ b/Source/Core/Calculation.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include "../../Include/RmlUi/Core/Types.h"
+#include "../../Include/RmlUi/Core/Unit.h"
+#include <array>
+
+namespace Rml {
+
+enum class CalculationDimension : uint8_t { Length, Angle, Time, Resolution, Percent, Count };
+
+struct CalculationNumericType {
+	std::array<int8_t, size_t(CalculationDimension::Count)> exponents = {};
+
+	bool operator==(const CalculationNumericType& other) const { return exponents == other.exponents; }
+	bool operator!=(const CalculationNumericType& other) const { return !(*this == other); }
+};
+
+// Internal immutable representation. Nodes are only exposed through shared pointers to const data;
+// parser construction is the only production path which mutates a node before publication.
+class Calculation {
+public:
+	enum class Kind : uint8_t { Value, Sum, Product, Negate, Invert, Min, Max, Clamp };
+	enum class ResidualForm : uint8_t { Tree, Constant, LinearLengthPercentage };
+	enum class ValueUnit : uint8_t { Public, Seconds };
+
+	struct Node {
+		Kind kind = Kind::Value;
+		float value = 0;
+		Unit unit = Unit::NUMBER;
+		ValueUnit value_unit = ValueUnit::Public;
+		CalculationNumericType type;
+		Vector<SharedPtr<const Node>> children;
+	};
+
+	explicit Calculation(SharedPtr<const Node> root, Units dependency_mask = Unit::UNKNOWN, ResidualForm residual_form = ResidualForm::Tree,
+		float linear_px = 0.f, float linear_percent = 0.f) :
+		root(std::move(root)), dependency_mask(dependency_mask), residual_form(residual_form), linear_px(linear_px), linear_percent(linear_percent)
+	{}
+
+	const SharedPtr<const Node>& GetRoot() const { return root; }
+	const CalculationNumericType& GetType() const { return root->type; }
+	Units GetDependencyMask() const { return dependency_mask; }
+	ResidualForm GetResidualForm() const { return residual_form; }
+	float GetLinearPx() const { return linear_px; }
+	float GetLinearPercent() const { return linear_percent; }
+	bool operator==(const Calculation& other) const;
+	bool operator!=(const Calculation& other) const { return !(*this == other); }
+	String ToString() const;
+
+	static CalculationPtr MakeValue(float value, Unit unit);
+	static CalculationPtr MakeOperation(Kind kind, Vector<CalculationPtr> operands);
+
+private:
+	SharedPtr<const Node> root;
+	Units dependency_mask = Unit::UNKNOWN;
+	ResidualForm residual_form = ResidualForm::Tree;
+	float linear_px = 0.f;
+	float linear_percent = 0.f;
+};
+
+} // namespace Rml

--- a/Source/Core/CalculationParser.cpp
+++ b/Source/Core/CalculationParser.cpp
@@ -1,0 +1,858 @@
+#include "CalculationParser.h"
+#include "../../Include/RmlUi/Core/StringUtilities.h"
+#include <cmath>
+#include <cstdlib>
+#include <limits>
+
+namespace Rml {
+namespace {
+
+	constexpr size_t MaxTerms = 32;
+	constexpr size_t MaxDepth = 32;
+	constexpr size_t MaxArguments = 32;
+
+	using NodePtr = SharedPtr<const Calculation::Node>;
+
+	CalculationNumericType TypeForUnit(Unit unit, CalculationPercentageHint hint)
+	{
+		CalculationNumericType type;
+		if (Any(unit & Unit::LENGTH))
+			type.exponents[size_t(CalculationDimension::Length)] = 1;
+		else if (Any(unit & Unit::ANGLE))
+			type.exponents[size_t(CalculationDimension::Angle)] = 1;
+		else if (unit == Unit::X)
+			type.exponents[size_t(CalculationDimension::Resolution)] = 1;
+		else if (unit == Unit::PERCENT)
+		{
+			if (hint == CalculationPercentageHint::Length)
+				type.exponents[size_t(CalculationDimension::Length)] = 1;
+			else if (hint == CalculationPercentageHint::Angle)
+				type.exponents[size_t(CalculationDimension::Angle)] = 1;
+			else
+				type.exponents[size_t(CalculationDimension::Percent)] = 1;
+		}
+		return type;
+	}
+
+	CalculationNumericType TimeType()
+	{
+		CalculationNumericType type;
+		type.exponents[size_t(CalculationDimension::Time)] = 1;
+		return type;
+	}
+
+	CalculationNumericType MultiplyTypes(CalculationNumericType lhs, const CalculationNumericType& rhs, int sign = 1)
+	{
+		for (size_t i = 0; i < lhs.exponents.size(); ++i)
+			lhs.exponents[i] = int8_t(lhs.exponents[i] + sign * rhs.exponents[i]);
+		return lhs;
+	}
+
+	CalculationTypeMask FinalTypeMask(const CalculationNumericType& type)
+	{
+		int dimension = -1;
+		for (size_t i = 0; i < type.exponents.size(); ++i)
+		{
+			const int8_t exponent = type.exponents[i];
+			if (exponent == 0)
+				continue;
+			if (exponent != 1 || dimension >= 0)
+				return 0;
+			dimension = int(i);
+		}
+		if (dimension < 0)
+			return CalculationTypeMask(CalculationFinalType::Number);
+
+		switch (CalculationDimension(dimension))
+		{
+		case CalculationDimension::Length: return CalculationTypeMask(CalculationFinalType::Length);
+		case CalculationDimension::Angle: return CalculationTypeMask(CalculationFinalType::Angle);
+		case CalculationDimension::Time: return CalculationTypeMask(CalculationFinalType::Time);
+		case CalculationDimension::Resolution: return CalculationTypeMask(CalculationFinalType::Resolution);
+		case CalculationDimension::Percent: return CalculationTypeMask(CalculationFinalType::Percent);
+		default: return 0;
+		}
+	}
+
+	bool IsWhitespace(char c)
+	{
+		return c == '\f' || StringUtilities::IsWhitespace(c);
+	}
+
+	bool IsDigit(char c)
+	{
+		return c >= '0' && c <= '9';
+	}
+
+	template <size_t N>
+	bool EqualsAsciiCaseInsensitive(StringView string, const char (&literal)[N])
+	{
+		if (string.size() != N - 1)
+			return false;
+		for (size_t i = 0; i < N - 1; ++i)
+		{
+			const char c = string.begin()[i];
+			const char lower = (c >= 'A' && c <= 'Z') ? char(c + ('a' - 'A')) : c;
+			if (lower != literal[i])
+				return false;
+		}
+		return true;
+	}
+
+	enum class FunctionKind : uint8_t { Unknown, Calc, Min, Max, Clamp };
+
+	class Parser {
+	public:
+		Parser(const String& input, CalculationParseTarget target) : input(input), target(target) {}
+
+		NodePtr Parse()
+		{
+			SkipWhitespace();
+			NodePtr root = ParseFunction(0);
+			SkipWhitespace();
+			if (!root || position != input.size())
+				return nullptr;
+			if ((FinalTypeMask(root->type) & target.allowed_final_types) == 0)
+				return nullptr;
+			return root;
+		}
+
+		Units GetDependencyMask() const { return dependency_mask; }
+
+	private:
+		bool SkipWhitespace()
+		{
+			bool saw_whitespace = false;
+			for (;;)
+			{
+				while (position < input.size() && IsWhitespace(input[position]))
+				{
+					saw_whitespace = true;
+					++position;
+				}
+				if (position + 1 < input.size() && input[position] == '/' && input[position + 1] == '*')
+				{
+					const size_t end = input.find("*/", position + 2);
+					if (end == String::npos)
+					{
+						position = input.size();
+						break;
+					}
+					position = end + 2;
+					continue;
+				}
+				break;
+			}
+			return saw_whitespace;
+		}
+
+		bool Consume(char c)
+		{
+			SkipWhitespace();
+			if (position < input.size() && input[position] == c)
+			{
+				++position;
+				return true;
+			}
+			return false;
+		}
+
+		bool ConsumeClose()
+		{
+			SkipWhitespace();
+			if (position == input.size())
+				return true;
+			if (input[position] == ')')
+			{
+				++position;
+				return true;
+			}
+			return false;
+		}
+
+		NodePtr ParseFunction(size_t depth)
+		{
+			if (depth > MaxDepth)
+				return nullptr;
+			SkipWhitespace();
+			const size_t name_begin = position;
+			while (position < input.size() &&
+				((input[position] >= 'a' && input[position] <= 'z') || (input[position] >= 'A' && input[position] <= 'Z') || input[position] == '-'))
+				++position;
+			const StringView name(input, name_begin, position - name_begin);
+			FunctionKind function = FunctionKind::Unknown;
+			if (EqualsAsciiCaseInsensitive(name, "calc"))
+				function = FunctionKind::Calc;
+			else if (EqualsAsciiCaseInsensitive(name, "min"))
+				function = FunctionKind::Min;
+			else if (EqualsAsciiCaseInsensitive(name, "max"))
+				function = FunctionKind::Max;
+			else if (EqualsAsciiCaseInsensitive(name, "clamp"))
+				function = FunctionKind::Clamp;
+			if (function == FunctionKind::Unknown)
+				return nullptr;
+			if (position >= input.size() || input[position++] != '(')
+				return nullptr;
+
+			if (function == FunctionKind::Calc)
+			{
+				NodePtr node = ParseSum(depth);
+				if (!node || !ConsumeClose())
+					return nullptr;
+				return node;
+			}
+
+			Vector<NodePtr> arguments;
+			if (function == FunctionKind::Clamp)
+			{
+				arguments.reserve(3);
+				for (size_t i = 0; i < 3; ++i)
+				{
+					SkipWhitespace();
+					NodePtr argument;
+					const bool none = (i == 0 || i == 2) && ConsumeKeyword("none");
+					if (none)
+						argument = nullptr;
+					else
+						argument = ParseSum(depth);
+					if (!none && !argument)
+						return nullptr;
+					arguments.push_back(std::move(argument));
+					if (i != 2 && !Consume(','))
+						return nullptr;
+				}
+				if (!ConsumeClose())
+					return nullptr;
+				CalculationNumericType common;
+				bool have_common = false;
+				for (const NodePtr& argument : arguments)
+				{
+					if (!argument)
+						continue;
+					if (!have_common)
+					{
+						common = argument->type;
+						have_common = true;
+					}
+					else if (common != argument->type)
+						return nullptr;
+				}
+				if (!have_common)
+					return nullptr;
+				auto node = MakeShared<Calculation::Node>();
+				node->kind = Calculation::Kind::Clamp;
+				node->type = common;
+				node->children = std::move(arguments);
+				return node;
+			}
+
+			SkipWhitespace();
+			if (position < input.size() && input[position] == ')')
+				return nullptr;
+			arguments.reserve(2);
+			while (arguments.size() < MaxArguments)
+			{
+				NodePtr argument = ParseSum(depth);
+				if (!argument)
+					return nullptr;
+				arguments.push_back(std::move(argument));
+				SkipWhitespace();
+				if (position == input.size() || input[position] == ')')
+				{
+					if (position < input.size())
+						++position;
+					break;
+				}
+				if (arguments.size() == MaxArguments)
+					return nullptr;
+				if (!Consume(','))
+					return nullptr;
+			}
+			if (arguments.empty() || arguments.size() > MaxArguments)
+				return nullptr;
+			if (position > input.size())
+				return nullptr;
+			for (size_t i = 1; i < arguments.size(); ++i)
+				if (arguments[i]->type != arguments[0]->type)
+					return nullptr;
+			auto node = MakeShared<Calculation::Node>();
+			node->kind = function == FunctionKind::Min ? Calculation::Kind::Min : Calculation::Kind::Max;
+			node->type = arguments[0]->type;
+			node->children = std::move(arguments);
+			return node;
+		}
+
+		template <size_t N>
+		bool ConsumeKeyword(const char (&keyword)[N])
+		{
+			SkipWhitespace();
+			constexpr size_t length = N - 1;
+			if (position + length > input.size() || !EqualsAsciiCaseInsensitive(StringView(input, position, length), keyword))
+				return false;
+			const size_t end = position + length;
+			if (end < input.size() && ((input[end] >= 'a' && input[end] <= 'z') || (input[end] >= 'A' && input[end] <= 'Z') || input[end] == '-'))
+				return false;
+			position = end;
+			return true;
+		}
+
+		NodePtr ParseSum(size_t depth)
+		{
+			NodePtr lhs = ParseProduct(depth);
+			if (!lhs)
+				return nullptr;
+			const CalculationNumericType type = lhs->type;
+			Vector<NodePtr> children;
+			for (;;)
+			{
+				const bool whitespace_before = SkipWhitespace();
+				if (position >= input.size() || (input[position] != '+' && input[position] != '-'))
+					break;
+				if (children.empty())
+				{
+					children.reserve(2);
+					children.push_back(std::move(lhs));
+				}
+				const char op = input[position++];
+				const bool whitespace_after = SkipWhitespace();
+				if (!whitespace_before || !whitespace_after)
+					return nullptr;
+				NodePtr rhs = ParseProduct(depth);
+				if (!rhs || rhs->type != type)
+					return nullptr;
+				if (op == '-')
+					rhs = MakeUnary(Calculation::Kind::Negate, std::move(rhs));
+				children.push_back(std::move(rhs));
+			}
+			if (children.empty())
+				return lhs;
+			auto node = MakeShared<Calculation::Node>();
+			node->kind = Calculation::Kind::Sum;
+			node->type = type;
+			node->children = std::move(children);
+			return node;
+		}
+
+		NodePtr ParseProduct(size_t depth)
+		{
+			NodePtr lhs = ParseValue(depth);
+			if (!lhs)
+				return nullptr;
+			Vector<NodePtr> children;
+			CalculationNumericType type = lhs->type;
+			for (;;)
+			{
+				const size_t before_whitespace = position;
+				SkipWhitespace();
+				if (position >= input.size() || (input[position] != '*' && input[position] != '/'))
+				{
+					position = before_whitespace;
+					break;
+				}
+				if (children.empty())
+				{
+					children.reserve(2);
+					children.push_back(std::move(lhs));
+				}
+				const char op = input[position++];
+				NodePtr rhs = ParseValue(depth);
+				if (!rhs)
+					return nullptr;
+				type = MultiplyTypes(type, rhs->type, op == '/' ? -1 : 1);
+				if (op == '/')
+					rhs = MakeUnary(Calculation::Kind::Invert, std::move(rhs));
+				children.push_back(std::move(rhs));
+			}
+			if (children.empty())
+				return lhs;
+			auto node = MakeShared<Calculation::Node>();
+			node->kind = Calculation::Kind::Product;
+			node->type = type;
+			node->children = std::move(children);
+			return node;
+		}
+
+		NodePtr ParseValue(size_t depth)
+		{
+			SkipWhitespace();
+			if (position >= input.size())
+				return nullptr;
+			if (input[position] == '(')
+			{
+				if (depth >= MaxDepth)
+					return nullptr;
+				++position;
+				NodePtr value = ParseSum(depth + 1);
+				if (!value || !ConsumeClose())
+					return nullptr;
+				return value;
+			}
+			if ((input[position] >= 'a' && input[position] <= 'z') || (input[position] >= 'A' && input[position] <= 'Z'))
+			{
+				if (depth >= MaxDepth)
+					return nullptr;
+				return ParseFunction(depth + 1);
+			}
+			return ParseNumericValue();
+		}
+
+		NodePtr ParseNumericValue()
+		{
+			if (++terms > MaxTerms)
+				return nullptr;
+
+			const size_t number_begin = position;
+			if (position < input.size() && (input[position] == '+' || input[position] == '-'))
+				++position;
+
+			const size_t integer_begin = position;
+			while (position < input.size() && IsDigit(input[position]))
+				++position;
+			bool has_digits = position > integer_begin;
+
+			if (position + 1 < input.size() && input[position] == '.' && IsDigit(input[position + 1]))
+			{
+				++position;
+				while (position < input.size() && IsDigit(input[position]))
+					++position;
+				has_digits = true;
+			}
+			if (!has_digits)
+				return nullptr;
+
+			if (position < input.size() && (input[position] == 'e' || input[position] == 'E'))
+			{
+				size_t exponent_position = position + 1;
+				if (exponent_position < input.size() && (input[exponent_position] == '+' || input[exponent_position] == '-'))
+					++exponent_position;
+				if (exponent_position < input.size() && IsDigit(input[exponent_position]))
+				{
+					position = exponent_position + 1;
+					while (position < input.size() && IsDigit(input[position]))
+						++position;
+				}
+			}
+
+			char* end = nullptr;
+			const char* number_begin_ptr = input.c_str() + number_begin;
+			const float number = strtof(number_begin_ptr, &end);
+			if (end != input.c_str() + position || !std::isfinite(number))
+				return nullptr;
+			const size_t unit_begin = position;
+			if (position < input.size() && input[position] == '%')
+				++position;
+			else
+				while (position < input.size() &&
+					((input[position] >= 'a' && input[position] <= 'z') || (input[position] >= 'A' && input[position] <= 'Z')))
+					++position;
+			const StringView unit_name(input, unit_begin, position - unit_begin);
+			Unit unit = Unit::UNKNOWN;
+			Calculation::ValueUnit value_unit = Calculation::ValueUnit::Public;
+			bool milliseconds = false;
+			if (unit_name.empty())
+				unit = Unit::NUMBER;
+			else if (EqualsAsciiCaseInsensitive(unit_name, "%"))
+				unit = Unit::PERCENT;
+			else if (EqualsAsciiCaseInsensitive(unit_name, "px"))
+				unit = Unit::PX;
+			else if (EqualsAsciiCaseInsensitive(unit_name, "dp"))
+				unit = Unit::DP;
+			else if (EqualsAsciiCaseInsensitive(unit_name, "vw"))
+				unit = Unit::VW;
+			else if (EqualsAsciiCaseInsensitive(unit_name, "vh"))
+				unit = Unit::VH;
+			else if (EqualsAsciiCaseInsensitive(unit_name, "em"))
+				unit = Unit::EM;
+			else if (EqualsAsciiCaseInsensitive(unit_name, "rem"))
+				unit = Unit::REM;
+			else if (EqualsAsciiCaseInsensitive(unit_name, "in"))
+				unit = Unit::INCH;
+			else if (EqualsAsciiCaseInsensitive(unit_name, "cm"))
+				unit = Unit::CM;
+			else if (EqualsAsciiCaseInsensitive(unit_name, "mm"))
+				unit = Unit::MM;
+			else if (EqualsAsciiCaseInsensitive(unit_name, "pt"))
+				unit = Unit::PT;
+			else if (EqualsAsciiCaseInsensitive(unit_name, "pc"))
+				unit = Unit::PC;
+			else if (EqualsAsciiCaseInsensitive(unit_name, "deg"))
+				unit = Unit::DEG;
+			else if (EqualsAsciiCaseInsensitive(unit_name, "rad"))
+				unit = Unit::RAD;
+			else if (EqualsAsciiCaseInsensitive(unit_name, "x"))
+				unit = Unit::X;
+			else if ((target.allowed_final_types & CalculationTypeMask(CalculationFinalType::Time)) != 0 &&
+				(EqualsAsciiCaseInsensitive(unit_name, "s") || (milliseconds = EqualsAsciiCaseInsensitive(unit_name, "ms"))))
+			{
+				unit = Unit::NUMBER;
+				value_unit = Calculation::ValueUnit::Seconds;
+			}
+			if (unit == Unit::UNKNOWN)
+				return nullptr;
+			if (unit == Unit::EM || unit == Unit::REM || unit == Unit::VW || unit == Unit::VH || unit == Unit::DP || Any(unit & Unit::PPI_UNIT))
+				dependency_mask = dependency_mask | unit;
+			auto node = MakeShared<Calculation::Node>();
+			node->value = milliseconds ? number * 0.001f : number;
+			node->unit = unit;
+			node->value_unit = value_unit;
+			node->type = value_unit == Calculation::ValueUnit::Seconds ? TimeType() : TypeForUnit(unit, target.percentage_hint);
+			return node;
+		}
+
+		NodePtr MakeUnary(Calculation::Kind kind, NodePtr child)
+		{
+			auto node = MakeShared<Calculation::Node>();
+			node->kind = kind;
+			node->type = kind == Calculation::Kind::Invert ? MultiplyTypes({}, child->type, -1) : child->type;
+			node->children.push_back(std::move(child));
+			return node;
+		}
+
+		const String& input;
+		CalculationParseTarget target;
+		size_t position = 0;
+		size_t terms = 0;
+		Units dependency_mask = Unit::UNKNOWN;
+	};
+
+	struct EvalValue {
+		float value = 0;
+		CalculationNumericType type;
+		Unit unit = Unit::UNKNOWN;
+		Calculation::ValueUnit value_unit = Calculation::ValueUnit::Public;
+		bool percent_only = false;
+		int percentage_basis_power = 0;
+		bool contains_dp_scaled_physical = false;
+	};
+
+	enum class EvalStatus { Success, Deferred, Failure };
+
+	bool CanonicalValue(const Calculation::Node& node, EvalValue& result)
+	{
+		result.value = node.value;
+		result.type = node.type;
+		result.unit = node.unit;
+		result.value_unit = node.value_unit;
+		result.percent_only = node.unit == Unit::PERCENT;
+		result.percentage_basis_power =
+			(node.unit == Unit::PERCENT && FinalTypeMask(node.type) != CalculationTypeMask(CalculationFinalType::Percent)) ? 1 : 0;
+		result.contains_dp_scaled_physical = Any(node.unit & Unit::PPI_UNIT);
+		switch (node.unit)
+		{
+		case Unit::NUMBER: return true;
+		case Unit::PERCENT: return true;
+		case Unit::PX: return true;
+		case Unit::INCH:
+			result.value *= 96.f;
+			result.unit = Unit::PX;
+			return true;
+		case Unit::CM:
+			result.value *= 96.f / 2.54f;
+			result.unit = Unit::PX;
+			return true;
+		case Unit::MM:
+			result.value *= 96.f / 25.4f;
+			result.unit = Unit::PX;
+			return true;
+		case Unit::PT:
+			result.value *= 96.f / 72.f;
+			result.unit = Unit::PX;
+			return true;
+		case Unit::PC:
+			result.value *= 16.f;
+			result.unit = Unit::PX;
+			return true;
+		case Unit::DEG: return true;
+		case Unit::RAD:
+			result.value *= 180.f / float(3.14159265358979323846);
+			result.unit = Unit::DEG;
+			return true;
+		case Unit::X: return true;
+		default: return false;
+		}
+	}
+
+	Unit CanonicalUnit(const CalculationNumericType& type, bool percent_only)
+	{
+		if (percent_only)
+			return Unit::PERCENT;
+		const CalculationTypeMask mask = FinalTypeMask(type);
+		if (mask == CalculationTypeMask(CalculationFinalType::Number))
+			return Unit::NUMBER;
+		if (mask == CalculationTypeMask(CalculationFinalType::Length))
+			return Unit::PX;
+		if (mask == CalculationTypeMask(CalculationFinalType::Angle))
+			return Unit::DEG;
+		if (mask == CalculationTypeMask(CalculationFinalType::Time))
+			return Unit::NUMBER;
+		if (mask == CalculationTypeMask(CalculationFinalType::Resolution))
+			return Unit::X;
+		if (mask == CalculationTypeMask(CalculationFinalType::Percent))
+			return Unit::PERCENT;
+		return Unit::UNKNOWN;
+	}
+
+	EvalStatus EvaluateNode(const Calculation::Node& node, EvalValue& result)
+	{
+		if (node.kind == Calculation::Kind::Value)
+		{
+			if (!CanonicalValue(node, result))
+				return EvalStatus::Deferred;
+			return std::isfinite(result.value) ? EvalStatus::Success : EvalStatus::Failure;
+		}
+		if (node.kind == Calculation::Kind::Negate || node.kind == Calculation::Kind::Invert)
+		{
+			if (node.children.size() != 1 || !node.children[0])
+				return EvalStatus::Failure;
+			const EvalStatus child_status = EvaluateNode(*node.children[0], result);
+			if (child_status != EvalStatus::Success)
+				return child_status;
+			if (node.kind == Calculation::Kind::Negate)
+				result.value = -result.value;
+			else
+			{
+				result.value = 1.f / result.value;
+				result.type = node.type;
+				result.percent_only = false;
+				result.percentage_basis_power = -result.percentage_basis_power;
+			}
+			result.unit = CanonicalUnit(result.type, result.percent_only);
+			result.value_unit = FinalTypeMask(result.type) == CalculationTypeMask(CalculationFinalType::Time) ? Calculation::ValueUnit::Seconds
+																											  : Calculation::ValueUnit::Public;
+			return std::isfinite(result.value) ? EvalStatus::Success : EvalStatus::Failure;
+		}
+
+		if (node.kind == Calculation::Kind::Sum || node.kind == Calculation::Kind::Product)
+		{
+			if (node.children.empty())
+				return EvalStatus::Failure;
+			EvalValue aggregate;
+			const EvalStatus first_status = EvaluateNode(*node.children[0], aggregate);
+			if (first_status != EvalStatus::Success)
+				return first_status;
+			for (size_t i = 1; i < node.children.size(); ++i)
+			{
+				EvalValue rhs;
+				if (!node.children[i])
+					return EvalStatus::Failure;
+				const EvalStatus rhs_status = EvaluateNode(*node.children[i], rhs);
+				if (rhs_status != EvalStatus::Success)
+					return rhs_status;
+				if (node.kind == Calculation::Kind::Sum)
+				{
+					if (aggregate.unit != rhs.unit || aggregate.percentage_basis_power != rhs.percentage_basis_power)
+						return EvalStatus::Deferred;
+					aggregate.value += rhs.value;
+					aggregate.percent_only = aggregate.percent_only && rhs.percent_only;
+				}
+				else
+				{
+					aggregate.value *= rhs.value;
+					aggregate.type = MultiplyTypes(aggregate.type, rhs.type);
+					aggregate.percent_only = aggregate.percent_only && (rhs.unit == Unit::NUMBER || rhs.percent_only);
+					aggregate.percentage_basis_power += rhs.percentage_basis_power;
+					aggregate.unit = CanonicalUnit(aggregate.type, aggregate.percent_only);
+					aggregate.value_unit = FinalTypeMask(aggregate.type) == CalculationTypeMask(CalculationFinalType::Time)
+						? Calculation::ValueUnit::Seconds
+						: Calculation::ValueUnit::Public;
+				}
+				aggregate.contains_dp_scaled_physical |= rhs.contains_dp_scaled_physical;
+				if (!std::isfinite(aggregate.value))
+					return EvalStatus::Failure;
+			}
+			aggregate.type = node.type;
+			aggregate.unit = CanonicalUnit(node.type, aggregate.percent_only);
+			result = aggregate;
+			result.value_unit = FinalTypeMask(result.type) == CalculationTypeMask(CalculationFinalType::Time) ? Calculation::ValueUnit::Seconds
+																											  : Calculation::ValueUnit::Public;
+			if (result.percentage_basis_power != 0)
+			{
+				const CalculationTypeMask final_type = FinalTypeMask(result.type);
+				const bool representable_percentage = result.percentage_basis_power == 1 && result.percent_only && result.unit == Unit::PERCENT &&
+					(final_type == CalculationTypeMask(CalculationFinalType::Length) ||
+						final_type == CalculationTypeMask(CalculationFinalType::Angle));
+				if (!representable_percentage)
+					return EvalStatus::Deferred;
+			}
+			return result.unit != Unit::UNKNOWN ? EvalStatus::Success : EvalStatus::Deferred;
+		}
+
+		if (node.kind == Calculation::Kind::Min || node.kind == Calculation::Kind::Max || node.kind == Calculation::Kind::Clamp)
+		{
+			Vector<EvalValue> values;
+			values.reserve(node.children.size());
+			bool contains_dp_scaled_physical = false;
+			for (const NodePtr& child : node.children)
+			{
+				if (!child)
+				{
+					values.push_back({});
+					continue;
+				}
+				EvalValue value;
+				const EvalStatus status = EvaluateNode(*child, value);
+				if (status != EvalStatus::Success)
+					return status;
+				contains_dp_scaled_physical |= value.contains_dp_scaled_physical;
+				values.push_back(value);
+			}
+			Unit common_unit = Unit::UNKNOWN;
+			int common_percentage_basis_power = 0;
+			bool have_common_percentage_basis_power = false;
+			for (size_t i = 0; i < values.size(); ++i)
+			{
+				if (!node.children[i])
+					continue;
+				if (common_unit == Unit::UNKNOWN)
+					common_unit = values[i].unit;
+				else if (values[i].unit != common_unit)
+					return EvalStatus::Deferred;
+				if (!have_common_percentage_basis_power)
+				{
+					common_percentage_basis_power = values[i].percentage_basis_power;
+					have_common_percentage_basis_power = true;
+				}
+				else if (values[i].percentage_basis_power != common_percentage_basis_power)
+					return EvalStatus::Deferred;
+			}
+			if (node.kind == Calculation::Kind::Min || node.kind == Calculation::Kind::Max)
+			{
+				result = values[0];
+				for (size_t i = 1; i < values.size(); ++i)
+					if ((node.kind == Calculation::Kind::Min && values[i].value < result.value) ||
+						(node.kind == Calculation::Kind::Max && values[i].value > result.value))
+						result = values[i];
+			}
+			else
+			{
+				const bool has_min = bool(node.children[0]);
+				const bool has_max = bool(node.children[2]);
+				result = values[1];
+				if (has_max && result.value > values[2].value)
+					result = values[2];
+				if (has_min && result.value < values[0].value)
+					result = values[0];
+			}
+			result.type = node.type;
+			result.unit = common_unit;
+			result.value_unit = FinalTypeMask(node.type) == CalculationTypeMask(CalculationFinalType::Time) ? Calculation::ValueUnit::Seconds
+																											: Calculation::ValueUnit::Public;
+			result.percentage_basis_power = common_percentage_basis_power;
+			result.contains_dp_scaled_physical = contains_dp_scaled_physical;
+			return std::isfinite(result.value) ? EvalStatus::Success : EvalStatus::Failure;
+		}
+		return EvalStatus::Failure;
+	}
+
+	NodePtr SimplifyNode(const NodePtr& node, bool& failed)
+	{
+		EvalValue value;
+		const EvalStatus status = EvaluateNode(*node, value);
+		if (status == EvalStatus::Failure)
+		{
+			failed = true;
+			return nullptr;
+		}
+		if (status == EvalStatus::Success && value.unit != Unit::UNKNOWN && !value.contains_dp_scaled_physical &&
+			node->kind != Calculation::Kind::Negate && node->kind != Calculation::Kind::Invert)
+		{
+			if (node->kind == Calculation::Kind::Value && node->value == value.value && node->unit == value.unit &&
+				node->value_unit == value.value_unit)
+				return node;
+			auto constant = MakeShared<Calculation::Node>();
+			constant->value = value.value;
+			constant->unit = value.unit;
+			constant->value_unit = value.value_unit;
+			constant->type = node->type;
+			return constant;
+		}
+
+		SharedPtr<Calculation::Node> simplified;
+		for (size_t i = 0; i < node->children.size(); ++i)
+		{
+			const NodePtr& child = node->children[i];
+			if (!child)
+				continue;
+			NodePtr simplified_child = SimplifyNode(child, failed);
+			if (failed)
+				return nullptr;
+			if (simplified_child != child)
+			{
+				if (!simplified)
+					simplified = MakeShared<Calculation::Node>(*node);
+				simplified->children[i] = std::move(simplified_child);
+			}
+		}
+		return simplified ? NodePtr(std::move(simplified)) : node;
+	}
+
+} // namespace
+
+CalculationParseTarget MakeCalculationParseTarget(CalculationFinalType type, CalculationPercentageHint hint)
+{
+	return {CalculationTypeMask(type), hint};
+}
+
+bool ParseCalculation(const String& expression, const CalculationParseTarget& target, CalculationPtr& result)
+{
+	result.reset();
+	Parser parser(expression, target);
+	NodePtr root = parser.Parse();
+	if (!root)
+		return false;
+	const Units dependency_mask = parser.GetDependencyMask();
+	bool failed = false;
+	NodePtr simplified_root = SimplifyNode(root, failed);
+	if (failed || !simplified_root)
+	{
+		return false;
+	}
+	result = MakeShared<Calculation>(std::move(simplified_root), dependency_mask);
+	return true;
+}
+
+bool EvaluateCalculation(const Calculation& calculation, CalculationConstantValue& result)
+{
+	if (!calculation.GetRoot())
+		return false;
+	EvalValue value;
+	if (EvaluateNode(*calculation.GetRoot(), value) != EvalStatus::Success || !std::isfinite(value.value))
+		return false;
+	result.value = value.value;
+	result.unit = value.unit;
+	return result.unit != Unit::UNKNOWN;
+}
+
+bool EvaluateCalculationTime(const Calculation& calculation, float& seconds)
+{
+	seconds = 0.f;
+	if (!calculation.GetRoot() || FinalTypeMask(calculation.GetType()) != CalculationTypeMask(CalculationFinalType::Time))
+		return false;
+	EvalValue value;
+	if (EvaluateNode(*calculation.GetRoot(), value) != EvalStatus::Success || value.value_unit != Calculation::ValueUnit::Seconds ||
+		!std::isfinite(value.value))
+		return false;
+	seconds = value.value;
+	return true;
+}
+
+CalculationTypeMask GetCalculationFinalType(const Calculation& calculation)
+{
+	return calculation.GetRoot() ? FinalTypeMask(calculation.GetType()) : 0;
+}
+
+bool SimplifyCalculation(const Calculation& calculation, CalculationPtr& result)
+{
+	result.reset();
+	if (!calculation.GetRoot())
+		return false;
+	bool failed = false;
+	NodePtr root = SimplifyNode(calculation.GetRoot(), failed);
+	if (failed || !root)
+		return false;
+	result = MakeShared<Calculation>(std::move(root), calculation.GetDependencyMask(), calculation.GetResidualForm(), calculation.GetLinearPx(),
+		calculation.GetLinearPercent());
+	return true;
+}
+
+} // namespace Rml

--- a/Source/Core/CalculationParser.h
+++ b/Source/Core/CalculationParser.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "Calculation.h"
+
+namespace Rml {
+
+enum class CalculationPercentageHint : uint8_t { None, Length, Angle };
+
+enum class CalculationFinalType : uint8_t {
+	Number = 1 << 0,
+	Length = 1 << 1,
+	Angle = 1 << 2,
+	Resolution = 1 << 3,
+	Percent = 1 << 4,
+	Time = 1 << 5,
+};
+
+using CalculationTypeMask = uint8_t;
+
+constexpr CalculationTypeMask operator|(CalculationFinalType lhs, CalculationFinalType rhs)
+{
+	return CalculationTypeMask(lhs) | CalculationTypeMask(rhs);
+}
+
+struct CalculationParseTarget {
+	CalculationTypeMask allowed_final_types = 0;
+	CalculationPercentageHint percentage_hint = CalculationPercentageHint::None;
+};
+
+struct CalculationConstantValue {
+	float value = 0;
+	Unit unit = Unit::UNKNOWN;
+};
+
+CalculationParseTarget MakeCalculationParseTarget(CalculationFinalType type, CalculationPercentageHint hint = CalculationPercentageHint::None);
+bool ParseCalculation(const String& expression, const CalculationParseTarget& target, CalculationPtr& result);
+bool EvaluateCalculation(const Calculation& calculation, CalculationConstantValue& result);
+bool EvaluateCalculationTime(const Calculation& calculation, float& seconds);
+CalculationTypeMask GetCalculationFinalType(const Calculation& calculation);
+bool SimplifyCalculation(const Calculation& calculation, CalculationPtr& result);
+
+} // namespace Rml

--- a/Source/Core/CalculationResolver.cpp
+++ b/Source/Core/CalculationResolver.cpp
@@ -1,0 +1,504 @@
+#include "CalculationResolver.h"
+#include "../../Include/RmlUi/Core/ComputedValues.h"
+#include "../../Include/RmlUi/Core/Context.h"
+#include "../../Include/RmlUi/Core/Element.h"
+#include "../../Include/RmlUi/Core/ElementDocument.h"
+#include "../../Include/RmlUi/Core/Math.h"
+#include "CalculationParser.h"
+#include "ComputeProperty.h"
+#include <cmath>
+
+namespace Rml {
+namespace {
+
+	using NodePtr = SharedPtr<const Calculation::Node>;
+
+	float PhysicalToPx(float value, Unit unit, float dp_ratio)
+	{
+		float inch = value * 96.f * dp_ratio;
+		switch (unit)
+		{
+		case Unit::INCH: return inch;
+		case Unit::CM: return inch / 2.54f;
+		case Unit::MM: return inch / 25.4f;
+		case Unit::PT: return inch / 72.f;
+		case Unit::PC: return inch / 6.f;
+		default: return value;
+		}
+	}
+
+	bool PercentageBasis(const CalculationResolverContext& context, float& basis)
+	{
+		switch (context.relative_target)
+		{
+		case RelativeTarget::FontSize: basis = context.font_size; return true;
+		case RelativeTarget::ParentFontSize: basis = context.parent_font_size; return true;
+		case RelativeTarget::LineHeight: basis = context.line_height; return true;
+		case RelativeTarget::None:
+		case RelativeTarget::ContainingBlockWidth:
+		case RelativeTarget::ContainingBlockHeight: return false;
+		}
+		return false;
+	}
+
+	NodePtr CanonicalizeNode(const NodePtr& node, const CalculationResolverContext& context, bool& failed)
+	{
+		if (node->kind == Calculation::Kind::Value)
+		{
+			float value = node->value;
+			Unit unit = node->unit;
+			switch (node->unit)
+			{
+			case Unit::PX:
+			case Unit::NUMBER:
+			case Unit::X: break;
+			case Unit::DP:
+				value *= context.dp_ratio;
+				unit = Unit::PX;
+				break;
+			case Unit::VW:
+				value *= context.viewport_dimensions.x * .01f;
+				unit = Unit::PX;
+				break;
+			case Unit::VH:
+				value *= context.viewport_dimensions.y * .01f;
+				unit = Unit::PX;
+				break;
+			case Unit::EM:
+				value *= (context.relative_target == RelativeTarget::ParentFontSize ? context.parent_font_size : context.font_size);
+				unit = Unit::PX;
+				break;
+			case Unit::REM:
+				value *= context.document_font_size;
+				unit = Unit::PX;
+				break;
+			case Unit::INCH:
+			case Unit::CM:
+			case Unit::MM:
+			case Unit::PT:
+			case Unit::PC:
+				value = PhysicalToPx(value, node->unit, context.dp_ratio);
+				unit = Unit::PX;
+				break;
+			case Unit::DEG:
+				value = Math::DegreesToRadians(value);
+				unit = Unit::RAD;
+				break;
+			case Unit::RAD: break;
+			case Unit::PERCENT:
+			{
+				float basis = 0.f;
+				if (PercentageBasis(context, basis))
+				{
+					value = value * .01f * basis;
+					unit = Unit::PX;
+				}
+				break;
+			}
+			default: break;
+			}
+			if (!std::isfinite(value))
+			{
+				failed = true;
+				return nullptr;
+			}
+			if (value == node->value && unit == node->unit)
+				return node;
+			auto result = MakeShared<Calculation::Node>(*node);
+			result->value = value;
+			result->unit = unit;
+			return result;
+		}
+
+		SharedPtr<Calculation::Node> result;
+		for (size_t i = 0; i < node->children.size(); ++i)
+		{
+			const NodePtr& child = node->children[i];
+			if (!child)
+				continue;
+			NodePtr canonical_child = CanonicalizeNode(child, context, failed);
+			if (failed || !canonical_child)
+				return nullptr;
+			if (canonical_child != child)
+			{
+				if (!result)
+					result = MakeShared<Calculation::Node>(*node);
+				result->children[i] = std::move(canonical_child);
+			}
+		}
+		return result ? NodePtr(std::move(result)) : node;
+	}
+
+	struct Affine {
+		bool valid = false;
+		bool scalar = false;
+		float number = 0.f;
+		float px = 0.f;
+		float percent = 0.f;
+	};
+
+	Affine AnalyzeAffine(const Calculation::Node& node)
+	{
+		if (node.kind == Calculation::Kind::Value)
+		{
+			if (node.unit == Unit::NUMBER)
+				return {true, true, node.value, 0.f, 0.f};
+			if (node.unit == Unit::PX)
+				return {true, false, 0.f, node.value, 0.f};
+			if (node.unit == Unit::PERCENT)
+				return {true, false, 0.f, 0.f, node.value};
+			return {};
+		}
+		if (node.kind == Calculation::Kind::Negate && node.children.size() == 1 && node.children[0])
+		{
+			Affine a = AnalyzeAffine(*node.children[0]);
+			if (!a.valid)
+				return {};
+			a.number = -a.number;
+			a.px = -a.px;
+			a.percent = -a.percent;
+			return a;
+		}
+		if (node.kind == Calculation::Kind::Invert && node.children.size() == 1 && node.children[0])
+		{
+			Affine a = AnalyzeAffine(*node.children[0]);
+			if (!a.valid || !a.scalar || a.number == 0.f)
+				return {};
+			a.number = 1.f / a.number;
+			return std::isfinite(a.number) ? a : Affine{};
+		}
+		if (node.kind == Calculation::Kind::Sum)
+		{
+			Affine out{true, false, 0.f, 0.f, 0.f};
+			for (const NodePtr& child : node.children)
+			{
+				if (!child)
+					return {};
+				Affine a = AnalyzeAffine(*child);
+				if (!a.valid || a.scalar)
+					return {};
+				out.px += a.px;
+				out.percent += a.percent;
+			}
+			return out;
+		}
+		if (node.kind == Calculation::Kind::Product)
+		{
+			Affine out{true, true, 1.f, 0.f, 0.f};
+			for (const NodePtr& child : node.children)
+			{
+				if (!child)
+					return {};
+				Affine a = AnalyzeAffine(*child);
+				if (!a.valid)
+					return {};
+				if (out.scalar && a.scalar)
+					out.number *= a.number;
+				else if (out.scalar && !a.scalar)
+				{
+					out.px = a.px * out.number;
+					out.percent = a.percent * out.number;
+					out.number = 0.f;
+					out.scalar = false;
+				}
+				else if (!out.scalar && a.scalar)
+				{
+					out.px *= a.number;
+					out.percent *= a.number;
+				}
+				else
+					return {};
+			}
+			return out;
+		}
+		return {};
+	}
+
+	bool EvaluateUsedNode(const Calculation::Node& node, float percentage_basis, float& result)
+	{
+		if (node.kind == Calculation::Kind::Value)
+		{
+			if (node.unit == Unit::PERCENT)
+				result = node.value * .01f * percentage_basis;
+			else
+				result = node.value;
+			return std::isfinite(result);
+		}
+
+		if (node.kind == Calculation::Kind::Negate || node.kind == Calculation::Kind::Invert)
+		{
+			if (node.children.size() != 1 || !node.children[0] || !EvaluateUsedNode(*node.children[0], percentage_basis, result))
+				return false;
+			if (node.kind == Calculation::Kind::Negate)
+				result = -result;
+			else
+			{
+				if (result == 0.f)
+					return false;
+				result = 1.f / result;
+			}
+			return std::isfinite(result);
+		}
+
+		if (node.kind == Calculation::Kind::Sum || node.kind == Calculation::Kind::Product || node.kind == Calculation::Kind::Min ||
+			node.kind == Calculation::Kind::Max)
+		{
+			if (node.children.empty())
+				return false;
+			float accumulated = (node.kind == Calculation::Kind::Product ? 1.f : 0.f);
+			bool first = true;
+			for (const NodePtr& child : node.children)
+			{
+				float value = 0.f;
+				if (!child || !EvaluateUsedNode(*child, percentage_basis, value))
+					return false;
+				if (node.kind == Calculation::Kind::Sum)
+					accumulated += value;
+				else if (node.kind == Calculation::Kind::Product)
+					accumulated *= value;
+				else if (first || (node.kind == Calculation::Kind::Min ? value < accumulated : value > accumulated))
+					accumulated = value;
+				first = false;
+				if (!std::isfinite(accumulated))
+					return false;
+			}
+			result = accumulated;
+			return true;
+		}
+
+		if (node.kind == Calculation::Kind::Clamp)
+		{
+			if (node.children.size() != 3 || !node.children[1])
+				return false;
+			float value = 0.f;
+			if (!EvaluateUsedNode(*node.children[1], percentage_basis, value))
+				return false;
+			if (node.children[2])
+			{
+				float maximum = 0.f;
+				if (!EvaluateUsedNode(*node.children[2], percentage_basis, maximum))
+					return false;
+				value = Math::Min(value, maximum);
+			}
+			if (node.children[0])
+			{
+				float minimum = 0.f;
+				if (!EvaluateUsedNode(*node.children[0], percentage_basis, minimum))
+					return false;
+				value = Math::Max(value, minimum);
+			}
+			result = value;
+			return std::isfinite(result);
+		}
+
+		return false;
+	}
+
+	// Resolve a parsed calculation directly to its canonical scalar for element/compound use. Unlike
+	// ResolveCalculation(), this path deliberately does not canonicalize/simplify into replacement
+	// Calculation trees: animation endpoints and lazy compound values can be resolved every frame/use
+	// without allocating a transient calculation tree.
+	bool EvaluateElementNode(const Calculation::Node& node, const CalculationResolverContext& context, float percentage_basis, float& result)
+	{
+		if (node.kind == Calculation::Kind::Value)
+		{
+			result = node.value;
+			switch (node.unit)
+			{
+			case Unit::NUMBER:
+			case Unit::PX:
+			case Unit::RAD:
+			case Unit::X: break;
+			case Unit::DP: result *= context.dp_ratio; break;
+			case Unit::VW: result *= context.viewport_dimensions.x * .01f; break;
+			case Unit::VH: result *= context.viewport_dimensions.y * .01f; break;
+			case Unit::EM:
+				result *= (context.relative_target == RelativeTarget::ParentFontSize ? context.parent_font_size : context.font_size);
+				break;
+			case Unit::REM: result *= context.document_font_size; break;
+			case Unit::INCH:
+			case Unit::CM:
+			case Unit::MM:
+			case Unit::PT:
+			case Unit::PC: result = PhysicalToPx(result, node.unit, context.dp_ratio); break;
+			case Unit::DEG: result = Math::DegreesToRadians(result); break;
+			case Unit::PERCENT:
+			{
+				float basis = percentage_basis;
+				PercentageBasis(context, basis);
+				result *= .01f * basis;
+				break;
+			}
+			default: return false;
+			}
+			return std::isfinite(result);
+		}
+
+		if (node.kind == Calculation::Kind::Negate || node.kind == Calculation::Kind::Invert)
+		{
+			if (node.children.size() != 1 || !node.children[0] || !EvaluateElementNode(*node.children[0], context, percentage_basis, result))
+				return false;
+			if (node.kind == Calculation::Kind::Negate)
+				result = -result;
+			else
+			{
+				if (result == 0.f)
+					return false;
+				result = 1.f / result;
+			}
+			return std::isfinite(result);
+		}
+
+		if (node.kind == Calculation::Kind::Sum || node.kind == Calculation::Kind::Product || node.kind == Calculation::Kind::Min ||
+			node.kind == Calculation::Kind::Max)
+		{
+			if (node.children.empty())
+				return false;
+			float accumulated = (node.kind == Calculation::Kind::Product ? 1.f : 0.f);
+			bool first = true;
+			for (const NodePtr& child : node.children)
+			{
+				float value = 0.f;
+				if (!child || !EvaluateElementNode(*child, context, percentage_basis, value))
+					return false;
+				if (node.kind == Calculation::Kind::Sum)
+					accumulated += value;
+				else if (node.kind == Calculation::Kind::Product)
+					accumulated *= value;
+				else if (first || (node.kind == Calculation::Kind::Min ? value < accumulated : value > accumulated))
+					accumulated = value;
+				first = false;
+				if (!std::isfinite(accumulated))
+					return false;
+			}
+			result = accumulated;
+			return true;
+		}
+
+		if (node.kind == Calculation::Kind::Clamp)
+		{
+			if (node.children.size() != 3 || !node.children[1])
+				return false;
+			float value = 0.f;
+			if (!EvaluateElementNode(*node.children[1], context, percentage_basis, value))
+				return false;
+			if (node.children[2])
+			{
+				float maximum = 0.f;
+				if (!EvaluateElementNode(*node.children[2], context, percentage_basis, maximum))
+					return false;
+				value = Math::Min(value, maximum);
+			}
+			if (node.children[0])
+			{
+				float minimum = 0.f;
+				if (!EvaluateElementNode(*node.children[0], context, percentage_basis, minimum))
+					return false;
+				value = Math::Max(value, minimum);
+			}
+			result = value;
+			return std::isfinite(result);
+		}
+
+		return false;
+	}
+
+} // namespace
+
+bool ResolveCalculation(const Calculation& calculation, const CalculationResolverContext& context, ResolvedCalculation& result)
+{
+	result = {};
+	if (!calculation.GetRoot())
+		return false;
+	bool failed = false;
+	NodePtr root = CanonicalizeNode(calculation.GetRoot(), context, failed);
+	if (failed || !root)
+		return false;
+
+	Calculation contextual(root, calculation.GetDependencyMask());
+	CalculationPtr simplified;
+	if (!SimplifyCalculation(contextual, simplified))
+		return false;
+
+	CalculationConstantValue constant;
+	if (EvaluateCalculation(*simplified, constant))
+	{
+		result.form = Calculation::ResidualForm::Constant;
+		result.is_constant = true;
+		result.value = constant.value;
+		result.unit = constant.unit;
+		if (result.unit == Unit::DEG)
+		{
+			result.value = Math::DegreesToRadians(result.value);
+			result.unit = Unit::RAD;
+		}
+		return std::isfinite(result.value);
+	}
+
+	const Affine affine = AnalyzeAffine(*simplified->GetRoot());
+	if (affine.valid && !affine.scalar && affine.px == 0.f && std::isfinite(affine.percent))
+	{
+		result.form = Calculation::ResidualForm::Constant;
+		result.is_constant = true;
+		result.value = affine.percent;
+		result.unit = Unit::PERCENT;
+		return true;
+	}
+	if (affine.valid && !affine.scalar && std::isfinite(affine.px) && std::isfinite(affine.percent))
+	{
+		result.form = Calculation::ResidualForm::LinearLengthPercentage;
+		result.residual = MakeShared<Calculation>(simplified->GetRoot(), calculation.GetDependencyMask(),
+			Calculation::ResidualForm::LinearLengthPercentage, affine.px, affine.percent);
+	}
+	else
+	{
+		result.form = Calculation::ResidualForm::Tree;
+		result.residual = MakeShared<Calculation>(simplified->GetRoot(), calculation.GetDependencyMask(), Calculation::ResidualForm::Tree);
+	}
+	return bool(result.residual);
+}
+
+bool ResolveUsedCalculation(const Calculation& calculation, float percentage_basis, float& result)
+{
+	if (!std::isfinite(percentage_basis) || percentage_basis < 0.f)
+		return false;
+
+	if (calculation.GetResidualForm() == Calculation::ResidualForm::LinearLengthPercentage)
+	{
+		result = calculation.GetLinearPx() + calculation.GetLinearPercent() * .01f * percentage_basis;
+		return std::isfinite(result);
+	}
+
+	if (!calculation.GetRoot())
+		return false;
+	return EvaluateUsedNode(*calculation.GetRoot(), percentage_basis, result);
+}
+
+bool ResolveElementCalculation(const Calculation& calculation, Element& element, float percentage_basis, float& result,
+	RelativeTarget relative_target)
+{
+	if (!calculation.GetRoot() || !std::isfinite(percentage_basis))
+		return false;
+
+	CalculationResolverContext context;
+	context.font_size = element.GetComputedValues().font_size();
+	if (Element* parent = element.GetParentNode())
+		context.parent_font_size = parent->GetComputedValues().font_size();
+	else
+		context.parent_font_size = DefaultComputedValues().font_size();
+	if (ElementDocument* document = element.GetOwnerDocument())
+		context.document_font_size = document->GetComputedValues().font_size();
+	else
+		context.document_font_size = DefaultComputedValues().font_size();
+	context.line_height = element.GetLineHeight();
+	context.relative_target = relative_target;
+	if (Context* element_context = element.GetContext())
+	{
+		context.viewport_dimensions = Vector2f(element_context->GetDimensions());
+		context.dp_ratio = element_context->GetDensityIndependentPixelRatio();
+	}
+
+	return EvaluateElementNode(*calculation.GetRoot(), context, percentage_basis, result);
+}
+
+} // namespace Rml

--- a/Source/Core/CalculationResolver.h
+++ b/Source/Core/CalculationResolver.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "../../Include/RmlUi/Core/PropertyDefinition.h"
+#include "../../Include/RmlUi/Core/Types.h"
+#include "Calculation.h"
+
+namespace Rml {
+
+class Element;
+
+struct CalculationResolverContext {
+	float font_size = 0.f;
+	float parent_font_size = 0.f;
+	float document_font_size = 0.f;
+	float line_height = 0.f;
+	Vector2f viewport_dimensions = {};
+	float dp_ratio = 1.f;
+	RelativeTarget relative_target = RelativeTarget::None;
+};
+
+struct ResolvedCalculation {
+	Calculation::ResidualForm form = Calculation::ResidualForm::Constant;
+	bool is_constant = false;
+	float value = 0.f;
+	Unit unit = Unit::UNKNOWN;
+	CalculationPtr residual;
+};
+
+bool ResolveCalculation(const Calculation& calculation, const CalculationResolverContext& context, ResolvedCalculation& result);
+bool ResolveUsedCalculation(const Calculation& calculation, float percentage_basis, float& result);
+bool ResolveElementCalculation(const Calculation& calculation, Element& element, float percentage_basis, float& result,
+	RelativeTarget relative_target = RelativeTarget::None);
+
+} // namespace Rml

--- a/Source/Core/ComputeProperty.cpp
+++ b/Source/Core/ComputeProperty.cpp
@@ -3,6 +3,9 @@
 #include "../../Include/RmlUi/Core/Property.h"
 #include "../../Include/RmlUi/Core/StringUtilities.h"
 #include "ControlledLifetimeResource.h"
+#ifdef RMLUI_MATH_EXPRESSIONS
+	#include "CalculationResolver.h"
+#endif
 
 namespace Rml {
 
@@ -84,9 +87,26 @@ float ComputeAngle(NumericValue value)
 	return 0.0f;
 }
 
-float ComputeFontsize(NumericValue value, const Style::ComputedValues& values, const Style::ComputedValues* parent_values,
+float ComputeFontsize(const Property* property, const Style::ComputedValues& values, const Style::ComputedValues* parent_values,
 	const Style::ComputedValues* document_values, float dp_ratio, Vector2f vp_dimensions)
 {
+#ifdef RMLUI_MATH_EXPRESSIONS
+	if (property->unit == Unit::CALCULATION)
+	{
+		const float parent_font_size = parent_values ? parent_values->font_size() : 0.f;
+		const float root_font_size =
+			(!document_values || &values == document_values) ? DefaultComputedValues().font_size() : document_values->font_size();
+		CalculationResolverContext context{values.font_size(), parent_font_size, root_font_size, values.line_height().value, vp_dimensions, dp_ratio,
+			property->definition ? property->definition->GetRelativeTarget() : RelativeTarget::ParentFontSize};
+		ResolvedCalculation resolved;
+		const CalculationPtr calculation = property->value.Get<CalculationPtr>();
+		if (calculation && ResolveCalculation(*calculation, context, resolved) && resolved.is_constant && resolved.unit == Unit::PX)
+			return resolved.value;
+		return values.font_size();
+	}
+#endif
+
+	NumericValue value = property->GetNumericValue();
 	if (Any(value.unit & (Unit::PERCENT | Unit::EM | Unit::REM)))
 	{
 		// Relative values are based on the parent's or document's font size instead of our own.
@@ -117,6 +137,49 @@ float ComputeFontsize(NumericValue value, const Style::ComputedValues& values, c
 	return ComputeLength(value, 0.f, 0.f, dp_ratio, vp_dimensions);
 }
 
+bool ComputeDefiniteLength(const Property* property, float font_size, float document_font_size, float dp_ratio, Vector2f vp_dimensions, float& result)
+{
+#ifdef RMLUI_MATH_EXPRESSIONS
+	if (property->unit == Unit::CALCULATION)
+	{
+		CalculationResolverContext context{font_size, font_size, document_font_size, 0.f, vp_dimensions, dp_ratio,
+			property->definition ? property->definition->GetRelativeTarget() : RelativeTarget::None};
+		ResolvedCalculation resolved;
+		const CalculationPtr calculation = property->value.Get<CalculationPtr>();
+		if (!calculation || !ResolveCalculation(*calculation, context, resolved) || !resolved.is_constant || resolved.unit != Unit::PX)
+			return false;
+		result = resolved.value;
+		return true;
+	}
+#endif
+	result = ComputeLength(property->GetNumericValue(), font_size, document_font_size, dp_ratio, vp_dimensions);
+	return true;
+}
+
+bool ComputeDefiniteNumber(const Property* property, float font_size, float document_font_size, float dp_ratio, Vector2f vp_dimensions, float& result)
+{
+#ifdef RMLUI_MATH_EXPRESSIONS
+	if (property->unit == Unit::CALCULATION)
+	{
+		CalculationResolverContext context{font_size, font_size, document_font_size, 0.f, vp_dimensions, dp_ratio,
+			property->definition ? property->definition->GetRelativeTarget() : RelativeTarget::None};
+		ResolvedCalculation resolved;
+		const CalculationPtr calculation = property->value.Get<CalculationPtr>();
+		if (!calculation || !ResolveCalculation(*calculation, context, resolved) || !resolved.is_constant || resolved.unit != Unit::NUMBER)
+			return false;
+		result = resolved.value;
+		return true;
+	}
+#else
+	(void)font_size;
+	(void)document_font_size;
+	(void)dp_ratio;
+	(void)vp_dimensions;
+#endif
+	result = property->Get<float>();
+	return true;
+}
+
 String ComputeFontFamily(String font_family)
 {
 	return StringUtilities::ToLower(std::move(font_family));
@@ -124,6 +187,15 @@ String ComputeFontFamily(String font_family)
 
 Style::Clip ComputeClip(const Property* property)
 {
+#ifdef RMLUI_MATH_EXPRESSIONS
+	if (property->unit == Unit::CALCULATION)
+	{
+		float value = 0.f;
+		if (ComputeDefiniteNumber(property, 0.f, 0.f, 1.f, Vector2f(1.f), value))
+			return Style::Clip(Style::Clip::Type::Number, static_cast<int8_t>(value));
+		return Style::Clip();
+	}
+#endif
 	const int value = property->Get<int>();
 	if (property->unit == Unit::KEYWORD)
 		return Style::Clip(static_cast<Style::Clip::Type>(value));
@@ -135,6 +207,23 @@ Style::Clip ComputeClip(const Property* property)
 
 Style::LineHeight ComputeLineHeight(const Property* property, float font_size, float document_font_size, float dp_ratio, Vector2f vp_dimensions)
 {
+#ifdef RMLUI_MATH_EXPRESSIONS
+	if (property->unit == Unit::CALCULATION)
+	{
+		CalculationResolverContext context{font_size, font_size, document_font_size, 0.f, vp_dimensions, dp_ratio,
+			property->definition ? property->definition->GetRelativeTarget() : RelativeTarget::FontSize};
+		ResolvedCalculation resolved;
+		const CalculationPtr calculation = property->value.Get<CalculationPtr>();
+		if (calculation && ResolveCalculation(*calculation, context, resolved) && resolved.is_constant)
+		{
+			if (resolved.unit == Unit::NUMBER)
+				return Style::LineHeight(font_size * resolved.value, Style::LineHeight::Number, resolved.value);
+			if (resolved.unit == Unit::PX)
+				return Style::LineHeight(resolved.value, Style::LineHeight::Length, resolved.value);
+		}
+		return Style::LineHeight();
+	}
+#endif
 	if (Any(property->unit & Unit::LENGTH))
 	{
 		float value = ComputeLength(property->GetNumericValue(), font_size, document_font_size, dp_ratio, vp_dimensions);
@@ -157,6 +246,18 @@ Style::LineHeight ComputeLineHeight(const Property* property, float font_size, f
 Style::VerticalAlign ComputeVerticalAlign(const Property* property, float line_height, float font_size, float document_font_size, float dp_ratio,
 	Vector2f vp_dimensions)
 {
+#ifdef RMLUI_MATH_EXPRESSIONS
+	if (property->unit == Unit::CALCULATION)
+	{
+		CalculationResolverContext context{font_size, font_size, document_font_size, line_height, vp_dimensions, dp_ratio,
+			property->definition ? property->definition->GetRelativeTarget() : RelativeTarget::LineHeight};
+		ResolvedCalculation resolved;
+		const CalculationPtr calculation = property->value.Get<CalculationPtr>();
+		if (calculation && ResolveCalculation(*calculation, context, resolved) && resolved.is_constant && resolved.unit == Unit::PX)
+			return Style::VerticalAlign(resolved.value);
+		return Style::VerticalAlign();
+	}
+#endif
 	if (Any(property->unit & Unit::LENGTH))
 	{
 		float value = ComputeLength(property->GetNumericValue(), font_size, document_font_size, dp_ratio, vp_dimensions);
@@ -175,6 +276,25 @@ Style::LengthPercentage ComputeLengthPercentage(const Property* property, float 
 	Vector2f vp_dimensions)
 {
 	using namespace Style;
+#ifdef RMLUI_MATH_EXPRESSIONS
+	if (property->unit == Unit::CALCULATION)
+	{
+		CalculationResolverContext context{font_size, font_size, document_font_size, 0.f, vp_dimensions, dp_ratio,
+			property->definition ? property->definition->GetRelativeTarget() : RelativeTarget::None};
+		ResolvedCalculation resolved;
+		const CalculationPtr calculation = property->value.Get<CalculationPtr>();
+		if (calculation && ResolveCalculation(*calculation, context, resolved))
+		{
+			if (resolved.is_constant && resolved.unit == Unit::PX)
+				return LengthPercentage(LengthPercentage::Length, resolved.value);
+			if (resolved.is_constant && resolved.unit == Unit::PERCENT)
+				return LengthPercentage(LengthPercentage::Percentage, resolved.value);
+			if (resolved.residual)
+				return LengthPercentage(std::move(resolved.residual));
+		}
+		return LengthPercentage();
+	}
+#endif
 	if (property->unit == Unit::PERCENT)
 		return LengthPercentage(LengthPercentage::Percentage, property->Get<float>());
 
@@ -186,6 +306,17 @@ Style::LengthPercentageAuto ComputeLengthPercentageAuto(const Property* property
 	Vector2f vp_dimensions)
 {
 	using namespace Style;
+#ifdef RMLUI_MATH_EXPRESSIONS
+	if (property->unit == Unit::CALCULATION)
+	{
+		const LengthPercentage value = ComputeLengthPercentage(property, font_size, document_font_size, dp_ratio, vp_dimensions);
+		if (value.type == LengthPercentage::Calculation)
+			return LengthPercentageAuto(value.calculation);
+		if (value.type == LengthPercentage::Percentage)
+			return LengthPercentageAuto(LengthPercentageAuto::Percentage, value.value);
+		return LengthPercentageAuto(LengthPercentageAuto::Length, value.value);
+	}
+#endif
 	if (property->unit == Unit::PERCENT)
 		return LengthPercentageAuto(LengthPercentageAuto::Percentage, property->Get<float>());
 	else if (property->unit == Unit::KEYWORD)
@@ -198,6 +329,10 @@ Style::LengthPercentageAuto ComputeLengthPercentageAuto(const Property* property
 Style::LengthPercentage ComputeOrigin(const Property* property, float font_size, float document_font_size, float dp_ratio, Vector2f vp_dimensions)
 {
 	using namespace Style;
+#ifdef RMLUI_MATH_EXPRESSIONS
+	if (property->unit == Unit::CALCULATION)
+		return ComputeLengthPercentage(property, font_size, document_font_size, dp_ratio, vp_dimensions);
+#endif
 	static_assert(
 		(int)OriginX::Left == (int)OriginY::Top && (int)OriginX::Center == (int)OriginY::Center && (int)OriginX::Right == (int)OriginY::Bottom, "");
 
@@ -223,6 +358,15 @@ Style::LengthPercentage ComputeOrigin(const Property* property, float font_size,
 Style::LengthPercentage ComputeMaxSize(const Property* property, float font_size, float document_font_size, float dp_ratio, Vector2f vp_dimensions)
 {
 	using namespace Style;
+#ifdef RMLUI_MATH_EXPRESSIONS
+	if (property->unit == Unit::CALCULATION)
+	{
+		LengthPercentage value = ComputeLengthPercentage(property, font_size, document_font_size, dp_ratio, vp_dimensions);
+		if (value.type == LengthPercentage::Length && value.value < 0.f)
+			value.value = FLT_MAX;
+		return value;
+	}
+#endif
 	if (Any(property->unit & Unit::KEYWORD))
 		return LengthPercentage(LengthPercentage::Length, FLT_MAX);
 	else if (Any(property->unit & Unit::PERCENT))

--- a/Source/Core/ComputeProperty.h
+++ b/Source/Core/ComputeProperty.h
@@ -12,8 +12,13 @@ float ComputeLength(NumericValue value, float font_size, float document_font_siz
 
 float ComputeAngle(NumericValue value);
 
-float ComputeFontsize(NumericValue value, const Style::ComputedValues& values, const Style::ComputedValues* parent_values,
+float ComputeFontsize(const Property* property, const Style::ComputedValues& values, const Style::ComputedValues* parent_values,
 	const Style::ComputedValues* document_values, float dp_ratio, Vector2f vp_dimensions);
+
+bool ComputeDefiniteLength(const Property* property, float font_size, float document_font_size, float dp_ratio, Vector2f vp_dimensions,
+	float& result);
+bool ComputeDefiniteNumber(const Property* property, float font_size, float document_font_size, float dp_ratio, Vector2f vp_dimensions,
+	float& result);
 
 String ComputeFontFamily(String font_family);
 

--- a/Source/Core/ComputedValues.cpp
+++ b/Source/Core/ComputedValues.cpp
@@ -1,5 +1,7 @@
 #include "../../Include/RmlUi/Core/ComputedValues.h"
+#include "../../Include/RmlUi/Core/Context.h"
 #include "../../Include/RmlUi/Core/Element.h"
+#include "../../Include/RmlUi/Core/ElementDocument.h"
 #include "ComputeProperty.h"
 #include "ElementStyle.h"
 #ifdef RMLUI_MATH_EXPRESSIONS

--- a/Source/Core/ComputedValues.cpp
+++ b/Source/Core/ComputedValues.cpp
@@ -2,8 +2,59 @@
 #include "../../Include/RmlUi/Core/Element.h"
 #include "ComputeProperty.h"
 #include "ElementStyle.h"
+#ifdef RMLUI_MATH_EXPRESSIONS
+	#include "CalculationResolver.h"
+#endif
 
 namespace Rml {
+
+#ifdef RMLUI_MATH_EXPRESSIONS
+namespace Style {
+
+	struct ComputedCalculationStore {
+		UnorderedMap<uint8_t, CalculationPtr> entries;
+	};
+
+	ComputedValues::ComputedValues(Element* element) : element(element) {}
+	ComputedValues::~ComputedValues() = default;
+
+	CalculationPtr ComputedValues::GetCalculation(ComputedCalculationSlot slot) const
+	{
+		if (!calculations)
+			return nullptr;
+		auto it = calculations->entries.find(static_cast<uint8_t>(slot));
+		return it != calculations->entries.end() ? it->second : nullptr;
+	}
+
+	void ComputedValues::SetCalculation(ComputedCalculationSlot slot, CalculationPtr calculation)
+	{
+		const uint8_t key = static_cast<uint8_t>(slot);
+		if (calculation)
+		{
+			if (!calculations)
+				calculations = UniquePtr<ComputedCalculationStore>(new ComputedCalculationStore);
+			calculations->entries[key] = std::move(calculation);
+		}
+		else if (calculations)
+		{
+			calculations->entries.erase(key);
+			if (calculations->entries.empty())
+				calculations.reset();
+		}
+	}
+
+	void ComputedValues::CopyNonInheritedCalculations(const ComputedValues& other)
+	{
+		if (!other.calculations)
+		{
+			calculations.reset();
+			return;
+		}
+		calculations = UniquePtr<ComputedCalculationStore>(new ComputedCalculationStore(*other.calculations));
+	}
+
+} // namespace Style
+#endif
 
 const AnimationList* Style::ComputedValues::animation() const
 {
@@ -46,9 +97,48 @@ float Style::ComputedValues::letter_spacing() const
 	if (inherited.has_letter_spacing)
 	{
 		if (auto p = element->GetProperty(PropertyId::LetterSpacing))
+		{
+#ifdef RMLUI_MATH_EXPRESSIONS
+			if (p->unit == Unit::CALCULATION)
+			{
+				float dp_ratio = 1.f;
+				Vector2f vp_dimensions(1.f);
+				if (Context* context = element->GetContext())
+				{
+					dp_ratio = context->GetDensityIndependentPixelRatio();
+					vp_dimensions = Vector2f(context->GetDimensions());
+				}
+				float document_font_size = DefaultComputedValues().font_size();
+				if (ElementDocument* document = element->GetOwnerDocument())
+					document_font_size = document->GetComputedValues().font_size();
+				float value = 0.f;
+				if (ComputeDefiniteLength(p, font_size(), document_font_size, dp_ratio, vp_dimensions, value))
+					return value;
+				return 0.f;
+			}
+#endif
 			return element->ResolveLength(p->GetNumericValue());
+		}
 	}
 	return 0.f;
+}
+
+float Style::ComputedValues::GetLocalNumericProperty(PropertyId id, float default_value) const
+{
+	if (const Property* p = GetLocalPropertyWithResolvedVariables(id))
+	{
+#ifdef RMLUI_MATH_EXPRESSIONS
+		if (p->unit == Unit::CALCULATION)
+		{
+			float value = default_value;
+			if (ComputeDefiniteNumber(p, 0.f, 0.f, 1.f, Vector2f(1.f), value))
+				return value;
+			return default_value;
+		}
+#endif
+		return p->Get<float>();
+	}
+	return default_value;
 }
 
 const Property* ComputedValues::GetLocalPropertyWithResolvedVariables(PropertyId id) const
@@ -62,6 +152,14 @@ float ResolveValueOr(Style::LengthPercentageAuto length, float base_value, float
 		return length.value;
 	else if (length.type == Style::LengthPercentageAuto::Percentage && base_value >= 0.f)
 		return length.value * 0.01f * base_value;
+#ifdef RMLUI_MATH_EXPRESSIONS
+	else if (length.type == Style::LengthPercentageAuto::Calculation && length.calculation)
+	{
+		float result = 0.f;
+		if (ResolveUsedCalculation(*length.calculation, base_value, result))
+			return result;
+	}
+#endif
 	return default_value;
 }
 
@@ -71,6 +169,14 @@ float ResolveValueOr(Style::LengthPercentage length, float base_value, float def
 		return length.value;
 	else if (length.type == Style::LengthPercentage::Percentage && base_value >= 0.f)
 		return length.value * 0.01f * base_value;
+#ifdef RMLUI_MATH_EXPRESSIONS
+	else if (length.type == Style::LengthPercentage::Calculation && length.calculation)
+	{
+		float result = 0.f;
+		if (ResolveUsedCalculation(*length.calculation, base_value, result))
+			return result;
+	}
+#endif
 	return default_value;
 }
 

--- a/Source/Core/DecoratorGradient.cpp
+++ b/Source/Core/DecoratorGradient.cpp
@@ -1,4 +1,7 @@
 #include "DecoratorGradient.h"
+#ifdef RMLUI_MATH_EXPRESSIONS
+	#include "CalculationResolver.h"
+#endif
 #include "../../Include/RmlUi/Core/ComputedValues.h"
 #include "../../Include/RmlUi/Core/Element.h"
 #include "../../Include/RmlUi/Core/ElementUtilities.h"
@@ -10,6 +13,18 @@
 #include "DecoratorShader.h"
 
 namespace Rml {
+
+#ifdef RMLUI_MATH_EXPRESSIONS
+static bool CalculationContainsPercentage(const Calculation::Node& node)
+{
+	if (node.kind == Calculation::Kind::Value && node.unit == Unit::PERCENT)
+		return true;
+	for (const auto& child : node.children)
+		if (child && CalculationContainsPercentage(*child))
+			return true;
+	return false;
+}
+#endif
 
 // Returns the point along the input line ('line_point', 'line_vector') closest to the input 'point'.
 static Vector2f IntersectionPointToLineNormal(const Vector2f point, const Vector2f line_point, const Vector2f line_vector)
@@ -25,14 +40,30 @@ static Vector2f IntersectionPointToLineNormal(const Vector2f point, const Vector
 /// @param[in] unresolved_stops
 /// @return A list of resolved color stops, all in number units.
 static ColorStopList ResolveColorStops(Element* element, const float gradient_line_length, const float soft_spacing,
-	const ColorStopList& unresolved_stops)
+	const ColorStopList& unresolved_stops, bool angle_positions = false)
 {
+#ifndef RMLUI_MATH_EXPRESSIONS
+	(void)angle_positions;
+#endif
 	ColorStopList stops = unresolved_stops;
 	const int num_stops = (int)stops.size();
 
 	// Resolve all lengths, percentages, and angles to numbers. After this step all stops with a unit other than Number are considered as Auto.
 	for (ColorStop& stop : stops)
 	{
+#ifdef RMLUI_MATH_EXPRESSIONS
+		if (stop.position_calculation)
+		{
+			float resolved_position = 0.f;
+			const float percentage_basis = (angle_positions ? 2.f * Math::RMLUI_PI : gradient_line_length);
+			if (ResolveElementCalculation(*stop.position_calculation, *element, percentage_basis, resolved_position))
+				stop.position = NumericValue(resolved_position / percentage_basis, Unit::NUMBER);
+			else
+				stop.position = NumericValue(0.f, Unit::UNKNOWN);
+			stop.position_calculation.reset();
+			continue;
+		}
+#endif
 		if (Any(stop.position.unit & Unit::LENGTH))
 		{
 			const float resolved_position = element->ResolveLength(stop.position);
@@ -370,7 +401,19 @@ SharedPtr<Decorator> DecoratorLinearGradientInstancer::InstanceDecorator(const S
 	}
 	else
 	{
-		angle = ComputeAngle(p_angle->GetNumericValue());
+#ifdef RMLUI_MATH_EXPRESSIONS
+		if (p_angle->unit == Unit::CALCULATION)
+		{
+			const CalculationPtr calculation = p_angle->value.Get<CalculationPtr>();
+			ResolvedCalculation resolved;
+			if (!calculation || !ResolveCalculation(*calculation, CalculationResolverContext{}, resolved) || !resolved.is_constant ||
+				resolved.unit != Unit::RAD)
+				return nullptr;
+			angle = resolved.value;
+		}
+		else
+#endif
+			angle = ComputeAngle(p_angle->GetNumericValue());
 	}
 
 	if (p_color_stop_list->unit != Unit::COLORSTOPLIST)
@@ -390,13 +433,22 @@ DecoratorRadialGradient::DecoratorRadialGradient() {}
 DecoratorRadialGradient::~DecoratorRadialGradient() {}
 
 bool DecoratorRadialGradient::Initialise(bool in_repeating, Shape in_shape, SizeType in_size_type, Vector2Numeric in_size, Vector2Numeric in_position,
-	const ColorStopList& in_color_stops)
+	const ColorStopList& in_color_stops
+#ifdef RMLUI_MATH_EXPRESSIONS
+	,
+	Array<CalculationPtr, 2> in_size_calculations, Array<CalculationPtr, 2> in_position_calculations
+#endif
+)
 {
 	repeating = in_repeating;
 	shape = in_shape;
 	size_type = in_size_type;
 	size = in_size;
 	position = in_position;
+#ifdef RMLUI_MATH_EXPRESSIONS
+	size_calculations = std::move(in_size_calculations);
+	position_calculations = std::move(in_position_calculations);
+#endif
 	color_stops = in_color_stops;
 	return !color_stops.empty();
 }
@@ -458,8 +510,24 @@ void DecoratorRadialGradient::RenderElement(Element* element, DecoratorDataHandl
 DecoratorRadialGradient::RadialGradientShape DecoratorRadialGradient::CalculateRadialGradientShape(Element* element, Vector2f dimensions) const
 {
 	RadialGradientShape result;
-	result.center.x = element->ResolveNumericValue(position.x, dimensions.x);
-	result.center.y = element->ResolveNumericValue(position.y, dimensions.y);
+#ifdef RMLUI_MATH_EXPRESSIONS
+	if (position_calculations[0])
+	{
+		if (!ResolveElementCalculation(*position_calculations[0], *element, dimensions.x, result.center.x))
+			result.center.x = 0.f;
+	}
+	else
+#endif
+		result.center.x = element->ResolveNumericValue(position.x, dimensions.x);
+#ifdef RMLUI_MATH_EXPRESSIONS
+	if (position_calculations[1])
+	{
+		if (!ResolveElementCalculation(*position_calculations[1], *element, dimensions.y, result.center.y))
+			result.center.y = 0.f;
+	}
+	else
+#endif
+		result.center.y = element->ResolveNumericValue(position.y, dimensions.y);
 	const bool is_circle = (shape == Shape::Circle);
 
 	auto Abs = [](Vector2f v) { return Vector2f{Math::Absolute(v.x), Math::Absolute(v.y)}; };
@@ -503,8 +571,29 @@ DecoratorRadialGradient::RadialGradientShape DecoratorRadialGradient::CalculateR
 	break;
 	case SizeType::LengthPercentage:
 	{
-		result.radius.x = element->ResolveNumericValue(size.x, d.x);
-		result.radius.y = (is_circle ? result.radius.x : element->ResolveNumericValue(size.y, d.y));
+#ifdef RMLUI_MATH_EXPRESSIONS
+		if (size_calculations[0])
+		{
+			if (!ResolveElementCalculation(*size_calculations[0], *element, d.x, result.radius.x))
+				result.radius.x = 0.f;
+		}
+		else
+#endif
+			result.radius.x = element->ResolveNumericValue(size.x, d.x);
+		if (is_circle)
+			result.radius.y = result.radius.x;
+		else
+		{
+#ifdef RMLUI_MATH_EXPRESSIONS
+			if (size_calculations[1])
+			{
+				if (!ResolveElementCalculation(*size_calculations[1], *element, d.y, result.radius.y))
+					result.radius.y = 0.f;
+			}
+			else
+#endif
+				result.radius.y = element->ResolveNumericValue(size.y, d.y);
+		}
 		result.radius = Abs(result.radius);
 	}
 	break;
@@ -554,14 +643,31 @@ SharedPtr<Decorator> DecoratorRadialGradientInstancer::InstanceDecorator(const S
 	Shape shape = (Shape)p_ending_shape->Get<int>();
 	if (shape == Shape::Unspecified)
 	{
-		const bool circle_sized = (Any(p_size_x->unit & Unit::LENGTH_PERCENT) && p_size_y->unit == Unit::KEYWORD);
+		const bool circle_sized = ((Any(p_size_x->unit & Unit::LENGTH_PERCENT)
+#ifdef RMLUI_MATH_EXPRESSIONS
+									   || p_size_x->unit == Unit::CALCULATION
+#endif
+									   ) &&
+			p_size_y->unit == Unit::KEYWORD);
 		shape = (circle_sized ? Shape::Circle : Shape::Ellipse);
 	}
-	if (shape == Shape::Circle && (p_size_x->unit == Unit::PERCENT || p_size_y->unit != Unit::KEYWORD))
+	bool circle_size_has_percentage = p_size_x->unit == Unit::PERCENT;
+#ifdef RMLUI_MATH_EXPRESSIONS
+	if (p_size_x->unit == Unit::CALCULATION)
+	{
+		const CalculationPtr calculation = p_size_x->value.Get<CalculationPtr>();
+		circle_size_has_percentage = calculation && calculation->GetRoot() && CalculationContainsPercentage(*calculation->GetRoot());
+	}
+#endif
+	if (shape == Shape::Circle && (circle_size_has_percentage || p_size_y->unit != Unit::KEYWORD))
 		return nullptr;
 
 	SizeType size_type = {};
 	Vector2Numeric size;
+#ifdef RMLUI_MATH_EXPRESSIONS
+	Array<CalculationPtr, 2> size_calculations;
+	Array<CalculationPtr, 2> position_calculations;
+#endif
 	if (p_size_x->unit == Unit::KEYWORD)
 	{
 		size_type = (SizeType)p_size_x->Get<int>();
@@ -569,11 +675,62 @@ SharedPtr<Decorator> DecoratorRadialGradientInstancer::InstanceDecorator(const S
 	else
 	{
 		size_type = SizeType::LengthPercentage;
-		size.x = p_size_x->GetNumericValue();
-		size.y = (p_size_y->unit == Unit::KEYWORD ? size.x : p_size_y->GetNumericValue());
+#ifdef RMLUI_MATH_EXPRESSIONS
+		if (p_size_x->unit == Unit::CALCULATION)
+		{
+			size.x = NumericValue(0.f, Unit::PX);
+			size_calculations[0] = p_size_x->value.Get<CalculationPtr>();
+			if (!size_calculations[0])
+				return nullptr;
+		}
+		else
+#endif
+			size.x = p_size_x->GetNumericValue();
+		if (p_size_y->unit == Unit::KEYWORD)
+		{
+			size.y = size.x;
+#ifdef RMLUI_MATH_EXPRESSIONS
+			size_calculations[1] = size_calculations[0];
+#endif
+		}
+		else
+		{
+#ifdef RMLUI_MATH_EXPRESSIONS
+			if (p_size_y->unit == Unit::CALCULATION)
+			{
+				size.y = NumericValue(0.f, Unit::PX);
+				size_calculations[1] = p_size_y->value.Get<CalculationPtr>();
+				if (!size_calculations[1])
+					return nullptr;
+			}
+			else
+#endif
+				size.y = p_size_y->GetNumericValue();
+		}
 	}
 
-	const Vector2Numeric position = ComputePosition(p_position);
+	Vector2Numeric position;
+	for (int dimension = 0; dimension < 2; ++dimension)
+	{
+		const Property& p = *p_position[dimension];
+#ifdef RMLUI_MATH_EXPRESSIONS
+		if (p.unit == Unit::CALCULATION)
+		{
+			position[dimension] = NumericValue(0.f, Unit::PX);
+			position_calculations[dimension] = p.value.Get<CalculationPtr>();
+			if (!position_calculations[dimension])
+				return nullptr;
+			continue;
+		}
+#endif
+		if (p.unit == Unit::KEYWORD)
+		{
+			const int keyword = p.Get<int>();
+			position[dimension] = NumericValue(keyword == 0 ? 0.f : (keyword == 1 ? 50.f : 100.f), Unit::PERCENT);
+		}
+		else
+			position[dimension] = p.GetNumericValue();
+	}
 	const bool repeating = (name == "repeating-radial-gradient");
 
 	if (p_color_stop_list->unit != Unit::COLORSTOPLIST)
@@ -581,7 +738,12 @@ SharedPtr<Decorator> DecoratorRadialGradientInstancer::InstanceDecorator(const S
 	const ColorStopList& color_stop_list = p_color_stop_list->value.GetReference<ColorStopList>();
 
 	auto decorator = MakeShared<DecoratorRadialGradient>();
-	if (decorator->Initialise(repeating, shape, size_type, size, position, color_stop_list))
+	if (decorator->Initialise(repeating, shape, size_type, size, position, color_stop_list
+#ifdef RMLUI_MATH_EXPRESSIONS
+			,
+			std::move(size_calculations), std::move(position_calculations)
+#endif
+				))
 		return decorator;
 
 	return nullptr;
@@ -591,11 +753,19 @@ DecoratorConicGradient::DecoratorConicGradient() {}
 
 DecoratorConicGradient::~DecoratorConicGradient() {}
 
-bool DecoratorConicGradient::Initialise(bool in_repeating, float in_angle, Vector2Numeric in_position, const ColorStopList& in_color_stops)
+bool DecoratorConicGradient::Initialise(bool in_repeating, float in_angle, Vector2Numeric in_position, const ColorStopList& in_color_stops
+#ifdef RMLUI_MATH_EXPRESSIONS
+	,
+	Array<CalculationPtr, 2> in_position_calculations
+#endif
+)
 {
 	repeating = in_repeating;
 	angle = in_angle;
 	position = in_position;
+#ifdef RMLUI_MATH_EXPRESSIONS
+	position_calculations = std::move(in_position_calculations);
+#endif
 	color_stops = in_color_stops;
 	return !color_stops.empty();
 }
@@ -611,10 +781,28 @@ DecoratorDataHandle DecoratorConicGradient::GenerateElementData(Element* element
 	const RenderBox render_box = element->GetRenderBox(paint_area);
 	const Vector2f dimensions = render_box.GetFillSize();
 
-	const Vector2f center =
-		Vector2f{element->ResolveNumericValue(position.x, dimensions.x), element->ResolveNumericValue(position.y, dimensions.y)}.Round();
+	Vector2f center;
+#ifdef RMLUI_MATH_EXPRESSIONS
+	if (position_calculations[0])
+	{
+		if (!ResolveElementCalculation(*position_calculations[0], *element, dimensions.x, center.x))
+			center.x = 0.f;
+	}
+	else
+#endif
+		center.x = element->ResolveNumericValue(position.x, dimensions.x);
+#ifdef RMLUI_MATH_EXPRESSIONS
+	if (position_calculations[1])
+	{
+		if (!ResolveElementCalculation(*position_calculations[1], *element, dimensions.y, center.y))
+			center.y = 0.f;
+	}
+	else
+#endif
+		center.y = element->ResolveNumericValue(position.y, dimensions.y);
+	center = center.Round();
 
-	ColorStopList resolved_stops = ResolveColorStops(element, 1.f, 0.f, color_stops);
+	ColorStopList resolved_stops = ResolveColorStops(element, 1.f, 0.f, color_stops, true);
 
 	CompiledShader shader = render_manager->CompileShader("conic-gradient",
 		Dictionary{
@@ -679,8 +867,45 @@ SharedPtr<Decorator> DecoratorConicGradientInstancer::InstanceDecorator(const St
 	if (!p_angle || !p_position[0] || !p_position[1] || !p_color_stop_list)
 		return nullptr;
 
-	const float angle = ComputeAngle(p_angle->GetNumericValue());
-	const Vector2Numeric position = ComputePosition(p_position);
+	float angle = 0.f;
+#ifdef RMLUI_MATH_EXPRESSIONS
+	if (p_angle->unit == Unit::CALCULATION)
+	{
+		const CalculationPtr calculation = p_angle->value.Get<CalculationPtr>();
+		ResolvedCalculation resolved;
+		if (!calculation || !ResolveCalculation(*calculation, CalculationResolverContext{}, resolved) || !resolved.is_constant ||
+			resolved.unit != Unit::RAD)
+			return nullptr;
+		angle = resolved.value;
+	}
+	else
+#endif
+		angle = ComputeAngle(p_angle->GetNumericValue());
+	Vector2Numeric position;
+#ifdef RMLUI_MATH_EXPRESSIONS
+	Array<CalculationPtr, 2> position_calculations;
+#endif
+	for (int dimension = 0; dimension < 2; ++dimension)
+	{
+		const Property& p = *p_position[dimension];
+#ifdef RMLUI_MATH_EXPRESSIONS
+		if (p.unit == Unit::CALCULATION)
+		{
+			position[dimension] = NumericValue(0.f, Unit::PX);
+			position_calculations[dimension] = p.value.Get<CalculationPtr>();
+			if (!position_calculations[dimension])
+				return nullptr;
+			continue;
+		}
+#endif
+		if (p.unit == Unit::KEYWORD)
+		{
+			const int keyword = p.Get<int>();
+			position[dimension] = NumericValue(keyword == 0 ? 0.f : (keyword == 1 ? 50.f : 100.f), Unit::PERCENT);
+		}
+		else
+			position[dimension] = p.GetNumericValue();
+	}
 	const bool repeating = (name == "repeating-conic-gradient");
 
 	if (p_color_stop_list->unit != Unit::COLORSTOPLIST)
@@ -688,7 +913,12 @@ SharedPtr<Decorator> DecoratorConicGradientInstancer::InstanceDecorator(const St
 	const ColorStopList& color_stop_list = p_color_stop_list->value.GetReference<ColorStopList>();
 
 	auto decorator = MakeShared<DecoratorConicGradient>();
-	if (decorator->Initialise(repeating, angle, position, color_stop_list))
+	if (decorator->Initialise(repeating, angle, position, color_stop_list
+#ifdef RMLUI_MATH_EXPRESSIONS
+			,
+			std::move(position_calculations)
+#endif
+				))
 		return decorator;
 
 	return nullptr;

--- a/Source/Core/DecoratorGradient.h
+++ b/Source/Core/DecoratorGradient.h
@@ -120,7 +120,12 @@ public:
 	DecoratorRadialGradient();
 	virtual ~DecoratorRadialGradient();
 
-	bool Initialise(bool repeating, Shape shape, SizeType size_type, Vector2Numeric size, Vector2Numeric position, const ColorStopList& color_stops);
+	bool Initialise(bool repeating, Shape shape, SizeType size_type, Vector2Numeric size, Vector2Numeric position, const ColorStopList& color_stops
+#ifdef RMLUI_MATH_EXPRESSIONS
+		,
+		Array<CalculationPtr, 2> size_calculations = {}, Array<CalculationPtr, 2> position_calculations = {}
+#endif
+	);
 
 	DecoratorDataHandle GenerateElementData(Element* element, BoxArea paint_area) const override;
 	void ReleaseElementData(DecoratorDataHandle element_data) const override;
@@ -138,6 +143,10 @@ private:
 	SizeType size_type = {};
 	Vector2Numeric size;
 	Vector2Numeric position;
+#ifdef RMLUI_MATH_EXPRESSIONS
+	Array<CalculationPtr, 2> size_calculations;
+	Array<CalculationPtr, 2> position_calculations;
+#endif
 
 	ColorStopList color_stops;
 };
@@ -168,7 +177,12 @@ public:
 	DecoratorConicGradient();
 	virtual ~DecoratorConicGradient();
 
-	bool Initialise(bool repeating, float angle, Vector2Numeric position, const ColorStopList& color_stops);
+	bool Initialise(bool repeating, float angle, Vector2Numeric position, const ColorStopList& color_stops
+#ifdef RMLUI_MATH_EXPRESSIONS
+		,
+		Array<CalculationPtr, 2> position_calculations = {}
+#endif
+	);
 
 	DecoratorDataHandle GenerateElementData(Element* element, BoxArea paint_area) const override;
 	void ReleaseElementData(DecoratorDataHandle element_data) const override;
@@ -179,6 +193,9 @@ private:
 	bool repeating = false;
 	float angle = {};
 	Vector2Numeric position;
+#ifdef RMLUI_MATH_EXPRESSIONS
+	Array<CalculationPtr, 2> position_calculations;
+#endif
 	ColorStopList color_stops;
 };
 

--- a/Source/Core/DecoratorNinePatch.cpp
+++ b/Source/Core/DecoratorNinePatch.cpp
@@ -178,7 +178,15 @@ SharedPtr<Decorator> DecoratorNinePatchInstancer::InstanceDecorator(const String
 	Array<NumericValue, 4> edges;
 	for (int i = 0; i < 4; i++)
 	{
-		edges[i] = properties.GetProperty(edge_ids[i])->GetNumericValue();
+		const Property* edge_property = properties.GetProperty(edge_ids[i]);
+		RMLUI_ASSERT(edge_property);
+#ifdef RMLUI_MATH_EXPRESSIONS
+		// Nine-patch edge values are an RmlUi-specific numeric extension. They intentionally do not
+		// accept CSS math, so reject before the legacy NumericValue extraction boundary.
+		if (edge_property->unit == Unit::CALCULATION)
+			return nullptr;
+#endif
+		edges[i] = edge_property->GetNumericValue();
 		if (edges[i].number != 0.0f)
 		{
 			edges_set = true;

--- a/Source/Core/DecoratorText.cpp
+++ b/Source/Core/DecoratorText.cpp
@@ -124,6 +124,10 @@ SharedPtr<Decorator> DecoratorTextInstancer::InstanceDecorator(const String& /*n
 	Array<const Property*, 2> p_align = {properties.GetProperty(ids.align_x), properties.GetProperty(ids.align_y)};
 	if (!p_text || !p_color || !p_align[0] || !p_align[1])
 		return nullptr;
+#ifdef RMLUI_MATH_EXPRESSIONS
+	if (p_align[0]->unit == Unit::CALCULATION || p_align[1]->unit == Unit::CALCULATION)
+		return nullptr;
+#endif
 
 	String text = StringUtilities::DecodeRml(p_text->Get<String>());
 	if (text.empty())

--- a/Source/Core/DecoratorTiled.cpp
+++ b/Source/Core/DecoratorTiled.cpp
@@ -166,6 +166,11 @@ void DecoratorTiled::Tile::GenerateGeometry(Mesh& mesh, const ComputedValues& co
 			case Style::LengthPercentage::Percentage:
 				tile_offset[i] = (surface_dimensions[i] - final_tile_dimensions[i]) * align[i].value * 0.01f;
 				break;
+#ifdef RMLUI_MATH_EXPRESSIONS
+			case Style::LengthPercentage::Calculation:
+				RMLUI_ASSERTMSG(false, "Decorator tile alignment rejects calculated values during property parsing.");
+				break;
+#endif
 			}
 		}
 		tile_offset = tile_offset.Round();
@@ -273,6 +278,21 @@ bool DecoratorTiledInstancer::GetTileProperties(DecoratorTiled::Tile* tiles, Tex
 		// tiles in a shorthand since we can't always declare an empty string.
 		if (texture_name.empty() || texture_name == "auto")
 			continue;
+
+#ifdef RMLUI_MATH_EXPRESSIONS
+		// Tiled decorators are an RmlUi extension and do not opt into CSS math. Reject calculated
+		// alignment before resolving sprites or textures so the rejection is deterministic and cannot
+		// be masked by an unrelated resource-loading failure.
+		if (ids.fit != PropertyId::Invalid)
+		{
+			for (const PropertyId align_id : {ids.align_x, ids.align_y})
+			{
+				const Property* align_property = properties.GetProperty(align_id);
+				if (align_property && align_property->unit == Unit::CALCULATION)
+					return false;
+			}
+		}
+#endif
 
 		// We are required to set default values before instancing the tile, thus, all properties should always be
 		// dereferencable. If the debugger captures a zero-dereference, check that all properties for every tile is set

--- a/Source/Core/Element.cpp
+++ b/Source/Core/Element.cpp
@@ -2914,15 +2914,8 @@ void Element::UpdateTransformState()
 			have_perspective = true;
 
 			// Compute the vanishing point from the perspective origin
-			if (computed.perspective_origin_x().type == Style::PerspectiveOrigin::Percentage)
-				vanish.x = pos.x + computed.perspective_origin_x().value * 0.01f * size.x;
-			else
-				vanish.x = pos.x + computed.perspective_origin_x().value;
-
-			if (computed.perspective_origin_y().type == Style::PerspectiveOrigin::Percentage)
-				vanish.y = pos.y + computed.perspective_origin_y().value * 0.01f * size.y;
-			else
-				vanish.y = pos.y + computed.perspective_origin_y().value;
+			vanish.x = pos.x + ResolveValue(computed.perspective_origin_x(), size.x);
+			vanish.y = pos.y + ResolveValue(computed.perspective_origin_y(), size.y);
 		}
 
 		if (have_perspective)
@@ -2963,7 +2956,11 @@ void Element::UpdateTransformState()
 			const int n = transform_ptr->GetNumPrimitives();
 			for (int i = 0; i < n; ++i)
 			{
+#ifdef RMLUI_MATH_EXPRESSIONS
+				const TransformPrimitive primitive = transform_ptr->ResolvePrimitive(i, *this);
+#else
 				const TransformPrimitive& primitive = transform_ptr->GetPrimitive(i);
+#endif
 				Matrix4f matrix = TransformUtilities::ResolveTransform(primitive, *this);
 				transform *= matrix;
 				have_transform = true;
@@ -2974,15 +2971,8 @@ void Element::UpdateTransformState()
 				// Compute the transform origin
 				Vector3f transform_origin(pos.x + size.x * 0.5f, pos.y + size.y * 0.5f, 0);
 
-				if (computed.transform_origin_x().type == Style::TransformOrigin::Percentage)
-					transform_origin.x = pos.x + computed.transform_origin_x().value * size.x * 0.01f;
-				else
-					transform_origin.x = pos.x + computed.transform_origin_x().value;
-
-				if (computed.transform_origin_y().type == Style::TransformOrigin::Percentage)
-					transform_origin.y = pos.y + computed.transform_origin_y().value * size.y * 0.01f;
-				else
-					transform_origin.y = pos.y + computed.transform_origin_y().value;
+				transform_origin.x = pos.x + ResolveValue(computed.transform_origin_x(), size.x);
+				transform_origin.y = pos.y + ResolveValue(computed.transform_origin_y(), size.y);
 
 				transform_origin.z = computed.transform_origin_z();
 

--- a/Source/Core/ElementAnimation.cpp
+++ b/Source/Core/ElementAnimation.cpp
@@ -13,6 +13,9 @@
 #include "ComputeProperty.h"
 #include "ElementStyle.h"
 #include "TransformUtilities.h"
+#ifdef RMLUI_MATH_EXPRESSIONS
+	#include "CalculationResolver.h"
+#endif
 
 namespace Rml {
 
@@ -77,6 +80,23 @@ static bool CombineAndDecompose(Transform& t, Element& e)
 
 	return true;
 }
+
+static bool PrepareSingleTransform(Transform& transform, Element& element)
+{
+	bool must_decompose = false;
+	for (TransformPrimitive& primitive : transform.GetPrimitives())
+	{
+		if (!TransformUtilities::PrepareForInterpolation(primitive, element))
+		{
+			must_decompose = true;
+			break;
+		}
+	}
+	return !must_decompose || CombineAndDecompose(transform, element);
+}
+
+enum class PrepareTransformResult { Unchanged = 0, ChangedT0 = 1, ChangedT1 = 2, ChangedT0andT1 = 3, Invalid = 4 };
+static PrepareTransformResult PrepareTransformPair(Transform& t0, Transform& t1, Element& element);
 
 /**
     An abstraction for decorator and filter declarations.
@@ -182,7 +202,7 @@ static NumericValue InterpolateNumericValue(NumericValue v0, NumericValue v1, fl
 	if (Any(v0.unit & Unit::LENGTH) && Any(v1.unit & Unit::LENGTH))
 	{
 		float f0 = element.ResolveLength(v0);
-		float f1 = element.ResolveLength(v0);
+		float f1 = element.ResolveLength(v1);
 		return NumericValue{Mix(f0, f1, alpha), Unit::PX};
 	}
 
@@ -196,15 +216,194 @@ static NumericValue InterpolateNumericValue(NumericValue v0, NumericValue v1, fl
 	return alpha < 0.5f ? v0 : v1;
 }
 
+#ifdef RMLUI_MATH_EXPRESSIONS
+static bool ResolveCalculatedAnimationEndpoint(const Property& property, Element& element, const PropertyDefinition* definition, NumericValue& result)
+{
+	if (Any(property.unit & Unit::NUMERIC))
+	{
+		result = property.GetNumericValue();
+		return true;
+	}
+	if (property.unit != Unit::CALCULATION)
+		return false;
+
+	const CalculationPtr calculation = property.value.Get<CalculationPtr>();
+	if (!calculation || !calculation->GetRoot())
+		return false;
+
+	RelativeTarget relative_target = (definition ? definition->GetRelativeTarget() : RelativeTarget::None);
+	float percentage_basis = 1.f;
+	switch (relative_target)
+	{
+	case RelativeTarget::ContainingBlockWidth: percentage_basis = element.GetContainingBlock().x; break;
+	case RelativeTarget::ContainingBlockHeight: percentage_basis = element.GetContainingBlock().y; break;
+	case RelativeTarget::FontSize: percentage_basis = element.GetComputedValues().font_size(); break;
+	case RelativeTarget::ParentFontSize:
+		if (Element* parent = element.GetParentNode())
+			percentage_basis = parent->GetComputedValues().font_size();
+		else
+			percentage_basis = DefaultComputedValues().font_size();
+		break;
+	case RelativeTarget::LineHeight: percentage_basis = element.GetLineHeight(); break;
+	case RelativeTarget::None: break;
+	}
+
+	float value = 0.f;
+	if (!ResolveElementCalculation(*calculation, element, percentage_basis, value, relative_target))
+		return false;
+
+	const CalculationNumericType& type = calculation->GetType();
+	auto is_dimension = [&](CalculationDimension dimension) {
+		for (size_t i = 0; i < type.exponents.size(); i++)
+		{
+			const int expected = (i == size_t(dimension) ? 1 : 0);
+			if (type.exponents[i] != expected)
+				return false;
+		}
+		return true;
+	};
+	auto is_number = [&]() {
+		for (int exponent : type.exponents)
+			if (exponent != 0)
+				return false;
+		return true;
+	};
+
+	Unit unit = Unit::UNKNOWN;
+	if (is_number() || is_dimension(CalculationDimension::Percent))
+		unit = Unit::NUMBER;
+	else if (is_dimension(CalculationDimension::Length))
+		unit = Unit::PX;
+	else if (is_dimension(CalculationDimension::Angle))
+		unit = Unit::RAD;
+	else if (is_dimension(CalculationDimension::Resolution))
+		unit = Unit::X;
+	else
+		return false;
+
+	result = NumericValue(value, unit);
+	return true;
+}
+
+static bool CalculationContainsUnit(const Calculation::Node& node, Unit unit)
+{
+	if (node.kind == Calculation::Kind::Value && node.unit == unit)
+		return true;
+	for (const auto& child : node.children)
+		if (child && CalculationContainsUnit(*child, unit))
+			return true;
+	return false;
+}
+
+static SharedPtr<const Calculation::Node> MakeCalculationEndpointNode(const Property& property, const CalculationNumericType& target_type)
+{
+	if (property.unit == Unit::CALCULATION)
+	{
+		const CalculationPtr calculation = property.value.Get<CalculationPtr>();
+		if (!calculation || !calculation->GetRoot() || calculation->GetType() != target_type)
+			return nullptr;
+		return calculation->GetRoot();
+	}
+
+	if (!Any(property.unit & Unit::NUMERIC))
+		return nullptr;
+	auto node = MakeShared<Calculation::Node>();
+	node->value = property.Get<float>();
+	node->unit = property.unit;
+	node->type = target_type;
+	return node;
+}
+
+static CalculationPtr InterpolateCalculations(const Property& p0, const Property& p1, float alpha)
+{
+	const CalculationPtr c0 = (p0.unit == Unit::CALCULATION ? p0.value.Get<CalculationPtr>() : nullptr);
+	const CalculationPtr c1 = (p1.unit == Unit::CALCULATION ? p1.value.Get<CalculationPtr>() : nullptr);
+	const CalculationNumericType* target_type = c0 && c0->GetRoot() ? &c0->GetType() : (c1 && c1->GetRoot() ? &c1->GetType() : nullptr);
+	if (!target_type)
+		return nullptr;
+
+	const auto endpoint0 = MakeCalculationEndpointNode(p0, *target_type);
+	const auto endpoint1 = MakeCalculationEndpointNode(p1, *target_type);
+	if (!endpoint0 || !endpoint1)
+		return nullptr;
+
+	auto make_weighted = [&](float weight, SharedPtr<const Calculation::Node> endpoint) -> SharedPtr<const Calculation::Node> {
+		auto weight_node = MakeShared<Calculation::Node>();
+		weight_node->value = weight;
+		weight_node->unit = Unit::NUMBER;
+
+		auto product = MakeShared<Calculation::Node>();
+		product->kind = Calculation::Kind::Product;
+		product->type = *target_type;
+		product->children = {std::move(weight_node), std::move(endpoint)};
+		return product;
+	};
+
+	auto sum = MakeShared<Calculation::Node>();
+	sum->kind = Calculation::Kind::Sum;
+	sum->type = *target_type;
+	sum->children = {make_weighted(1.f - alpha, endpoint0), make_weighted(alpha, endpoint1)};
+	return MakeShared<Calculation>(std::move(sum));
+}
+
+static bool ShouldDeferCalculatedPercentageInterpolation(const Property& p0, const Property& p1, const PropertyDefinition* definition)
+{
+	if (definition && definition->GetRelativeTarget() != RelativeTarget::None)
+		return false;
+
+	const CalculationPtr calculations[] = {
+		p0.unit == Unit::CALCULATION ? p0.value.Get<CalculationPtr>() : nullptr,
+		p1.unit == Unit::CALCULATION ? p1.value.Get<CalculationPtr>() : nullptr,
+	};
+	if (!calculations[0] && !calculations[1])
+		return false;
+	bool has_length_calculation = false;
+	for (const CalculationPtr& calculation : calculations)
+	{
+		if (!calculation || !calculation->GetRoot())
+			continue;
+		const CalculationNumericType& type = calculation->GetType();
+		bool is_length = true;
+		for (size_t i = 0; i < type.exponents.size(); ++i)
+			is_length &= type.exponents[i] == (i == size_t(CalculationDimension::Length) ? 1 : 0);
+		if (!is_length)
+			continue;
+		has_length_calculation = true;
+		if (CalculationContainsUnit(*calculation->GetRoot(), Unit::PERCENT))
+			return true;
+	}
+	return has_length_calculation && (p0.unit == Unit::PERCENT || p1.unit == Unit::PERCENT);
+}
+#endif
+
 static Property InterpolateProperties(const Property& p0, const Property& p1, float alpha, Element& element, const PropertyDefinition* definition)
 {
 	const Property& p_discrete = (alpha < 0.5f ? p0 : p1);
 
+#ifdef RMLUI_MATH_EXPRESSIONS
+	if ((Any(p0.unit & Unit::NUMERIC) || p0.unit == Unit::CALCULATION) && (Any(p1.unit & Unit::NUMERIC) || p1.unit == Unit::CALCULATION))
+	{
+		if (ShouldDeferCalculatedPercentageInterpolation(p0, p1, definition))
+		{
+			if (CalculationPtr calculation = InterpolateCalculations(p0, p1, alpha))
+				return Property{std::move(calculation), Unit::CALCULATION};
+			return p_discrete;
+		}
+		NumericValue v0, v1;
+		if (ResolveCalculatedAnimationEndpoint(p0, element, definition, v0) && ResolveCalculatedAnimationEndpoint(p1, element, definition, v1))
+		{
+			NumericValue v = InterpolateNumericValue(v0, v1, alpha, element, definition);
+			return Property{v.number, v.unit};
+		}
+		return p_discrete;
+	}
+#else
 	if (Any(p0.unit & Unit::NUMERIC) && Any(p1.unit & Unit::NUMERIC))
 	{
 		NumericValue v = InterpolateNumericValue(p0.GetNumericValue(), p1.GetNumericValue(), alpha, element, definition);
 		return Property{v.number, v.unit};
 	}
+#endif
 
 	if (p0.unit == Unit::KEYWORD && p1.unit == Unit::KEYWORD)
 	{
@@ -240,6 +439,39 @@ static Property InterpolateProperties(const Property& p0, const Property& p1, fl
 	{
 		auto& t0 = p0.value.GetReference<TransformPtr>();
 		auto& t1 = p1.value.GetReference<TransformPtr>();
+
+#ifdef RMLUI_MATH_EXPRESSIONS
+		if (t0 && t1 && (t0->HasCalculations() || t1->HasCalculations()))
+		{
+			auto resolve_transform = [&](const Transform& source) {
+				Transform result;
+				for (int i = 0; i < source.GetNumPrimitives(); i++)
+					result.AddPrimitive(source.HasCalculations() ? source.ResolvePrimitive(i, element) : source.GetPrimitive(i));
+				return result;
+			};
+
+			Transform resolved0 = resolve_transform(*t0);
+			Transform resolved1 = resolve_transform(*t1);
+			if (!PrepareSingleTransform(resolved0, element) || !PrepareSingleTransform(resolved1, element) ||
+				PrepareTransformPair(resolved0, resolved1, element) == PrepareTransformResult::Invalid)
+				return p_discrete;
+
+			const auto& resolved_prims0 = resolved0.GetPrimitives();
+			const auto& resolved_prims1 = resolved1.GetPrimitives();
+			if (resolved_prims0.size() != resolved_prims1.size())
+				return p_discrete;
+
+			auto interpolated = MakeShared<Transform>();
+			for (size_t i = 0; i < resolved_prims0.size(); i++)
+			{
+				TransformPrimitive primitive = resolved_prims0[i];
+				if (!TransformUtilities::InterpolateWith(primitive, resolved_prims1[i], alpha))
+					return p_discrete;
+				interpolated->AddPrimitive(primitive);
+			}
+			return Property{TransformPtr(std::move(interpolated)), Unit::TRANSFORM};
+		}
+#endif
 
 		const auto& prim0 = t0->GetPrimitives();
 		const auto& prim1 = t1->GetPrimitives();
@@ -378,6 +610,21 @@ static Property InterpolateProperties(const Property& p0, const Property& p1, fl
 		{
 			result[i].color = InterpolateColour(c0[i].color.ToNonPremultiplied(), c1[i].color.ToNonPremultiplied(), alpha).ToPremultiplied();
 
+#ifdef RMLUI_MATH_EXPRESSIONS
+			if (c0[i].position_calculation || c1[i].position_calculation)
+			{
+				const Property position0 = c0[i].position_calculation ? Property(c0[i].position_calculation, Unit::CALCULATION)
+																	  : Property(c0[i].position.number, c0[i].position.unit);
+				const Property position1 = c1[i].position_calculation ? Property(c1[i].position_calculation, Unit::CALCULATION)
+																	  : Property(c1[i].position.number, c1[i].position.unit);
+				result[i].position_calculation = InterpolateCalculations(position0, position1, alpha);
+				if (!result[i].position_calculation)
+					return p_discrete;
+				result[i].position = c0[i].position_calculation ? c0[i].position : c1[i].position;
+				continue;
+			}
+#endif
+
 			// We don't provide the property definition in the following, because it doesn't actually represent how
 			// percentages are resolved for stop positions. Here, we don't trivially know how they are resolved, so if
 			// users try to mix lengths and percentages, we instead fall back to discrete interpolation. See the
@@ -391,8 +638,6 @@ static Property InterpolateProperties(const Property& p0, const Property& p1, fl
 	// Fall back to discrete interpolation for incompatible units.
 	return p_discrete;
 }
-
-enum class PrepareTransformResult { Unchanged = 0, ChangedT0 = 1, ChangedT1 = 2, ChangedT0andT1 = 3, Invalid = 4 };
 
 static PrepareTransformResult PrepareTransformPair(Transform& t0, Transform& t1, Element& element)
 {
@@ -533,20 +778,12 @@ static bool PrepareTransforms(Vector<AnimationKey>& keys, Element& element, int 
 		if (!property.value.GetReference<TransformPtr>())
 			property.value = MakeShared<Transform>();
 
-		bool must_decompose = false;
 		Transform& transform = *property.value.GetReference<TransformPtr>();
-
-		for (TransformPrimitive& primitive : transform.GetPrimitives())
-		{
-			if (!TransformUtilities::PrepareForInterpolation(primitive, element))
-			{
-				must_decompose = true;
-				break;
-			}
-		}
-
-		if (must_decompose)
-			result &= CombineAndDecompose(transform, element);
+#ifdef RMLUI_MATH_EXPRESSIONS
+		if (transform.HasCalculations())
+			continue;
+#endif
+		result &= PrepareSingleTransform(transform, element);
 	}
 
 	if (!result)
@@ -582,6 +819,15 @@ static bool PrepareTransforms(Vector<AnimationKey>& keys, Element& element, int 
 
 		auto& t0 = prop0.value.GetReference<TransformPtr>();
 		auto& t1 = prop1.value.GetReference<TransformPtr>();
+
+#ifdef RMLUI_MATH_EXPRESSIONS
+		if ((t0 && t0->HasCalculations()) || (t1 && t1->HasCalculations()))
+		{
+			dirty_list[i] = false;
+			++i;
+			continue;
+		}
+#endif
 
 		auto prepare_result = PrepareTransformPair(*t0, *t1, element);
 
@@ -640,7 +886,11 @@ bool ElementAnimation::InternalAddKey(float time, const Property& in_property, E
 	const Units valid_units =
 		(Unit::NUMBER_LENGTH_PERCENT | Unit::ANGLE | Unit::COLOUR | Unit::TRANSFORM | Unit::KEYWORD | Unit::DECORATOR | Unit::FILTER);
 
-	if (!Any(in_property.unit & valid_units))
+	if (!Any(in_property.unit & valid_units)
+#ifdef RMLUI_MATH_EXPRESSIONS
+		&& in_property.unit != Unit::CALCULATION
+#endif
+	)
 	{
 		const char* property_type = (in_property.unit == Unit::BOXSHADOWLIST ? "Box shadows do not" : "Property value does not");
 		Log::Message(Log::LT_WARNING, "%s support animations or transitions. Value: %s", property_type, in_property.ToString().c_str());

--- a/Source/Core/ElementHandle.cpp
+++ b/Source/Core/ElementHandle.cpp
@@ -218,7 +218,13 @@ public:
 		for (int i = 0; i < 4; i++)
 		{
 			if (const Property* p = properties.GetProperty(ids[i]))
+			{
+#ifdef RMLUI_MATH_EXPRESSIONS
+				if (p->unit == Unit::CALCULATION)
+					return false;
+#endif
 				out_constraints[i] = p->GetNumericValue();
+			}
 		}
 		return true;
 	}

--- a/Source/Core/ElementStyle.cpp
+++ b/Source/Core/ElementStyle.cpp
@@ -20,6 +20,9 @@
 #include "ElementDefinition.h"
 #include "PropertiesIterator.h"
 #include "PropertyShorthandDefinition.h"
+#ifdef RMLUI_MATH_EXPRESSIONS
+	#include "Calculation.h"
+#endif
 #include <algorithm>
 #include <optional>
 
@@ -44,6 +47,53 @@ ElementStyle::ElementStyle(Element* _element)
 {
 	element = _element;
 }
+
+#ifdef RMLUI_MATH_EXPRESSIONS
+static const Units mutable_unit_mask = Unit::EM | Unit::REM | Unit::VW | Unit::VH | Unit::DP_SCALABLE_LENGTH;
+
+Units ElementStyle::GetMutableUnitDependencies(const Property& property) const
+{
+	if (property.unit == Unit::CALCULATION)
+	{
+		const CalculationPtr calculation = property.value.Get<CalculationPtr>();
+		return calculation ? calculation->GetDependencyMask() & mutable_unit_mask : Unit::UNKNOWN;
+	}
+	return property.unit & mutable_unit_mask;
+}
+
+Units ElementStyle::GetResolvedUnitDependencies(PropertyId id) const
+{
+	if (!resolved_unit_dependencies)
+		return Unit::UNKNOWN;
+	const auto it = resolved_unit_dependencies->find(id);
+	return it != resolved_unit_dependencies->end() ? it->second : Unit::UNKNOWN;
+}
+
+void ElementStyle::UpdateResolvedUnitDependencies(PropertyId id, const Property& specified_property, const Property* resolved_property)
+{
+	const bool requires_cache = specified_property.unit == Unit::VAR_EXPRESSION || specified_property.unit == Unit::SHORTHAND_PLACEHOLDER;
+	const Units dependencies = resolved_property ? GetMutableUnitDependencies(*resolved_property) : Unit::UNKNOWN;
+	if (requires_cache && Any(dependencies))
+	{
+		if (!resolved_unit_dependencies)
+			resolved_unit_dependencies = MakeUnique<UnorderedMap<PropertyId, Units>>();
+		(*resolved_unit_dependencies)[id] = dependencies;
+	}
+	else
+	{
+		EraseResolvedUnitDependencies(id);
+	}
+}
+
+void ElementStyle::EraseResolvedUnitDependencies(PropertyId id)
+{
+	if (!resolved_unit_dependencies)
+		return;
+	resolved_unit_dependencies->erase(id);
+	if (resolved_unit_dependencies->empty())
+		resolved_unit_dependencies.reset();
+}
+#endif
 
 const Property* ElementStyle::GetLocalProperty(PropertyId id, const PropertyDictionary& inline_properties, const ElementDefinition* definition)
 {
@@ -814,7 +864,14 @@ void ElementStyle::DirtyPropertiesWithUnits(Units units)
 		auto name_property_pair = *it;
 		PropertyId id = name_property_pair.first;
 		const Property& property = name_property_pair.second;
-		if (Any(property.unit & units))
+		Units dependencies = property.unit;
+#ifdef RMLUI_MATH_EXPRESSIONS
+		if (property.unit == Unit::CALCULATION)
+			dependencies = GetMutableUnitDependencies(property);
+		else if (property.unit == Unit::VAR_EXPRESSION || property.unit == Unit::SHORTHAND_PLACEHOLDER)
+			dependencies = GetResolvedUnitDependencies(id);
+#endif
+		if (Any(dependencies & units))
 			DirtyProperty(id);
 	}
 }
@@ -913,6 +970,14 @@ PropertyIdSet ElementStyle::ComputeValues(Style::ComputedValues& values, const S
 	SmallUnorderedSet<String> variable_dependencies;
 	bool dirty_em_properties = false;
 
+#ifdef RMLUI_MATH_EXPRESSIONS
+	// ComputeValues already visits every specified longhand below, so rebuild the sparse cache from
+	// those resolved values. This also drops entries for removed properties without adding any
+	// substitution work to unit-dirty scans.
+	if (resolved_unit_dependencies)
+		resolved_unit_dependencies.reset();
+#endif
+
 	// Always do font-size first if dirty, because of em-relative values
 	if (dirty_properties.Contains(PropertyId::FontSize))
 	{
@@ -921,7 +986,7 @@ PropertyIdSet ElementStyle::ComputeValues(Style::ComputedValues& values, const S
 			variable_dependencies.clear();
 			property = ResolveVariables(PropertyId::FontSize, property, variable_dependencies, property_storage);
 			if (property)
-				values.font_size(ComputeFontsize(property->GetNumericValue(), values, parent_values, document_values, dp_ratio, vp_dimensions));
+				values.font_size(ComputeFontsize(property, values, parent_values, document_values, dp_ratio, vp_dimensions));
 		}
 		else if (parent_values)
 			values.font_size(parent_values->font_size());
@@ -977,6 +1042,13 @@ PropertyIdSet ElementStyle::ComputeValues(Style::ComputedValues& values, const S
 		auto id_property_pair = *it;
 		const PropertyId id = id_property_pair.first;
 		const Property* property = ResolveVariables(id, &id_property_pair.second, variable_dependencies, property_storage);
+#ifdef RMLUI_MATH_EXPRESSIONS
+		// The cache is rebuilt from scratch above and only exists to retain dependencies hidden behind
+		// variable/shorthand substitution. Ordinary specified values expose their units directly and
+		// need no cache entry or per-property maintenance on this hot path.
+		if (id_property_pair.second.unit == Unit::VAR_EXPRESSION || id_property_pair.second.unit == Unit::SHORTHAND_PLACEHOLDER)
+			UpdateResolvedUnitDependencies(id, id_property_pair.second, property);
+#endif
 		if (!property)
 			continue;
 
@@ -986,7 +1058,13 @@ PropertyIdSet ElementStyle::ComputeValues(Style::ComputedValues& values, const S
 				dirty_properties.Insert(id);
 		}
 
-		if (dirty_em_properties && property->unit == Unit::EM)
+		if (dirty_em_properties
+#ifdef RMLUI_MATH_EXPRESSIONS
+			&& Any(GetMutableUnitDependencies(*property) & Unit::EM)
+#else
+			&& property->unit == Unit::EM
+#endif
+		)
 			dirty_properties.Insert(id);
 
 		ComputeValue(values, dp_ratio, vp_dimensions, font_size, document_font_size, dirty_font_face_handle, id, property);
@@ -1082,18 +1160,16 @@ void ElementStyle::ComputeValue(Style::ComputedValues& values, float dp_ratio, V
 		break;
 
 	case PropertyId::BorderTopWidth:
-		values.border_top_width(ComputeBorderWidth(ComputeLength(p->GetNumericValue(), font_size, document_font_size, dp_ratio, vp_dimensions)));
+		{ float value; if (ComputeDefiniteLength(p, font_size, document_font_size, dp_ratio, vp_dimensions, value)) values.border_top_width(ComputeBorderWidth(value)); }
 		break;
 	case PropertyId::BorderRightWidth:
-		values.border_right_width(
-			ComputeBorderWidth(ComputeLength(p->GetNumericValue(), font_size, document_font_size, dp_ratio, vp_dimensions)));
+		{ float value; if (ComputeDefiniteLength(p, font_size, document_font_size, dp_ratio, vp_dimensions, value)) values.border_right_width(ComputeBorderWidth(value)); }
 		break;
 	case PropertyId::BorderBottomWidth:
-		values.border_bottom_width(
-			ComputeBorderWidth(ComputeLength(p->GetNumericValue(), font_size, document_font_size, dp_ratio, vp_dimensions)));
+		{ float value; if (ComputeDefiniteLength(p, font_size, document_font_size, dp_ratio, vp_dimensions, value)) values.border_bottom_width(ComputeBorderWidth(value)); }
 		break;
 	case PropertyId::BorderLeftWidth:
-		values.border_left_width(ComputeBorderWidth(ComputeLength(p->GetNumericValue(), font_size, document_font_size, dp_ratio, vp_dimensions)));
+		{ float value; if (ComputeDefiniteLength(p, font_size, document_font_size, dp_ratio, vp_dimensions, value)) values.border_left_width(ComputeBorderWidth(value)); }
 		break;
 
 	case PropertyId::BorderTopColor:
@@ -1110,16 +1186,16 @@ void ElementStyle::ComputeValue(Style::ComputedValues& values, float dp_ratio, V
 		break;
 
 	case PropertyId::BorderTopLeftRadius:
-		values.border_top_left_radius(ComputeLength(p->GetNumericValue(), font_size, document_font_size, dp_ratio, vp_dimensions));
+		{ float value; if (ComputeDefiniteLength(p, font_size, document_font_size, dp_ratio, vp_dimensions, value)) values.border_top_left_radius(value); }
 		break;
 	case PropertyId::BorderTopRightRadius:
-		values.border_top_right_radius(ComputeLength(p->GetNumericValue(), font_size, document_font_size, dp_ratio, vp_dimensions));
+		{ float value; if (ComputeDefiniteLength(p, font_size, document_font_size, dp_ratio, vp_dimensions, value)) values.border_top_right_radius(value); }
 		break;
 	case PropertyId::BorderBottomRightRadius:
-		values.border_bottom_right_radius(ComputeLength(p->GetNumericValue(), font_size, document_font_size, dp_ratio, vp_dimensions));
+		{ float value; if (ComputeDefiniteLength(p, font_size, document_font_size, dp_ratio, vp_dimensions, value)) values.border_bottom_right_radius(value); }
 		break;
 	case PropertyId::BorderBottomLeftRadius:
-		values.border_bottom_left_radius(ComputeLength(p->GetNumericValue(), font_size, document_font_size, dp_ratio, vp_dimensions));
+		{ float value; if (ComputeDefiniteLength(p, font_size, document_font_size, dp_ratio, vp_dimensions, value)) values.border_bottom_left_radius(value); }
 		break;
 
 	case PropertyId::Display:
@@ -1153,7 +1229,8 @@ void ElementStyle::ComputeValue(Style::ComputedValues& values, float dp_ratio, V
 		break;
 
 	case PropertyId::ZIndex:
-		values.z_index((p->unit == Unit::KEYWORD ? ZIndex(ZIndex::Auto) : ZIndex(ZIndex::Number, p->Get<float>())));
+		if (p->unit == Unit::KEYWORD) values.z_index(ZIndex(ZIndex::Auto));
+		else { float value; if (ComputeDefiniteNumber(p, font_size, document_font_size, dp_ratio, vp_dimensions, value)) values.z_index(ZIndex(ZIndex::Number, value)); }
 		break;
 
 	case PropertyId::Width:
@@ -1209,7 +1286,7 @@ void ElementStyle::ComputeValue(Style::ComputedValues& values, float dp_ratio, V
 		values.image_color(p->Get<Colourb>());
 		break;
 	case PropertyId::Opacity:
-		values.opacity(p->Get<float>());
+		{ float value; if (ComputeDefiniteNumber(p, font_size, document_font_size, dp_ratio, vp_dimensions, value)) values.opacity(value); }
 		break;
 
 	case PropertyId::FontFamily:
@@ -1221,7 +1298,14 @@ void ElementStyle::ComputeValue(Style::ComputedValues& values, float dp_ratio, V
 		dirty_font_face_handle = true;
 		break;
 	case PropertyId::FontWeight:
-		values.font_weight((FontWeight)p->Get< int >());
+		if (p->unit == Unit::KEYWORD)
+			values.font_weight((FontWeight)p->Get<int>());
+		else
+		{
+			float value;
+			if (ComputeDefiniteNumber(p, font_size, document_font_size, dp_ratio, vp_dimensions, value))
+				values.font_weight((FontWeight)static_cast<int>(value));
+		}
 		dirty_font_face_handle = true;
 		break;
 	case PropertyId::FontSize:
@@ -1270,7 +1354,7 @@ void ElementStyle::ComputeValue(Style::ComputedValues& values, float dp_ratio, V
 		values.focus((Focus)p->Get<int>());
 		break;
 	case PropertyId::ScrollbarMargin:
-		values.scrollbar_margin(ComputeLength(p->GetNumericValue(), font_size, document_font_size, dp_ratio, vp_dimensions));
+		{ float value; if (ComputeDefiniteLength(p, font_size, document_font_size, dp_ratio, vp_dimensions, value)) values.scrollbar_margin(value); }
 		break;
 	case PropertyId::OverscrollBehavior:
 		values.overscroll_behavior((OverscrollBehavior)p->Get<int>());
@@ -1280,7 +1364,8 @@ void ElementStyle::ComputeValue(Style::ComputedValues& values, float dp_ratio, V
 		break;
 
 	case PropertyId::Perspective:
-		values.perspective(p->unit == Unit::KEYWORD ? 0.f : ComputeLength(p->GetNumericValue(), font_size, document_font_size, dp_ratio, vp_dimensions));
+		if (p->unit == Unit::KEYWORD) values.perspective(0.f);
+		else { float value; if (ComputeDefiniteLength(p, font_size, document_font_size, dp_ratio, vp_dimensions, value)) values.perspective(value); }
 		values.has_local_perspective(values.perspective() > 0.f);
 		break;
 	case PropertyId::PerspectiveOriginX:
@@ -1300,7 +1385,7 @@ void ElementStyle::ComputeValue(Style::ComputedValues& values, float dp_ratio, V
 		values.transform_origin_y(ComputeOrigin(p, font_size, document_font_size, dp_ratio, vp_dimensions));
 		break;
 	case PropertyId::TransformOriginZ:
-		values.transform_origin_z(ComputeLength(p->GetNumericValue(), font_size, document_font_size, dp_ratio, vp_dimensions));
+		{ float value; if (ComputeDefiniteLength(p, font_size, document_font_size, dp_ratio, vp_dimensions, value)) values.transform_origin_z(value); }
 		break;
 
 	case PropertyId::Decorator:

--- a/Source/Core/ElementStyle.h
+++ b/Source/Core/ElementStyle.h
@@ -189,6 +189,13 @@ private:
 	void ComputeValue(Style::ComputedValues& values, float dp_ratio, Vector2f vp_dimensions, float font_size, float document_font_size,
 		bool& dirty_font_face_handle, PropertyId id, const Property* p);
 
+#ifdef RMLUI_MATH_EXPRESSIONS
+	Units GetMutableUnitDependencies(const Property& property) const;
+	Units GetResolvedUnitDependencies(PropertyId id) const;
+	void UpdateResolvedUnitDependencies(PropertyId id, const Property& specified_property, const Property* resolved_property);
+	void EraseResolvedUnitDependencies(PropertyId id);
+#endif
+
 	static const Property* GetLocalProperty(PropertyId id, const PropertyDictionary& inline_properties, const ElementDefinition* definition);
 	static const Property* GetLocalCustomProperty(const String& name, const PropertyDictionary& inline_properties,
 		const ElementDefinition* definition);
@@ -233,6 +240,9 @@ private:
 	PropertyIdSet dirty_properties;
 	UnorderedSet<String> dirty_variables;
 	UnorderedSet<ShorthandId> dirty_var_shorthands;
+#ifdef RMLUI_MATH_EXPRESSIONS
+	UniquePtr<UnorderedMap<PropertyId, Units>> resolved_unit_dependencies;
+#endif
 };
 
 } // namespace Rml

--- a/Source/Core/FilterBasic.cpp
+++ b/Source/Core/FilterBasic.cpp
@@ -4,6 +4,9 @@
 #include "../../Include/RmlUi/Core/PropertyDefinition.h"
 #include "../../Include/RmlUi/Core/PropertyDictionary.h"
 #include "../../Include/RmlUi/Core/RenderManager.h"
+#ifdef RMLUI_MATH_EXPRESSIONS
+	#include "CalculationResolver.h"
+#endif
 
 namespace Rml {
 
@@ -36,11 +39,29 @@ SharedPtr<Filter> FilterBasicInstancer::InstanceFilter(const String& name, const
 	if (!p_value)
 		return nullptr;
 
-	float value = p_value->Get<float>();
-	if (p_value->unit == Unit::PERCENT)
-		value *= 0.01f;
-	else if (p_value->unit == Unit::DEG)
-		value = Rml::Math::DegreesToRadians(value);
+	float value = 0.f;
+#ifdef RMLUI_MATH_EXPRESSIONS
+	if (p_value->unit == Unit::CALCULATION)
+	{
+		const CalculationPtr calculation = p_value->value.Get<CalculationPtr>();
+		ResolvedCalculation resolved;
+		if (!calculation || !ResolveCalculation(*calculation, CalculationResolverContext{}, resolved) || !resolved.is_constant)
+			return nullptr;
+		value = resolved.value;
+		if (resolved.unit == Unit::PERCENT)
+			value *= 0.01f;
+		else if (resolved.unit != Unit::NUMBER && resolved.unit != Unit::RAD)
+			return nullptr;
+	}
+	else
+#endif
+	{
+		value = p_value->Get<float>();
+		if (p_value->unit == Unit::PERCENT)
+			value *= 0.01f;
+		else if (p_value->unit == Unit::DEG)
+			value = Rml::Math::DegreesToRadians(value);
+	}
 
 	auto filter = MakeShared<FilterBasic>();
 	if (filter->Initialise(name, value))

--- a/Source/Core/FilterBlur.cpp
+++ b/Source/Core/FilterBlur.cpp
@@ -4,6 +4,9 @@
 #include "../../Include/RmlUi/Core/PropertyDefinition.h"
 #include "../../Include/RmlUi/Core/PropertyDictionary.h"
 #include "../../Include/RmlUi/Core/RenderManager.h"
+#ifdef RMLUI_MATH_EXPRESSIONS
+	#include "CalculationResolver.h"
+#endif
 
 namespace Rml {
 
@@ -13,15 +16,32 @@ bool FilterBlur::Initialise(NumericValue in_sigma)
 	return Any(in_sigma.unit & Unit::LENGTH);
 }
 
+#ifdef RMLUI_MATH_EXPRESSIONS
+bool FilterBlur::Initialise(CalculationPtr in_sigma)
+{
+	sigma_calculation = std::move(in_sigma);
+	sigma_value = NumericValue(0.f, Unit::PX);
+	return bool(sigma_calculation);
+}
+#endif
+
 CompiledFilter FilterBlur::CompileFilter(Element* element) const
 {
-	const float radius = element->ResolveLength(sigma_value);
+	float radius = element->ResolveLength(sigma_value);
+#ifdef RMLUI_MATH_EXPRESSIONS
+	if (sigma_calculation && !ResolveElementCalculation(*sigma_calculation, *element, 0.f, radius))
+		radius = 0.f;
+#endif
 	return element->GetRenderManager()->CompileFilter("blur", Dictionary{{"sigma", Variant(radius)}});
 }
 
 void FilterBlur::ExtendInkOverflow(Element* element, Rectanglef& scissor_region) const
 {
-	const float sigma = element->ResolveLength(sigma_value);
+	float sigma = element->ResolveLength(sigma_value);
+#ifdef RMLUI_MATH_EXPRESSIONS
+	if (sigma_calculation && !ResolveElementCalculation(*sigma_calculation, *element, 0.f, sigma))
+		sigma = 0.f;
+#endif
 	const float blur_extent = 3.0f * Math::Max(sigma, 1.f);
 	scissor_region = scissor_region.Extend(blur_extent);
 }
@@ -39,7 +59,15 @@ SharedPtr<Filter> FilterBlurInstancer::InstanceFilter(const String& /*name*/, co
 		return nullptr;
 
 	auto decorator = MakeShared<FilterBlur>();
-	if (decorator->Initialise(p_radius->GetNumericValue()))
+#ifdef RMLUI_MATH_EXPRESSIONS
+	if (p_radius->unit == Unit::CALCULATION)
+	{
+		if (decorator->Initialise(p_radius->value.Get<CalculationPtr>()))
+			return decorator;
+	}
+	else
+#endif
+		if (decorator->Initialise(p_radius->GetNumericValue()))
 		return decorator;
 
 	return nullptr;

--- a/Source/Core/FilterBlur.h
+++ b/Source/Core/FilterBlur.h
@@ -9,6 +9,9 @@ namespace Rml {
 class FilterBlur : public Filter {
 public:
 	bool Initialise(NumericValue sigma);
+#ifdef RMLUI_MATH_EXPRESSIONS
+	bool Initialise(CalculationPtr sigma);
+#endif
 
 	CompiledFilter CompileFilter(Element* element) const override;
 
@@ -16,6 +19,9 @@ public:
 
 private:
 	NumericValue sigma_value;
+#ifdef RMLUI_MATH_EXPRESSIONS
+	CalculationPtr sigma_calculation;
+#endif
 };
 
 class FilterBlurInstancer : public FilterInstancer {

--- a/Source/Core/FilterDropShadow.cpp
+++ b/Source/Core/FilterDropShadow.cpp
@@ -4,6 +4,9 @@
 #include "../../Include/RmlUi/Core/PropertyDefinition.h"
 #include "../../Include/RmlUi/Core/PropertyDictionary.h"
 #include "../../Include/RmlUi/Core/RenderManager.h"
+#ifdef RMLUI_MATH_EXPRESSIONS
+	#include "CalculationResolver.h"
+#endif
 
 namespace Rml {
 
@@ -16,12 +19,37 @@ bool FilterDropShadow::Initialise(Colourb in_color, NumericValue in_offset_x, Nu
 	return Any(in_offset_x.unit & Unit::LENGTH) && Any(in_offset_y.unit & Unit::LENGTH) && Any(in_sigma.unit & Unit::LENGTH);
 }
 
+#ifdef RMLUI_MATH_EXPRESSIONS
+bool FilterDropShadow::Initialise(Colourb in_color, NumericValue in_offset_x, NumericValue in_offset_y, NumericValue in_sigma,
+	CalculationPtr in_offset_x_calculation, CalculationPtr in_offset_y_calculation, CalculationPtr in_sigma_calculation)
+{
+	color = in_color;
+	value_offset_x = in_offset_x;
+	value_offset_y = in_offset_y;
+	value_sigma = in_sigma;
+	calculation_offset_x = std::move(in_offset_x_calculation);
+	calculation_offset_y = std::move(in_offset_y_calculation);
+	calculation_sigma = std::move(in_sigma_calculation);
+	return true;
+}
+#endif
+
 CompiledFilter FilterDropShadow::CompileFilter(Element* element) const
 {
-	const float sigma = element->ResolveLength(value_sigma);
+	float sigma = element->ResolveLength(value_sigma);
+	float offset_x = element->ResolveLength(value_offset_x);
+	float offset_y = element->ResolveLength(value_offset_y);
+#ifdef RMLUI_MATH_EXPRESSIONS
+	if (calculation_sigma && !ResolveElementCalculation(*calculation_sigma, *element, 0.f, sigma))
+		sigma = 0.f;
+	if (calculation_offset_x && !ResolveElementCalculation(*calculation_offset_x, *element, 0.f, offset_x))
+		offset_x = 0.f;
+	if (calculation_offset_y && !ResolveElementCalculation(*calculation_offset_y, *element, 0.f, offset_y))
+		offset_y = 0.f;
+#endif
 	const Vector2f offset = {
-		element->ResolveLength(value_offset_x),
-		element->ResolveLength(value_offset_y),
+		offset_x,
+		offset_y,
 	};
 
 	CompiledFilter filter = element->GetRenderManager()->CompileFilter("drop-shadow",
@@ -33,10 +61,20 @@ CompiledFilter FilterDropShadow::CompileFilter(Element* element) const
 void FilterDropShadow::ExtendInkOverflow(Element* element, Rectanglef& scissor_region) const
 {
 	// Expand the ink overflow area to cover both the native element *and* its offset shadow w/blur.
-	const float sigma = element->ResolveLength(value_sigma);
+	float sigma = element->ResolveLength(value_sigma);
+	float offset_x = element->ResolveLength(value_offset_x);
+	float offset_y = element->ResolveLength(value_offset_y);
+#ifdef RMLUI_MATH_EXPRESSIONS
+	if (calculation_sigma && !ResolveElementCalculation(*calculation_sigma, *element, 0.f, sigma))
+		sigma = 0.f;
+	if (calculation_offset_x && !ResolveElementCalculation(*calculation_offset_x, *element, 0.f, offset_x))
+		offset_x = 0.f;
+	if (calculation_offset_y && !ResolveElementCalculation(*calculation_offset_y, *element, 0.f, offset_y))
+		offset_y = 0.f;
+#endif
 	const Vector2f offset = {
-		element->ResolveLength(value_offset_x),
-		element->ResolveLength(value_offset_y),
+		offset_x,
+		offset_y,
 	};
 
 	const float blur_extent = 3.f * sigma;
@@ -63,8 +101,31 @@ SharedPtr<Filter> FilterDropShadowInstancer::InstanceFilter(const String& /*name
 		return nullptr;
 
 	auto decorator = MakeShared<FilterDropShadow>();
-	if (decorator->Initialise(p_color->Get<Colourb>(), p_offset_x->GetNumericValue(), p_offset_y->GetNumericValue(), p_sigma->GetNumericValue()))
+	NumericValue offset_x(0.f, Unit::PX), offset_y(0.f, Unit::PX), sigma(0.f, Unit::PX);
+#ifdef RMLUI_MATH_EXPRESSIONS
+	CalculationPtr offset_x_calculation, offset_y_calculation, sigma_calculation;
+	auto extract = [](const Property* property, NumericValue& numeric, CalculationPtr& calculation) {
+		if (property->unit == Unit::CALCULATION)
+		{
+			calculation = property->value.Get<CalculationPtr>();
+			return bool(calculation);
+		}
+		numeric = property->GetNumericValue();
+		return true;
+	};
+	if (!extract(p_offset_x, offset_x, offset_x_calculation) || !extract(p_offset_y, offset_y, offset_y_calculation) ||
+		!extract(p_sigma, sigma, sigma_calculation))
+		return nullptr;
+	if (decorator->Initialise(p_color->Get<Colourb>(), offset_x, offset_y, sigma, std::move(offset_x_calculation), std::move(offset_y_calculation),
+			std::move(sigma_calculation)))
 		return decorator;
+#else
+	offset_x = p_offset_x->GetNumericValue();
+	offset_y = p_offset_y->GetNumericValue();
+	sigma = p_sigma->GetNumericValue();
+	if (decorator->Initialise(p_color->Get<Colourb>(), offset_x, offset_y, sigma))
+		return decorator;
+#endif
 
 	return nullptr;
 }

--- a/Source/Core/FilterDropShadow.h
+++ b/Source/Core/FilterDropShadow.h
@@ -9,6 +9,10 @@ namespace Rml {
 class FilterDropShadow : public Filter {
 public:
 	bool Initialise(Colourb color, NumericValue offset_x, NumericValue offset_y, NumericValue sigma);
+#ifdef RMLUI_MATH_EXPRESSIONS
+	bool Initialise(Colourb color, NumericValue offset_x, NumericValue offset_y, NumericValue sigma, CalculationPtr offset_x_calculation,
+		CalculationPtr offset_y_calculation, CalculationPtr sigma_calculation);
+#endif
 
 	CompiledFilter CompileFilter(Element* element) const override;
 
@@ -17,6 +21,9 @@ public:
 private:
 	Colourb color;
 	NumericValue value_offset_x, value_offset_y, value_sigma;
+#ifdef RMLUI_MATH_EXPRESSIONS
+	CalculationPtr calculation_offset_x, calculation_offset_y, calculation_sigma;
+#endif
 };
 
 class FilterDropShadowInstancer : public FilterInstancer {

--- a/Source/Core/FontEffectBlur.cpp
+++ b/Source/Core/FontEffectBlur.cpp
@@ -97,7 +97,12 @@ FontEffectBlurInstancer::~FontEffectBlurInstancer() {}
 
 SharedPtr<FontEffect> FontEffectBlurInstancer::InstanceFontEffect(const String& /*name*/, const PropertyDictionary& properties)
 {
-	float width = properties.GetProperty(id_width)->Get<float>();
+	const Property* p_width = properties.GetProperty(id_width);
+#ifdef RMLUI_MATH_EXPRESSIONS
+	if (p_width->unit == Unit::CALCULATION)
+		return nullptr;
+#endif
+	float width = p_width->Get<float>();
 	Colourb color = properties.GetProperty(id_color)->Get<Colourb>();
 
 	auto font_effect = MakeShared<FontEffectBlur>();

--- a/Source/Core/FontEffectGlow.cpp
+++ b/Source/Core/FontEffectGlow.cpp
@@ -132,10 +132,19 @@ FontEffectGlowInstancer::~FontEffectGlowInstancer() {}
 SharedPtr<FontEffect> FontEffectGlowInstancer::InstanceFontEffect(const String& /*name*/, const PropertyDictionary& properties)
 {
 	Vector2i offset;
-	int width_outline = properties.GetProperty(id_width_outline)->Get<int>();
-	int width_blur = properties.GetProperty(id_width_blur)->Get<int>();
-	offset.x = properties.GetProperty(id_offset_x)->Get<int>();
-	offset.y = properties.GetProperty(id_offset_y)->Get<int>();
+	const Property* p_width_outline = properties.GetProperty(id_width_outline);
+	const Property* p_width_blur = properties.GetProperty(id_width_blur);
+	const Property* p_offset_x = properties.GetProperty(id_offset_x);
+	const Property* p_offset_y = properties.GetProperty(id_offset_y);
+#ifdef RMLUI_MATH_EXPRESSIONS
+	if (p_width_outline->unit == Unit::CALCULATION || p_width_blur->unit == Unit::CALCULATION || p_offset_x->unit == Unit::CALCULATION ||
+		p_offset_y->unit == Unit::CALCULATION)
+		return nullptr;
+#endif
+	int width_outline = p_width_outline->Get<int>();
+	int width_blur = p_width_blur->Get<int>();
+	offset.x = p_offset_x->Get<int>();
+	offset.y = p_offset_y->Get<int>();
 	Colourb color = properties.GetProperty(id_color)->Get<Colourb>();
 
 	if (width_blur < 0)

--- a/Source/Core/FontEffectOutline.cpp
+++ b/Source/Core/FontEffectOutline.cpp
@@ -80,7 +80,12 @@ FontEffectOutlineInstancer::~FontEffectOutlineInstancer() {}
 
 SharedPtr<FontEffect> FontEffectOutlineInstancer::InstanceFontEffect(const String& /*name*/, const PropertyDictionary& properties)
 {
-	float width = properties.GetProperty(id_width)->Get<float>();
+	const Property* p_width = properties.GetProperty(id_width);
+#ifdef RMLUI_MATH_EXPRESSIONS
+	if (p_width->unit == Unit::CALCULATION)
+		return nullptr;
+#endif
+	float width = p_width->Get<float>();
 	Colourb color = properties.GetProperty(id_color)->Get<Colourb>();
 
 	auto font_effect = MakeShared<FontEffectOutline>();

--- a/Source/Core/FontEffectShadow.cpp
+++ b/Source/Core/FontEffectShadow.cpp
@@ -45,8 +45,14 @@ FontEffectShadowInstancer::~FontEffectShadowInstancer() {}
 SharedPtr<FontEffect> FontEffectShadowInstancer::InstanceFontEffect(const String& /*name*/, const PropertyDictionary& properties)
 {
 	Vector2i offset;
-	offset.x = properties.GetProperty(id_offset_x)->Get<int>();
-	offset.y = properties.GetProperty(id_offset_y)->Get<int>();
+	const Property* p_offset_x = properties.GetProperty(id_offset_x);
+	const Property* p_offset_y = properties.GetProperty(id_offset_y);
+#ifdef RMLUI_MATH_EXPRESSIONS
+	if (p_offset_x->unit == Unit::CALCULATION || p_offset_y->unit == Unit::CALCULATION)
+		return nullptr;
+#endif
+	offset.x = p_offset_x->Get<int>();
+	offset.y = p_offset_y->Get<int>();
 	Colourb color = properties.GetProperty(id_color)->Get<Colourb>();
 
 	auto font_effect = MakeShared<FontEffectShadow>();

--- a/Source/Core/GeometryBoxShadow.cpp
+++ b/Source/Core/GeometryBoxShadow.cpp
@@ -9,6 +9,9 @@
 #include "../../Include/RmlUi/Core/Profiling.h"
 #include "../../Include/RmlUi/Core/RenderManager.h"
 #include "ElementStyle.h"
+#ifdef RMLUI_MATH_EXPRESSIONS
+	#include "CalculationResolver.h"
+#endif
 
 namespace Rml {
 
@@ -28,10 +31,27 @@ BoxShadowGeometryInfo GeometryBoxShadow::Resolve(Element* element, const CornerS
 	// Resolve all lengths to px units.
 	for (BoxShadow& shadow : shadow_list)
 	{
+#ifdef RMLUI_MATH_EXPRESSIONS
+		auto resolve_length = [&](NumericValue value, const CalculationPtr& calculation) {
+			if (!calculation)
+				return element->ResolveLength(value);
+			float result = 0.f;
+			return ResolveElementCalculation(*calculation, *element, 0.f, result) ? result : 0.f;
+		};
+		shadow.blur_radius = NumericValue(resolve_length(shadow.blur_radius, shadow.blur_radius_calculation), Unit::PX);
+		shadow.spread_distance = NumericValue(resolve_length(shadow.spread_distance, shadow.spread_distance_calculation), Unit::PX);
+		shadow.offset_x = NumericValue(resolve_length(shadow.offset_x, shadow.offset_x_calculation), Unit::PX);
+		shadow.offset_y = NumericValue(resolve_length(shadow.offset_y, shadow.offset_y_calculation), Unit::PX);
+		shadow.blur_radius_calculation.reset();
+		shadow.spread_distance_calculation.reset();
+		shadow.offset_x_calculation.reset();
+		shadow.offset_y_calculation.reset();
+#else
 		shadow.blur_radius = NumericValue(element->ResolveLength(shadow.blur_radius), Unit::PX);
 		shadow.spread_distance = NumericValue(element->ResolveLength(shadow.spread_distance), Unit::PX);
 		shadow.offset_x = NumericValue(element->ResolveLength(shadow.offset_x), Unit::PX);
 		shadow.offset_y = NumericValue(element->ResolveLength(shadow.offset_y), Unit::PX);
+#endif
 	}
 
 	{

--- a/Source/Core/Layout/BlockContainer.cpp
+++ b/Source/Core/Layout/BlockContainer.cpp
@@ -369,6 +369,19 @@ float BlockContainer::GetShrinkToFitWidth() const
 
 	float min_width, max_width;
 	LayoutDetails::GetMinMaxWidth(min_width, max_width, computed, box, 0.f);
+	const auto percentage_dependent = [](Style::LengthPercentage value) {
+		return value.type == Style::LengthPercentage::Percentage
+#ifdef RMLUI_MATH_EXPRESSIONS
+			|| value.type == Style::LengthPercentage::Calculation
+#endif
+			;
+	};
+	// Percentage-dependent min/max widths are indefinite while measuring intrinsic width. Treat them
+	// as their unconstrained defaults here, and resolve them later against the real containing block.
+	if (percentage_dependent(computed.min_width()))
+		min_width = 0.f;
+	if (percentage_dependent(computed.max_width()))
+		max_width = FLT_MAX;
 	content_width = Math::Clamp(content_width, min_width, max_width);
 
 	return content_width;

--- a/Source/Core/Layout/TableFormattingContext.cpp
+++ b/Source/Core/Layout/TableFormattingContext.cpp
@@ -235,7 +235,11 @@ void TableFormattingContext::DetermineRowHeights(TrackBoxList& rows, BoxList& ce
 			// The padding/border/margin and widths of columns are used.
 			const ComputedAxisSize computed = LayoutDetails::BuildComputedVerticalSize(element_row->GetComputedValues());
 
-			if (computed.size.type == Style::LengthPercentageAuto::Percentage)
+			if (computed.size.type == Style::LengthPercentageAuto::Percentage
+#ifdef RMLUI_MATH_EXPRESSIONS
+				|| computed.size.type == Style::LengthPercentageAuto::Calculation
+#endif
+			)
 				percentage_size_used = true;
 
 			sizing.ApplyTrackElement(i, 1, computed);

--- a/Source/Core/Property.cpp
+++ b/Source/Core/Property.cpp
@@ -1,5 +1,8 @@
 #include "../../Include/RmlUi/Core/Property.h"
 #include "../../Include/RmlUi/Core/PropertyDefinition.h"
+#ifdef RMLUI_MATH_EXPRESSIONS
+	#include "Calculation.h"
+#endif
 
 namespace Rml {
 
@@ -11,6 +14,13 @@ Property::Property() : unit(Unit::UNKNOWN), specificity(-1)
 
 String Property::ToString() const
 {
+#ifdef RMLUI_MATH_EXPRESSIONS
+	if (unit == Unit::CALCULATION)
+	{
+		const CalculationPtr calculation = value.Get<CalculationPtr>();
+		return calculation ? calculation->ToString() : String();
+	}
+#endif
 	if (!definition)
 		return value.Get<String>() + Rml::ToString(unit);
 

--- a/Source/Core/PropertyDefinition.cpp
+++ b/Source/Core/PropertyDefinition.cpp
@@ -1,4 +1,7 @@
 #include "../../Include/RmlUi/Core/PropertyDefinition.h"
+#ifdef RMLUI_MATH_EXPRESSIONS
+	#include "Calculation.h"
+#endif
 #include "../../Include/RmlUi/Core/Log.h"
 #include "../../Include/RmlUi/Core/StyleSheetSpecification.h"
 
@@ -90,6 +93,14 @@ bool PropertyDefinition::ParseValue(Property& property, const String& value) con
 
 bool PropertyDefinition::GetValue(String& value, const Property& property) const
 {
+#ifdef RMLUI_MATH_EXPRESSIONS
+	if (property.unit == Unit::CALCULATION)
+	{
+		const CalculationPtr calculation = property.value.Get<CalculationPtr>();
+		value = calculation ? calculation->ToString() : String();
+		return bool(calculation);
+	}
+#endif
 	value = property.value.Get<String>();
 
 	switch (property.unit)

--- a/Source/Core/PropertyParserAnimation.cpp
+++ b/Source/Core/PropertyParserAnimation.cpp
@@ -4,8 +4,126 @@
 #include "../../Include/RmlUi/Core/StringUtilities.h"
 #include "../../Include/RmlUi/Core/StyleSheetSpecification.h"
 #include "PropertyShorthandDefinition.h"
+#ifdef RMLUI_MATH_EXPRESSIONS
+	#include "CalculationParser.h"
+#endif
 
 namespace Rml {
+
+namespace {
+
+	enum class SplitMode { List, Components };
+
+	bool SplitAnimationValue(StringList& output, const String& input, SplitMode mode)
+	{
+		output.clear();
+		size_t begin = 0;
+		int depth = 0;
+		char quote = 0;
+		bool escaped = false;
+		for (size_t i = 0; i < input.size(); ++i)
+		{
+			const char c = input[i];
+			if (quote)
+			{
+				if (escaped)
+					escaped = false;
+				else if (c == '\\')
+					escaped = true;
+				else if (c == quote)
+					quote = 0;
+				continue;
+			}
+			if (c == '\'' || c == '"')
+			{
+				quote = c;
+				continue;
+			}
+			if (c == '(')
+			{
+				++depth;
+				continue;
+			}
+			if (c == ')')
+			{
+				if (depth == 0)
+					return false;
+				--depth;
+				continue;
+			}
+
+			const bool separator = depth == 0 && (mode == SplitMode::List ? c == ',' : StringUtilities::IsWhitespace(c));
+			if (!separator)
+				continue;
+
+			String token = StringUtilities::StripWhitespace(input.substr(begin, i - begin));
+			if (!token.empty())
+				output.push_back(std::move(token));
+			else if (mode == SplitMode::List)
+				return false;
+
+			begin = i + 1;
+			if (mode == SplitMode::Components)
+				while (begin < input.size() && StringUtilities::IsWhitespace(input[begin]))
+					++begin;
+			i = begin ? begin - 1 : 0;
+		}
+		if (quote || depth != 0)
+			return false;
+		String token = StringUtilities::StripWhitespace(input.substr(begin));
+		if (!token.empty())
+			output.push_back(std::move(token));
+		else if (mode == SplitMode::List)
+			return false;
+		return !output.empty();
+	}
+
+	bool ParseOrdinaryTime(const String& argument, float& seconds)
+	{
+		int count = 0;
+		return sscanf(argument.c_str(), "%fs%n", &seconds, &count) == 1 && count > 0;
+	}
+
+	bool ParseOrdinaryNumber(const String& argument, float& number)
+	{
+		int count = 0;
+		return sscanf(argument.c_str(), "%fs%n", &number, &count) == 1 && count == 0;
+	}
+
+#ifdef RMLUI_MATH_EXPRESSIONS
+	bool BeginsMathFunction(const String& argument)
+	{
+		const String lower = StringUtilities::ToLower(argument);
+		for (const char* name : {"calc(", "min(", "max(", "clamp("})
+			if (lower.rfind(name, 0) == 0)
+				return true;
+		return false;
+	}
+
+	bool ParseMathArgument(const String& argument, bool allow_number, CalculationTypeMask& final_type, float& value)
+	{
+		CalculationPtr calculation;
+		CalculationParseTarget target = MakeCalculationParseTarget(CalculationFinalType::Time);
+		if (allow_number)
+			target.allowed_final_types |= CalculationTypeMask(CalculationFinalType::Number);
+		if (!ParseCalculation(argument, target, calculation))
+			return false;
+		final_type = GetCalculationFinalType(*calculation);
+		if (final_type == CalculationTypeMask(CalculationFinalType::Time))
+			return EvaluateCalculationTime(*calculation, value);
+		if (final_type == CalculationTypeMask(CalculationFinalType::Number))
+		{
+			CalculationConstantValue constant;
+			if (!EvaluateCalculation(*calculation, constant) || constant.unit != Unit::NUMBER)
+				return false;
+			value = constant.value;
+			return true;
+		}
+		return false;
+	}
+#endif
+
+} // namespace
 
 enum class KeywordType { None, Tween, All, Alternate, Infinite, Paused };
 
@@ -94,7 +212,8 @@ PropertyParserAnimation::PropertyParserAnimation(Type type) : type(type) {}
 bool PropertyParserAnimation::ParseValue(Property& property, const String& value, const ParameterMap& /*parameters*/) const
 {
 	StringList list_of_values;
-	StringUtilities::ExpandString(list_of_values, value, ',');
+	if (!SplitAnimationValue(list_of_values, value, SplitMode::List))
+		return false;
 
 	bool result = false;
 	if (type == ANIMATION_PARSER)
@@ -118,7 +237,8 @@ bool PropertyParserAnimation::ParseAnimation(Property& property, const StringLis
 		Animation animation;
 
 		StringList arguments;
-		StringUtilities::ExpandString(arguments, single_animation_value, ' ');
+		if (!SplitAnimationValue(arguments, single_animation_value, SplitMode::Components))
+			return false;
 
 		bool duration_found = false;
 		bool delay_found = false;
@@ -159,12 +279,35 @@ bool PropertyParserAnimation::ParseAnimation(Property& property, const StringLis
 			{
 				// Either <duration>, <delay>, <num_iterations> or a <keyframes-name>
 				float number = 0.0f;
-				int count = 0;
+				bool parsed_numeric = false;
+				bool is_time = false;
+				bool is_number = false;
 
-				if (sscanf(argument.c_str(), "%fs%n", &number, &count) == 1)
+				if (ParseOrdinaryTime(argument, number))
 				{
-					// Found a number, if there was an 's' unit, count will be positive
-					if (count > 0)
+					parsed_numeric = true;
+					is_time = true;
+				}
+				else if (ParseOrdinaryNumber(argument, number))
+				{
+					parsed_numeric = true;
+					is_number = true;
+				}
+#ifdef RMLUI_MATH_EXPRESSIONS
+				else if (BeginsMathFunction(argument))
+				{
+					CalculationTypeMask final_type = 0;
+					if (!ParseMathArgument(argument, true, final_type, number))
+						return false;
+					parsed_numeric = true;
+					is_time = final_type == CalculationTypeMask(CalculationFinalType::Time);
+					is_number = final_type == CalculationTypeMask(CalculationFinalType::Number);
+				}
+#endif
+
+				if (parsed_numeric)
+				{
+					if (is_time)
 					{
 						// Duration or delay was assigned
 						if (!duration_found)
@@ -180,7 +323,7 @@ bool PropertyParserAnimation::ParseAnimation(Property& property, const StringLis
 						else
 							return false;
 					}
-					else
+					else if (is_number)
 					{
 						// No 's' unit means num_iterations was found
 						if (!num_iterations_found)
@@ -191,9 +334,15 @@ bool PropertyParserAnimation::ParseAnimation(Property& property, const StringLis
 						else
 							return false;
 					}
+					else
+						return false;
 				}
 				else
 				{
+#ifdef RMLUI_MATH_EXPRESSIONS
+					if (BeginsMathFunction(argument))
+						return false;
+#endif
 					// Must be an animation name
 					animation.name = argument;
 				}
@@ -225,7 +374,8 @@ bool PropertyParserAnimation::ParseTransition(Property& property, const StringLi
 		PropertyIdSet target_property_ids;
 
 		StringList arguments;
-		StringUtilities::ExpandString(arguments, single_transition_value, ' ');
+		if (!SplitAnimationValue(arguments, single_transition_value, SplitMode::Components))
+			return false;
 
 		bool duration_found = false;
 		bool delay_found = false;
@@ -262,12 +412,34 @@ bool PropertyParserAnimation::ParseTransition(Property& property, const StringLi
 			{
 				// Either <duration>, <delay> or a <property name>
 				float number = 0.0f;
-				int count = 0;
+				bool parsed_numeric = false;
+				bool is_time = false;
+				bool is_number = false;
 
-				if (sscanf(argument.c_str(), "%fs%n", &number, &count) == 1)
+				if (ParseOrdinaryTime(argument, number))
 				{
-					// Found a number, if there was an 's' unit, count will be positive
-					if (count > 0)
+					parsed_numeric = true;
+					is_time = true;
+				}
+				else if (ParseOrdinaryNumber(argument, number))
+				{
+					parsed_numeric = true;
+					is_number = true;
+				}
+#ifdef RMLUI_MATH_EXPRESSIONS
+				else if (BeginsMathFunction(argument))
+				{
+					CalculationTypeMask final_type = 0;
+					if (!ParseMathArgument(argument, false, final_type, number))
+						return false;
+					parsed_numeric = true;
+					is_time = final_type == CalculationTypeMask(CalculationFinalType::Time);
+				}
+#endif
+
+				if (parsed_numeric)
+				{
+					if (is_time)
 					{
 						// Duration or delay was assigned
 						if (!duration_found)
@@ -283,7 +455,7 @@ bool PropertyParserAnimation::ParseTransition(Property& property, const StringLi
 						else
 							return false;
 					}
-					else
+					else if (is_number)
 					{
 						// No 's' unit means reverse adjustment factor was found
 						if (!reverse_adjustment_factor_found)
@@ -294,9 +466,15 @@ bool PropertyParserAnimation::ParseTransition(Property& property, const StringLi
 						else
 							return false;
 					}
+					else
+						return false;
 				}
 				else
 				{
+#ifdef RMLUI_MATH_EXPRESSIONS
+					if (BeginsMathFunction(argument))
+						return false;
+#endif
 					// Must be a property name or shorthand, expand now
 					if (auto shorthand = StyleSheetSpecification::GetShorthand(argument))
 					{

--- a/Source/Core/PropertyParserBoxShadow.cpp
+++ b/Source/Core/PropertyParserBoxShadow.cpp
@@ -53,12 +53,41 @@ bool PropertyParserBoxShadow::ParseValue(Property& property, const String& value
 			Property prop;
 			if (parser_length->ParseValue(prop, argument, empty_parameter_map))
 			{
+				NumericValue numeric_value;
+#ifdef RMLUI_MATH_EXPRESSIONS
+				CalculationPtr calculation;
+				if (prop.unit == Unit::CALCULATION)
+				{
+					calculation = prop.value.Get<CalculationPtr>();
+					if (!calculation)
+						return false;
+					numeric_value = NumericValue(0.f, Unit::PX);
+				}
+				else
+#endif
+					numeric_value = prop.GetNumericValue();
 				switch (length_argument_index)
 				{
-				case 0: shadow.offset_x = prop.GetNumericValue(); break;
-				case 1: shadow.offset_y = prop.GetNumericValue(); break;
-				case 2: shadow.blur_radius = prop.GetNumericValue(); break;
-				case 3: shadow.spread_distance = prop.GetNumericValue(); break;
+				case 0: shadow.offset_x = numeric_value;
+#ifdef RMLUI_MATH_EXPRESSIONS
+					shadow.offset_x_calculation = calculation;
+#endif
+					break;
+				case 1: shadow.offset_y = numeric_value;
+#ifdef RMLUI_MATH_EXPRESSIONS
+					shadow.offset_y_calculation = calculation;
+#endif
+					break;
+				case 2: shadow.blur_radius = numeric_value;
+#ifdef RMLUI_MATH_EXPRESSIONS
+					shadow.blur_radius_calculation = calculation;
+#endif
+					break;
+				case 3: shadow.spread_distance = numeric_value;
+#ifdef RMLUI_MATH_EXPRESSIONS
+					shadow.spread_distance_calculation = calculation;
+#endif
+					break;
 				default: return false;
 				}
 				length_argument_index += 1;

--- a/Source/Core/PropertyParserColorStopList.cpp
+++ b/Source/Core/PropertyParserColorStopList.cpp
@@ -6,7 +6,15 @@
 namespace Rml {
 
 PropertyParserColorStopList::PropertyParserColorStopList(PropertyParser* parser_color) :
-	parser_color(parser_color), parser_length_percent_angle(Unit::LENGTH_PERCENT | Unit::ANGLE, Unit::PERCENT)
+	parser_color(parser_color),
+#ifdef RMLUI_MATH_EXPRESSIONS
+	parser_length_percent(Unit::LENGTH_PERCENT, Unit::PERCENT,
+		MakeCalculationParseTarget(CalculationFinalType::Length, CalculationPercentageHint::Length)),
+	parser_angle_percent(Unit::ANGLE | Unit::PERCENT, Unit::PERCENT,
+		MakeCalculationParseTarget(CalculationFinalType::Angle, CalculationPercentageHint::Angle))
+#else
+	parser_length_percent(Unit::LENGTH_PERCENT, Unit::PERCENT), parser_angle_percent(Unit::ANGLE | Unit::PERCENT, Unit::PERCENT)
+#endif
 {
 	RMLUI_ASSERT(parser_color);
 }
@@ -26,7 +34,9 @@ bool PropertyParserColorStopList::ParseValue(Property& property, const String& v
 	if (color_stop_str_list.empty())
 		return false;
 
-	const Unit accepted_units = (parameters.count("angle") ? (Unit::ANGLE | Unit::PERCENT) : Unit::LENGTH_PERCENT);
+	const bool angle_positions = parameters.count("angle") != 0;
+	const Unit accepted_units = (angle_positions ? (Unit::ANGLE | Unit::PERCENT) : Unit::LENGTH_PERCENT);
+	const PropertyParserNumber& position_parser = (angle_positions ? parser_angle_percent : parser_length_percent);
 
 	ColorStopList color_stops;
 	color_stops.reserve(color_stop_str_list.size());
@@ -52,11 +62,20 @@ bool PropertyParserColorStopList::ParseValue(Property& property, const String& v
 		for (size_t i = 1; i < values.size(); i++)
 		{
 			Property p_position(Style::LengthPercentageAuto::Auto);
-			if (!parser_length_percent_angle.ParseValue(p_position, values[i], empty_parameter_map))
+			if (!position_parser.ParseValue(p_position, values[i], empty_parameter_map))
 				return false;
 
 			if (Any(p_position.unit & accepted_units))
 				color_stop.position = NumericValue(p_position.Get<float>(), p_position.unit);
+#ifdef RMLUI_MATH_EXPRESSIONS
+			else if (p_position.unit == Unit::CALCULATION)
+			{
+				color_stop.position = NumericValue(0.f, angle_positions ? Unit::RAD : Unit::PX);
+				color_stop.position_calculation = p_position.value.Get<CalculationPtr>();
+				if (!color_stop.position_calculation)
+					return false;
+			}
+#endif
 			else if (p_position.unit != Unit::KEYWORD)
 				return false;
 

--- a/Source/Core/PropertyParserColorStopList.h
+++ b/Source/Core/PropertyParserColorStopList.h
@@ -19,7 +19,8 @@ public:
 
 private:
 	PropertyParser* parser_color;
-	PropertyParserNumber parser_length_percent_angle;
+	PropertyParserNumber parser_length_percent;
+	PropertyParserNumber parser_angle_percent;
 };
 
 } // namespace Rml

--- a/Source/Core/PropertyParserNumber.cpp
+++ b/Source/Core/PropertyParserNumber.cpp
@@ -1,4 +1,5 @@
 #include "PropertyParserNumber.h"
+#include "../../Include/RmlUi/Core/Property.h"
 #include <stdlib.h>
 
 namespace Rml {
@@ -26,6 +27,44 @@ struct PropertyParserNumberData {
 
 ControlledLifetimeResource<PropertyParserNumberData> PropertyParserNumber::parser_data;
 
+#ifdef RMLUI_MATH_EXPRESSIONS
+static bool IsMathFunction(const String& value)
+{
+	if (value.empty())
+		return false;
+
+	// Ordinary numeric values overwhelmingly begin with a digit, sign, or decimal point. Keep that
+	// hot path allocation-free and avoid case-folding the complete value merely to identify the four
+	// supported math function prefixes.
+	const char first = value.front();
+	if (first != 'c' && first != 'C' && first != 'm' && first != 'M')
+		return false;
+
+	auto StartsWithCaseInsensitive = [&value](StringView prefix) {
+		return value.size() >= prefix.size() && StringUtilities::StringCompareCaseInsensitive(StringView(value, 0, prefix.size()), prefix);
+	};
+
+	if (first == 'c' || first == 'C')
+		return StartsWithCaseInsensitive("calc(") || StartsWithCaseInsensitive("clamp(");
+
+	return StartsWithCaseInsensitive("min(") || StartsWithCaseInsensitive("max(");
+}
+
+static bool ParseMathValue(Property& property, const String& value, const CalculationParseTarget& calculation_target)
+{
+	if (calculation_target.allowed_final_types == 0)
+		return false;
+
+	CalculationPtr calculation;
+	if (!ParseCalculation(value, calculation_target, calculation))
+		return false;
+
+	property.value = std::move(calculation);
+	property.unit = Unit::CALCULATION;
+	return true;
+}
+#endif
+
 void PropertyParserNumber::Initialize()
 {
 	parser_data.Initialize();
@@ -37,6 +76,12 @@ void PropertyParserNumber::Shutdown()
 }
 
 PropertyParserNumber::PropertyParserNumber(Units units, Unit zero_unit) : units(units), zero_unit(zero_unit) {}
+
+#ifdef RMLUI_MATH_EXPRESSIONS
+PropertyParserNumber::PropertyParserNumber(Units units, Unit zero_unit, CalculationParseTarget calculation_target) :
+	units(units), zero_unit(zero_unit), calculation_target(calculation_target)
+{}
+#endif
 
 PropertyParserNumber::~PropertyParserNumber() {}
 
@@ -61,6 +106,13 @@ bool PropertyParserNumber::ParseValue(Property& property, const String& value, c
 	float float_value = strtof(str_number.c_str(), &str_end);
 	if (str_number.c_str() == str_end)
 	{
+#ifdef RMLUI_MATH_EXPRESSIONS
+		// Preserve the legacy numeric parser as the fast path. Supported math expressions always begin
+		// with an identifier and therefore reach this fallback only after ordinary number conversion
+		// fails, so non-math RCSS pays no math-prefix detection cost.
+		if (IsMathFunction(value))
+			return ParseMathValue(property, value, calculation_target);
+#endif
 		// Number conversion failed
 		return false;
 	}

--- a/Source/Core/PropertyParserNumber.h
+++ b/Source/Core/PropertyParserNumber.h
@@ -2,6 +2,9 @@
 
 #include "../../Include/RmlUi/Core/PropertyParser.h"
 #include "ControlledLifetimeResource.h"
+#ifdef RMLUI_MATH_EXPRESSIONS
+	#include "CalculationParser.h"
+#endif
 
 namespace Rml {
 
@@ -12,6 +15,9 @@ namespace Rml {
 class PropertyParserNumber : public PropertyParser {
 public:
 	PropertyParserNumber(Units units, Unit zero_unit = Unit::UNKNOWN);
+#ifdef RMLUI_MATH_EXPRESSIONS
+	PropertyParserNumber(Units units, Unit zero_unit, CalculationParseTarget calculation_target);
+#endif
 	virtual ~PropertyParserNumber();
 
 	/// Called to parse a RCSS number declaration.
@@ -32,6 +38,10 @@ private:
 
 	// If zero unit is set and pure numbers are not allowed, parsing of "0" is still allowed and assigned the given unit.
 	Unit zero_unit;
+
+#ifdef RMLUI_MATH_EXPRESSIONS
+	CalculationParseTarget calculation_target;
+#endif
 };
 
 } // namespace Rml

--- a/Source/Core/PropertyParserTransform.cpp
+++ b/Source/Core/PropertyParserTransform.cpp
@@ -7,7 +7,30 @@
 namespace Rml {
 
 PropertyParserTransform::PropertyParserTransform() :
-	number(Unit::NUMBER), length(Unit::LENGTH, Unit::PX), length_pct(Unit::LENGTH_PERCENT, Unit::PX), angle(Unit::ANGLE, Unit::RAD)
+	number(Unit::NUMBER, Unit::NUMBER
+#ifdef RMLUI_MATH_EXPRESSIONS
+		,
+		MakeCalculationParseTarget(CalculationFinalType::Number)
+#endif
+			),
+	length(Unit::LENGTH, Unit::PX
+#ifdef RMLUI_MATH_EXPRESSIONS
+		,
+		MakeCalculationParseTarget(CalculationFinalType::Length)
+#endif
+			),
+	length_pct(Unit::LENGTH_PERCENT, Unit::PX
+#ifdef RMLUI_MATH_EXPRESSIONS
+		,
+		MakeCalculationParseTarget(CalculationFinalType::Length, CalculationPercentageHint::Length)
+#endif
+			),
+	angle(Unit::ANGLE, Unit::RAD
+#ifdef RMLUI_MATH_EXPRESSIONS
+		,
+		MakeCalculationParseTarget(CalculationFinalType::Angle)
+#endif
+	)
 {}
 
 PropertyParserTransform::~PropertyParserTransform() {}
@@ -26,6 +49,9 @@ bool PropertyParserTransform::ParseValue(Property& property, const String& value
 	char const* next = value.c_str();
 
 	NumericValue args[16];
+#ifdef RMLUI_MATH_EXPRESSIONS
+	CalculationPtr calculations[16];
+#endif
 
 	const PropertyParser* number16[] = {&number, &number, &number, &number, &number, &number, &number, &number, &number, &number, &number, &number,
 		&number, &number, &number, &number};
@@ -43,99 +69,126 @@ bool PropertyParserTransform::ParseValue(Property& property, const String& value
 	auto number3 = number16;
 	auto number6 = number16;
 
+	auto scan = [&](int& bytes_read, const char* input, const char* keyword, const PropertyParser** parsers, int nargs) {
+		return Scan(bytes_read, input, keyword, parsers, args, nargs
+#ifdef RMLUI_MATH_EXPRESSIONS
+			,
+			calculations
+#endif
+		);
+	};
+	auto add_primitive = [&](const TransformPrimitive& primitive, int nargs) {
+#ifdef RMLUI_MATH_EXPRESSIONS
+		const int primitive_index = transform->GetNumPrimitives();
+#endif
+		transform->AddPrimitive(primitive);
+#ifdef RMLUI_MATH_EXPRESSIONS
+		for (int argument_index = 0; argument_index < nargs; ++argument_index)
+		{
+			if (calculations[argument_index])
+				transform->AddCalculation(primitive_index, argument_index, calculations[argument_index]);
+		}
+#else
+		(void)nargs;
+#endif
+	};
+
 	while (*next)
 	{
 		using namespace Transforms;
 		int bytes_read = 0;
 
-		if (Scan(bytes_read, next, "perspective", length1, args, 1))
+		if (scan(bytes_read, next, "perspective", length1, 1))
 		{
-			transform->AddPrimitive({Perspective(args)});
+			add_primitive({Perspective(args)}, 1);
 		}
-		else if (Scan(bytes_read, next, "matrix", number6, args, 6))
+		else if (scan(bytes_read, next, "matrix", number6, 6))
 		{
-			transform->AddPrimitive({Matrix2D(args)});
+			add_primitive({Matrix2D(args)}, 6);
 		}
-		else if (Scan(bytes_read, next, "matrix3d", number16, args, 16))
+		else if (scan(bytes_read, next, "matrix3d", number16, 16))
 		{
-			transform->AddPrimitive({Matrix3D(args)});
+			add_primitive({Matrix3D(args)}, 16);
 		}
-		else if (Scan(bytes_read, next, "translateX", lengthpct1, args, 1))
+		else if (scan(bytes_read, next, "translateX", lengthpct1, 1))
 		{
-			transform->AddPrimitive({TranslateX(args)});
+			add_primitive({TranslateX(args)}, 1);
 		}
-		else if (Scan(bytes_read, next, "translateY", lengthpct1, args, 1))
+		else if (scan(bytes_read, next, "translateY", lengthpct1, 1))
 		{
-			transform->AddPrimitive({TranslateY(args)});
+			add_primitive({TranslateY(args)}, 1);
 		}
-		else if (Scan(bytes_read, next, "translateZ", length1, args, 1))
+		else if (scan(bytes_read, next, "translateZ", length1, 1))
 		{
-			transform->AddPrimitive({TranslateZ(args)});
+			add_primitive({TranslateZ(args)}, 1);
 		}
-		else if (Scan(bytes_read, next, "translate", lengthpct2, args, 2))
+		else if (scan(bytes_read, next, "translate", lengthpct2, 2))
 		{
-			transform->AddPrimitive({Translate2D(args)});
+			add_primitive({Translate2D(args)}, 2);
 		}
-		else if (Scan(bytes_read, next, "translate3d", lengthpct2_length1, args, 3))
+		else if (scan(bytes_read, next, "translate3d", lengthpct2_length1, 3))
 		{
-			transform->AddPrimitive({Translate3D(args)});
+			add_primitive({Translate3D(args)}, 3);
 		}
-		else if (Scan(bytes_read, next, "scaleX", number1, args, 1))
+		else if (scan(bytes_read, next, "scaleX", number1, 1))
 		{
-			transform->AddPrimitive({ScaleX(args)});
+			add_primitive({ScaleX(args)}, 1);
 		}
-		else if (Scan(bytes_read, next, "scaleY", number1, args, 1))
+		else if (scan(bytes_read, next, "scaleY", number1, 1))
 		{
-			transform->AddPrimitive({ScaleY(args)});
+			add_primitive({ScaleY(args)}, 1);
 		}
-		else if (Scan(bytes_read, next, "scaleZ", number1, args, 1))
+		else if (scan(bytes_read, next, "scaleZ", number1, 1))
 		{
-			transform->AddPrimitive({ScaleZ(args)});
+			add_primitive({ScaleZ(args)}, 1);
 		}
-		else if (Scan(bytes_read, next, "scale", number2, args, 2))
+		else if (scan(bytes_read, next, "scale", number2, 2))
 		{
-			transform->AddPrimitive({Scale2D(args)});
+			add_primitive({Scale2D(args)}, 2);
 		}
-		else if (Scan(bytes_read, next, "scale", number1, args, 1))
+		else if (scan(bytes_read, next, "scale", number1, 1))
 		{
 			args[1] = args[0];
-			transform->AddPrimitive({Scale2D(args)});
+#ifdef RMLUI_MATH_EXPRESSIONS
+			calculations[1] = calculations[0];
+#endif
+			add_primitive({Scale2D(args)}, 2);
 		}
-		else if (Scan(bytes_read, next, "scale3d", number3, args, 3))
+		else if (scan(bytes_read, next, "scale3d", number3, 3))
 		{
-			transform->AddPrimitive({Scale3D(args)});
+			add_primitive({Scale3D(args)}, 3);
 		}
-		else if (Scan(bytes_read, next, "rotateX", angle1, args, 1))
+		else if (scan(bytes_read, next, "rotateX", angle1, 1))
 		{
-			transform->AddPrimitive({RotateX(args)});
+			add_primitive({RotateX(args)}, 1);
 		}
-		else if (Scan(bytes_read, next, "rotateY", angle1, args, 1))
+		else if (scan(bytes_read, next, "rotateY", angle1, 1))
 		{
-			transform->AddPrimitive({RotateY(args)});
+			add_primitive({RotateY(args)}, 1);
 		}
-		else if (Scan(bytes_read, next, "rotateZ", angle1, args, 1))
+		else if (scan(bytes_read, next, "rotateZ", angle1, 1))
 		{
-			transform->AddPrimitive({RotateZ(args)});
+			add_primitive({RotateZ(args)}, 1);
 		}
-		else if (Scan(bytes_read, next, "rotate", angle1, args, 1))
+		else if (scan(bytes_read, next, "rotate", angle1, 1))
 		{
-			transform->AddPrimitive({Rotate2D(args)});
+			add_primitive({Rotate2D(args)}, 1);
 		}
-		else if (Scan(bytes_read, next, "rotate3d", number3angle1, args, 4))
+		else if (scan(bytes_read, next, "rotate3d", number3angle1, 4))
 		{
-			transform->AddPrimitive({Rotate3D(args)});
+			add_primitive({Rotate3D(args)}, 4);
 		}
-		else if (Scan(bytes_read, next, "skewX", angle1, args, 1))
+		else if (scan(bytes_read, next, "skewX", angle1, 1))
 		{
-			transform->AddPrimitive({SkewX(args)});
+			add_primitive({SkewX(args)}, 1);
 		}
-		else if (Scan(bytes_read, next, "skewY", angle1, args, 1))
+		else if (scan(bytes_read, next, "skewY", angle1, 1))
 		{
-			transform->AddPrimitive({SkewY(args)});
+			add_primitive({SkewY(args)}, 1);
 		}
-		else if (Scan(bytes_read, next, "skew", angle2, args, 2))
+		else if (scan(bytes_read, next, "skew", angle2, 2))
 		{
-			transform->AddPrimitive({Skew2D(args)});
+			add_primitive({Skew2D(args)}, 2);
 		}
 
 		if (bytes_read > 0)
@@ -155,109 +208,131 @@ bool PropertyParserTransform::ParseValue(Property& property, const String& value
 }
 
 bool PropertyParserTransform::Scan(int& out_bytes_read, const char* str, const char* keyword, const PropertyParser** parsers, NumericValue* args,
-	int nargs) const
+	int nargs
+#ifdef RMLUI_MATH_EXPRESSIONS
+	,
+	CalculationPtr* calculations
+#endif
+) const
 {
 	out_bytes_read = 0;
-	int total_bytes_read = 0, bytes_read = 0;
-
-	/* skip leading white space */
-	bytes_read = 0;
-	sscanf(str, " %n", &bytes_read);
-	str += bytes_read;
-	total_bytes_read += bytes_read;
-
-	/* find the keyword */
-	if (!memcmp(str, keyword, strlen(keyword)))
-	{
-		bytes_read = (int)strlen(keyword);
-		str += bytes_read;
-		total_bytes_read += bytes_read;
-	}
-	else
-	{
+	const char* begin = str;
+	while (StringUtilities::IsWhitespace(*str))
+		++str;
+	const size_t keyword_length = strlen(keyword);
+	if (strlen(str) < keyword_length)
 		return false;
-	}
-
-	/* skip any white space */
-	bytes_read = 0;
-	sscanf(str, " %n", &bytes_read);
-	str += bytes_read;
-	total_bytes_read += bytes_read;
-
-	/* find the opening brace */
-	bytes_read = 0;
-	if (sscanf(str, " ( %n", &bytes_read), bytes_read)
-	{
-		str += bytes_read;
-		total_bytes_read += bytes_read;
-	}
-	else
-	{
+	if (memcmp(str, keyword, keyword_length) != 0)
 		return false;
-	}
-
-	/* use the quicker stack-based argument buffer, if possible */
-	char* arg = nullptr;
-	char arg_stack[1024];
-	String arg_heap;
-	if (strlen(str) < sizeof(arg_stack))
+	str += keyword_length;
+	while (StringUtilities::IsWhitespace(*str))
+		++str;
+	if (*str != '(')
+		return false;
+	const char* arguments_begin = ++str;
+	int depth = 1;
+	char quote = 0;
+	bool escaped = false;
+	for (; *str && depth > 0; ++str)
 	{
-		arg = arg_stack;
-	}
-	else
-	{
-		arg_heap = str;
-		arg = &arg_heap[0];
-	}
-
-	/* parse the arguments */
-	for (int i = 0; i < nargs; ++i)
-	{
-		Property prop;
-
-		bytes_read = 0;
-		if (sscanf(str, " %[^,)] %n", arg, &bytes_read), bytes_read && parsers[i]->ParseValue(prop, String(arg), ParameterMap()))
+		const char c = *str;
+		if (quote)
 		{
-			args[i].number = prop.value.Get<float>();
-			args[i].unit = prop.unit;
-			str += bytes_read;
-			total_bytes_read += bytes_read;
+			if (escaped)
+				escaped = false;
+			else if (c == '\\')
+				escaped = true;
+			else if (c == quote)
+				quote = 0;
+			continue;
+		}
+		if (c == '\'' || c == '"')
+			quote = c;
+		else if (c == '(')
+			++depth;
+		else if (c == ')')
+			--depth;
+	}
+	if (depth != 0 || quote)
+		return false;
+
+	const char* arguments_end = str - 1;
+	StringList argument_list;
+	String current;
+	depth = 0;
+	quote = 0;
+	escaped = false;
+	for (const char* p = arguments_begin; p < arguments_end; ++p)
+	{
+		const char c = *p;
+		if (quote)
+		{
+			current += c;
+			if (escaped)
+				escaped = false;
+			else if (c == '\\')
+				escaped = true;
+			else if (c == quote)
+				quote = 0;
+			continue;
+		}
+		if (c == '\'' || c == '"')
+		{
+			quote = c;
+			current += c;
+		}
+		else if (c == '(')
+		{
+			++depth;
+			current += c;
+		}
+		else if (c == ')')
+		{
+			--depth;
+			current += c;
+		}
+		else if (c == ',' && depth == 0)
+		{
+			argument_list.push_back(StringUtilities::StripWhitespace(current));
+			current.clear();
 		}
 		else
-		{
-			return false;
-		}
-
-		/* find the comma */
-		if (i < nargs - 1)
-		{
-			bytes_read = 0;
-			if (sscanf(str, " , %n", &bytes_read), bytes_read)
-			{
-				str += bytes_read;
-				total_bytes_read += bytes_read;
-			}
-			else
-			{
-				return false;
-			}
-		}
+			current += c;
 	}
-
-	/* find the closing brace */
-	bytes_read = 0;
-	if (sscanf(str, " ) %n", &bytes_read), bytes_read)
-	{
-		str += bytes_read;
-		total_bytes_read += bytes_read;
-	}
-	else
-	{
+	argument_list.push_back(StringUtilities::StripWhitespace(current));
+	if ((int)argument_list.size() != nargs)
 		return false;
+
+	for (int i = 0; i < nargs; ++i)
+	{
+#ifdef RMLUI_MATH_EXPRESSIONS
+		calculations[i].reset();
+#endif
+		Property prop;
+		if (argument_list[i].empty() || !parsers[i]->ParseValue(prop, argument_list[i], ParameterMap()))
+			return false;
+#ifdef RMLUI_MATH_EXPRESSIONS
+		if (prop.unit == Unit::CALCULATION)
+		{
+			calculations[i] = prop.value.Get<CalculationPtr>();
+			if (!calculations[i])
+				return false;
+			if (parsers[i] == &angle)
+				args[i] = NumericValue(0.f, Unit::RAD);
+			else if (parsers[i] == &number)
+				args[i] = NumericValue(0.f, Unit::NUMBER);
+			else
+				args[i] = NumericValue(0.f, Unit::PX);
+			continue;
+		}
+#endif
+		args[i] = prop.GetNumericValue();
 	}
 
-	out_bytes_read = total_bytes_read;
-	return total_bytes_read > 0;
+	while (StringUtilities::IsWhitespace(*str))
+		++str;
+	out_bytes_read = int(str - begin);
+	return out_bytes_read > 0;
 }
 
 } // namespace Rml

--- a/Source/Core/PropertyParserTransform.h
+++ b/Source/Core/PropertyParserTransform.h
@@ -29,7 +29,12 @@ private:
 	/// @param[out] args The numeric arguments encountered
 	/// @param[in] nargs The number of numeric arguments expected
 	/// @return True if parsed successfully, false otherwise.
-	bool Scan(int& out_bytes_read, const char* str, const char* keyword, const PropertyParser** parsers, NumericValue* args, int nargs) const;
+	bool Scan(int& out_bytes_read, const char* str, const char* keyword, const PropertyParser** parsers, NumericValue* args, int nargs
+#ifdef RMLUI_MATH_EXPRESSIONS
+		,
+		CalculationPtr* calculations
+#endif
+	) const;
 
 	PropertyParserNumber number, length, length_pct, angle;
 };

--- a/Source/Core/PropertySpecification.cpp
+++ b/Source/Core/PropertySpecification.cpp
@@ -401,6 +401,7 @@ bool PropertySpecification::ParseShorthandDeclaration(PropertyDictionary& dictio
 
 		size_t subvalue_i = 0;
 		String temp_subvalue;
+		bool repeated_item_consumed_remainder = false;
 		for (size_t i = 0; i < shorthand_definition->items.size() && subvalue_i < property_values.size(); i++)
 		{
 			bool result = false;
@@ -422,13 +423,23 @@ bool PropertySpecification::ParseShorthandDeclaration(PropertyDictionary& dictio
 				result = ParseShorthandDeclaration(dictionary, item.shorthand_id, *subvalue);
 
 			if (result)
+			{
 				subvalue_i += 1;
+				if (item.repeats)
+					repeated_item_consumed_remainder = true;
+			}
 			else if (item.repeats || !item.optional)
 				return false;
 
 			if (item.repeats)
 				break;
 		}
+
+		// Optional items may decline a subvalue, but an unconsumed trailing subvalue must not make the
+		// whole shorthand succeed. This is particularly important for optional numeric extension slots:
+		// an invalid calculated value must be rejected rather than silently ignored.
+		if (!repeated_item_consumed_remainder && subvalue_i != property_values.size())
+			return false;
 	}
 	else
 	{

--- a/Source/Core/StyleSheetContainer.cpp
+++ b/Source/Core/StyleSheetContainer.cpp
@@ -79,52 +79,52 @@ bool StyleSheetContainer::UpdateCompiledStyleSheet(const Context* context)
 #else
 			const bool has_calculated_media_value = false;
 #endif
-			auto values_equal = [has_calculated_media_value](float lhs, float rhs) {
-				return has_calculated_media_value ? Math::Absolute(lhs - rhs) < 0.0001f : lhs == rhs;
-			};
-			auto value_less = [has_calculated_media_value](float lhs, float rhs) {
-				return has_calculated_media_value ? lhs < rhs - 0.0001f : lhs < rhs;
-			};
-			auto value_greater = [has_calculated_media_value](float lhs, float rhs) {
-				return has_calculated_media_value ? lhs > rhs + 0.0001f : lhs > rhs;
-			};
+			auto values_equal = [](float lhs, float rhs, bool approximate) { return approximate ? Math::Absolute(lhs - rhs) < 0.0001f : lhs == rhs; };
+			auto value_less = [](float lhs, float rhs, bool approximate) { return approximate ? lhs < rhs - 0.0001f : lhs < rhs; };
+			auto value_greater = [](float lhs, float rhs, bool approximate) { return approximate ? lhs > rhs + 0.0001f : lhs > rhs; };
 
 			switch (id)
 			{
 			case MediaQueryId::Width:
 				if (!values_equal(float(vp_dimensions.x),
 						has_calculated_media_value ? media_value
-												   : ComputeLength(property.second.GetNumericValue(), font_size, font_size, dp_ratio, vp_dimensions)))
+												   : ComputeLength(property.second.GetNumericValue(), font_size, font_size, dp_ratio, vp_dimensions),
+						has_calculated_media_value))
 					all_match = false;
 				break;
 			case MediaQueryId::MinWidth:
 				if (value_less(float(vp_dimensions.x),
 						has_calculated_media_value ? media_value
-												   : ComputeLength(property.second.GetNumericValue(), font_size, font_size, dp_ratio, vp_dimensions)))
+												   : ComputeLength(property.second.GetNumericValue(), font_size, font_size, dp_ratio, vp_dimensions),
+						has_calculated_media_value))
 					all_match = false;
 				break;
 			case MediaQueryId::MaxWidth:
 				if (value_greater(float(vp_dimensions.x),
 						has_calculated_media_value ? media_value
-												   : ComputeLength(property.second.GetNumericValue(), font_size, font_size, dp_ratio, vp_dimensions)))
+												   : ComputeLength(property.second.GetNumericValue(), font_size, font_size, dp_ratio, vp_dimensions),
+						has_calculated_media_value))
 					all_match = false;
 				break;
 			case MediaQueryId::Height:
 				if (!values_equal(float(vp_dimensions.y),
 						has_calculated_media_value ? media_value
-												   : ComputeLength(property.second.GetNumericValue(), font_size, font_size, dp_ratio, vp_dimensions)))
+												   : ComputeLength(property.second.GetNumericValue(), font_size, font_size, dp_ratio, vp_dimensions),
+						has_calculated_media_value))
 					all_match = false;
 				break;
 			case MediaQueryId::MinHeight:
 				if (value_less(float(vp_dimensions.y),
 						has_calculated_media_value ? media_value
-												   : ComputeLength(property.second.GetNumericValue(), font_size, font_size, dp_ratio, vp_dimensions)))
+												   : ComputeLength(property.second.GetNumericValue(), font_size, font_size, dp_ratio, vp_dimensions),
+						has_calculated_media_value))
 					all_match = false;
 				break;
 			case MediaQueryId::MaxHeight:
 				if (value_greater(float(vp_dimensions.y),
 						has_calculated_media_value ? media_value
-												   : ComputeLength(property.second.GetNumericValue(), font_size, font_size, dp_ratio, vp_dimensions)))
+												   : ComputeLength(property.second.GetNumericValue(), font_size, font_size, dp_ratio, vp_dimensions),
+						has_calculated_media_value))
 					all_match = false;
 				break;
 			case MediaQueryId::AspectRatio:
@@ -143,15 +143,15 @@ bool StyleSheetContainer::UpdateCompiledStyleSheet(const Context* context)
 					all_match = false;
 				break;
 			case MediaQueryId::Resolution:
-				if (!values_equal(dp_ratio, has_calculated_media_value ? media_value : property.second.Get<float>()))
+				if (!values_equal(dp_ratio, has_calculated_media_value ? media_value : property.second.Get<float>(), has_calculated_media_value))
 					all_match = false;
 				break;
 			case MediaQueryId::MinResolution:
-				if (value_less(dp_ratio, has_calculated_media_value ? media_value : property.second.Get<float>()))
+				if (value_less(dp_ratio, has_calculated_media_value ? media_value : property.second.Get<float>(), has_calculated_media_value))
 					all_match = false;
 				break;
 			case MediaQueryId::MaxResolution:
-				if (value_greater(dp_ratio, has_calculated_media_value ? media_value : property.second.Get<float>()))
+				if (value_greater(dp_ratio, has_calculated_media_value ? media_value : property.second.Get<float>(), has_calculated_media_value))
 					all_match = false;
 				break;
 			case MediaQueryId::Orientation:

--- a/Source/Core/StyleSheetContainer.cpp
+++ b/Source/Core/StyleSheetContainer.cpp
@@ -7,6 +7,9 @@
 #include "../../Include/RmlUi/Core/Utilities.h"
 #include "ComputeProperty.h"
 #include "StyleSheetParser.h"
+#ifdef RMLUI_MATH_EXPRESSIONS
+	#include "CalculationResolver.h"
+#endif
 
 namespace Rml {
 
@@ -33,6 +36,27 @@ bool StyleSheetContainer::UpdateCompiledStyleSheet(const Context* context)
 
 	const float font_size = DefaultComputedValues().font_size();
 
+#ifdef RMLUI_MATH_EXPRESSIONS
+	auto resolve_media_value = [&](const Property& property, float& result) {
+		if (property.unit != Unit::CALCULATION)
+			return false;
+		const CalculationPtr calculation = property.value.Get<CalculationPtr>();
+		if (!calculation)
+			return false;
+		CalculationResolverContext resolver_context;
+		resolver_context.font_size = font_size;
+		resolver_context.parent_font_size = font_size;
+		resolver_context.document_font_size = font_size;
+		resolver_context.viewport_dimensions = vp_dimensions;
+		resolver_context.dp_ratio = dp_ratio;
+		ResolvedCalculation resolved;
+		if (!ResolveCalculation(*calculation, resolver_context, resolved) || !resolved.is_constant)
+			return false;
+		result = resolved.value;
+		return resolved.unit == Unit::PX || resolved.unit == Unit::X || resolved.unit == Unit::NUMBER;
+	};
+#endif
+
 	for (int media_block_index = 0; media_block_index < (int)media_blocks.size(); media_block_index++)
 	{
 		const MediaBlock& media_block = media_blocks[media_block_index];
@@ -43,31 +67,64 @@ bool StyleSheetContainer::UpdateCompiledStyleSheet(const Context* context)
 		{
 			const MediaQueryId id = static_cast<MediaQueryId>(property.first);
 			Vector2i ratio;
+			float media_value = 0.f;
+#ifdef RMLUI_MATH_EXPRESSIONS
+			const bool is_calculated_media_value = property.second.unit == Unit::CALCULATION;
+			const bool has_calculated_media_value = is_calculated_media_value && resolve_media_value(property.second, media_value);
+			if (is_calculated_media_value && !has_calculated_media_value)
+			{
+				all_match = false;
+				break;
+			}
+#else
+			const bool has_calculated_media_value = false;
+#endif
+			auto values_equal = [has_calculated_media_value](float lhs, float rhs) {
+				return has_calculated_media_value ? Math::Absolute(lhs - rhs) < 0.0001f : lhs == rhs;
+			};
+			auto value_less = [has_calculated_media_value](float lhs, float rhs) {
+				return has_calculated_media_value ? lhs < rhs - 0.0001f : lhs < rhs;
+			};
+			auto value_greater = [has_calculated_media_value](float lhs, float rhs) {
+				return has_calculated_media_value ? lhs > rhs + 0.0001f : lhs > rhs;
+			};
 
 			switch (id)
 			{
 			case MediaQueryId::Width:
-				if (vp_dimensions.x != ComputeLength(property.second.GetNumericValue(), font_size, font_size, dp_ratio, vp_dimensions))
+				if (!values_equal(float(vp_dimensions.x),
+						has_calculated_media_value ? media_value
+												   : ComputeLength(property.second.GetNumericValue(), font_size, font_size, dp_ratio, vp_dimensions)))
 					all_match = false;
 				break;
 			case MediaQueryId::MinWidth:
-				if (vp_dimensions.x < ComputeLength(property.second.GetNumericValue(), font_size, font_size, dp_ratio, vp_dimensions))
+				if (value_less(float(vp_dimensions.x),
+						has_calculated_media_value ? media_value
+												   : ComputeLength(property.second.GetNumericValue(), font_size, font_size, dp_ratio, vp_dimensions)))
 					all_match = false;
 				break;
 			case MediaQueryId::MaxWidth:
-				if (vp_dimensions.x > ComputeLength(property.second.GetNumericValue(), font_size, font_size, dp_ratio, vp_dimensions))
+				if (value_greater(float(vp_dimensions.x),
+						has_calculated_media_value ? media_value
+												   : ComputeLength(property.second.GetNumericValue(), font_size, font_size, dp_ratio, vp_dimensions)))
 					all_match = false;
 				break;
 			case MediaQueryId::Height:
-				if (vp_dimensions.y != ComputeLength(property.second.GetNumericValue(), font_size, font_size, dp_ratio, vp_dimensions))
+				if (!values_equal(float(vp_dimensions.y),
+						has_calculated_media_value ? media_value
+												   : ComputeLength(property.second.GetNumericValue(), font_size, font_size, dp_ratio, vp_dimensions)))
 					all_match = false;
 				break;
 			case MediaQueryId::MinHeight:
-				if (vp_dimensions.y < ComputeLength(property.second.GetNumericValue(), font_size, font_size, dp_ratio, vp_dimensions))
+				if (value_less(float(vp_dimensions.y),
+						has_calculated_media_value ? media_value
+												   : ComputeLength(property.second.GetNumericValue(), font_size, font_size, dp_ratio, vp_dimensions)))
 					all_match = false;
 				break;
 			case MediaQueryId::MaxHeight:
-				if (vp_dimensions.y > ComputeLength(property.second.GetNumericValue(), font_size, font_size, dp_ratio, vp_dimensions))
+				if (value_greater(float(vp_dimensions.y),
+						has_calculated_media_value ? media_value
+												   : ComputeLength(property.second.GetNumericValue(), font_size, font_size, dp_ratio, vp_dimensions)))
 					all_match = false;
 				break;
 			case MediaQueryId::AspectRatio:
@@ -86,15 +143,15 @@ bool StyleSheetContainer::UpdateCompiledStyleSheet(const Context* context)
 					all_match = false;
 				break;
 			case MediaQueryId::Resolution:
-				if (dp_ratio != property.second.Get<float>())
+				if (!values_equal(dp_ratio, has_calculated_media_value ? media_value : property.second.Get<float>()))
 					all_match = false;
 				break;
 			case MediaQueryId::MinResolution:
-				if (dp_ratio < property.second.Get<float>())
+				if (value_less(dp_ratio, has_calculated_media_value ? media_value : property.second.Get<float>()))
 					all_match = false;
 				break;
 			case MediaQueryId::MaxResolution:
-				if (dp_ratio > property.second.Get<float>())
+				if (value_greater(dp_ratio, has_calculated_media_value ? media_value : property.second.Get<float>()))
 					all_match = false;
 				break;
 			case MediaQueryId::Orientation:

--- a/Source/Core/StyleSheetParser.cpp
+++ b/Source/Core/StyleSheetParser.cpp
@@ -201,6 +201,10 @@ public:
 
 			if (const Property* property = properties.GetProperty(id_resolution))
 			{
+#ifdef RMLUI_MATH_EXPRESSIONS
+				if (property->unit == Unit::CALCULATION)
+					return false;
+#endif
 				if (property->unit == Unit::X)
 					image_resolution_factor = property->Get<float>();
 			}
@@ -212,13 +216,37 @@ public:
 
 			Vector2f position, size;
 			if (auto p = properties.GetProperty(id_rx))
+			{
+#ifdef RMLUI_MATH_EXPRESSIONS
+				if (p->unit == Unit::CALCULATION)
+					return false;
+#endif
 				position.x = p->Get<float>();
+			}
 			if (auto p = properties.GetProperty(id_ry))
+			{
+#ifdef RMLUI_MATH_EXPRESSIONS
+				if (p->unit == Unit::CALCULATION)
+					return false;
+#endif
 				position.y = p->Get<float>();
+			}
 			if (auto p = properties.GetProperty(id_rw))
+			{
+#ifdef RMLUI_MATH_EXPRESSIONS
+				if (p->unit == Unit::CALCULATION)
+					return false;
+#endif
 				size.x = p->Get<float>();
+			}
 			if (auto p = properties.GetProperty(id_rh))
+			{
+#ifdef RMLUI_MATH_EXPRESSIONS
+				if (p->unit == Unit::CALCULATION)
+					return false;
+#endif
 				size.y = p->Get<float>();
+			}
 
 			sprite_definitions.emplace_back(name, Rectanglef::FromPositionSize(position, size));
 		}
@@ -326,7 +354,17 @@ public:
 			return true;
 		}
 
-		return specification.ParsePropertyDeclaration(*properties, name, value);
+		if (!specification.ParsePropertyDeclaration(*properties, name, value))
+			return false;
+#ifdef RMLUI_MATH_EXPRESSIONS
+		if (name == "font-weight" || name == "-rmlui-face-index")
+		{
+			const PropertyId id = (name == "font-weight" ? CastId(FontFaceId::FontWeight) : CastId(FontFaceId::FaceIndex));
+			if (const Property* property = properties->GetProperty(id); property && property->unit == Unit::CALCULATION)
+				return false;
+		}
+#endif
+		return true;
 	}
 };
 
@@ -550,6 +588,10 @@ bool StyleSheetParser::ParseFontFaceBlock(const SharedPtr<const PropertySource>&
 	}
 
 	auto get_property = [&properties](FontFaceId id) { return properties.GetProperty(static_cast<PropertyId>(id)); };
+#ifdef RMLUI_MATH_EXPRESSIONS
+	if (get_property(FontFaceId::FaceIndex)->unit == Unit::CALCULATION || get_property(FontFaceId::FontWeight)->unit == Unit::CALCULATION)
+		return false;
+#endif
 	const String family = get_property(FontFaceId::FontFamily)->Get<String>();
 	const bool is_fallback = get_property(FontFaceId::FallbackFace)->Get<bool>();
 	const int face_index = get_property(FontFaceId::FaceIndex)->Get<int>();
@@ -578,6 +620,7 @@ bool StyleSheetParser::ParseMediaFeatureMap(const String& rules, PropertyDiction
 	String current_string;
 
 	modifier = MediaQueryModifier::None;
+	int value_parenthesis_depth = 0;
 
 	for (size_t cursor = 0; cursor < rules.length(); cursor++)
 	{
@@ -587,6 +630,11 @@ bool StyleSheetParser::ParseMediaFeatureMap(const String& rules, PropertyDiction
 		{
 		case ' ':
 		{
+			if (state == Value)
+			{
+				current_string += character;
+				break;
+			}
 			if (state == Global)
 			{
 				current_string = StringUtilities::StripWhitespace(StringUtilities::ToLower(std::move(current_string)));
@@ -610,6 +658,12 @@ bool StyleSheetParser::ParseMediaFeatureMap(const String& rules, PropertyDiction
 		}
 		case '(':
 		{
+			if (state == Value)
+			{
+				++value_parenthesis_depth;
+				current_string += character;
+				break;
+			}
 			if (state != Global)
 			{
 				Log::Message(Log::LT_WARNING, "Unexpected '(' in @media query list at %s:%d.", stream_file_name.c_str(), line_number);
@@ -632,6 +686,12 @@ bool StyleSheetParser::ParseMediaFeatureMap(const String& rules, PropertyDiction
 		break;
 		case ')':
 		{
+			if (state == Value && value_parenthesis_depth > 0)
+			{
+				--value_parenthesis_depth;
+				current_string += character;
+				break;
+			}
 			if (state != Value)
 			{
 				Log::Message(Log::LT_WARNING, "Unexpected ')' in @media query list at %s:%d.", stream_file_name.c_str(), line_number);
@@ -646,6 +706,7 @@ bool StyleSheetParser::ParseMediaFeatureMap(const String& rules, PropertyDiction
 
 			current_string.clear();
 			state = Global;
+			value_parenthesis_depth = 0;
 		}
 		break;
 		case ':':

--- a/Source/Core/StyleSheetSpecification.cpp
+++ b/Source/Core/StyleSheetSpecification.cpp
@@ -21,12 +21,25 @@ namespace Rml {
 static StyleSheetSpecification* instance = nullptr;
 
 struct DefaultStyleSheetParsers : NonCopyMoveable {
+#ifdef RMLUI_MATH_EXPRESSIONS
+	PropertyParserNumber number = PropertyParserNumber(Unit::NUMBER, Unit::UNKNOWN, MakeCalculationParseTarget(CalculationFinalType::Number));
+	PropertyParserNumber length = PropertyParserNumber(Unit::LENGTH, Unit::PX, MakeCalculationParseTarget(CalculationFinalType::Length));
+	PropertyParserNumber length_percent = PropertyParserNumber(Unit::LENGTH_PERCENT, Unit::PX,
+		MakeCalculationParseTarget(CalculationFinalType::Length, CalculationPercentageHint::Length));
+	PropertyParserNumber number_percent = PropertyParserNumber(Unit::NUMBER_PERCENT, Unit::UNKNOWN,
+		{CalculationFinalType::Number | CalculationFinalType::Percent, CalculationPercentageHint::None});
+	PropertyParserNumber number_length_percent = PropertyParserNumber(Unit::NUMBER_LENGTH_PERCENT, Unit::PX);
+	PropertyParserNumber line_height = PropertyParserNumber(Unit::NUMBER_LENGTH_PERCENT, Unit::PX,
+		{CalculationFinalType::Number | CalculationFinalType::Length, CalculationPercentageHint::Length});
+	PropertyParserNumber angle = PropertyParserNumber(Unit::ANGLE, Unit::RAD, MakeCalculationParseTarget(CalculationFinalType::Angle));
+#else
 	PropertyParserNumber number = PropertyParserNumber(Unit::NUMBER);
 	PropertyParserNumber length = PropertyParserNumber(Unit::LENGTH, Unit::PX);
 	PropertyParserNumber length_percent = PropertyParserNumber(Unit::LENGTH_PERCENT, Unit::PX);
 	PropertyParserNumber number_percent = PropertyParserNumber(Unit::NUMBER_PERCENT);
 	PropertyParserNumber number_length_percent = PropertyParserNumber(Unit::NUMBER_LENGTH_PERCENT, Unit::PX);
 	PropertyParserNumber angle = PropertyParserNumber(Unit::ANGLE, Unit::RAD);
+#endif
 	PropertyParserKeyword keyword = PropertyParserKeyword();
 	PropertyParserString string = PropertyParserString();
 	PropertyParserAnimation animation = PropertyParserAnimation(PropertyParserAnimation::ANIMATION_PARSER);
@@ -38,7 +51,11 @@ struct DefaultStyleSheetParsers : NonCopyMoveable {
 	PropertyParserFontEffect font_effect = PropertyParserFontEffect();
 	PropertyParserTransform transform = PropertyParserTransform();
 	PropertyParserRatio ratio = PropertyParserRatio();
+#ifdef RMLUI_MATH_EXPRESSIONS
+	PropertyParserNumber resolution = PropertyParserNumber(Unit::X, Unit::UNKNOWN, MakeCalculationParseTarget(CalculationFinalType::Resolution));
+#else
 	PropertyParserNumber resolution = PropertyParserNumber(Unit::X);
+#endif
 	PropertyParserBoxShadow box_shadow = PropertyParserBoxShadow(&color, &length);
 };
 
@@ -229,6 +246,9 @@ void StyleSheetSpecification::RegisterDefaultParsers()
 	RegisterParser("length_percent", &default_parsers->length_percent);
 	RegisterParser("number_percent", &default_parsers->number_percent);
 	RegisterParser("number_length_percent", &default_parsers->number_length_percent);
+#ifdef RMLUI_MATH_EXPRESSIONS
+	RegisterParser("line_height", &default_parsers->line_height);
+#endif
 	RegisterParser("angle", &default_parsers->angle);
 	RegisterParser("keyword", &default_parsers->keyword);
 	RegisterParser("string", &default_parsers->string);
@@ -327,7 +347,11 @@ void StyleSheetSpecification::RegisterDefaultProperties()
 	RegisterProperty(PropertyId::MinHeight, "min-height", "0px", false, true).AddParser("length_percent").SetRelativeTarget(RelativeTarget::ContainingBlockHeight);
 	RegisterProperty(PropertyId::MaxHeight, "max-height", "none", false, true).AddParser("keyword", "none").AddParser("length_percent").SetRelativeTarget(RelativeTarget::ContainingBlockHeight);
 
+#ifdef RMLUI_MATH_EXPRESSIONS
+	RegisterProperty(PropertyId::LineHeight, "line-height", "1.2", true, true).AddParser("line_height").SetRelativeTarget(RelativeTarget::FontSize);
+#else
 	RegisterProperty(PropertyId::LineHeight, "line-height", "1.2", true, true).AddParser("number_length_percent").SetRelativeTarget(RelativeTarget::FontSize);
+#endif
 	RegisterProperty(PropertyId::VerticalAlign, "vertical-align", "baseline", false, true)
 		.AddParser("keyword", "baseline, middle, sub, super, text-top, text-bottom, top, center, bottom")
 		.AddParser("length_percent").SetRelativeTarget(RelativeTarget::LineHeight);

--- a/Source/Core/Transform.cpp
+++ b/Source/Core/Transform.cpp
@@ -1,7 +1,11 @@
 #include "../../Include/RmlUi/Core/Transform.h"
+#include "../../Include/RmlUi/Core/Element.h"
 #include "../../Include/RmlUi/Core/Property.h"
 #include "../../Include/RmlUi/Core/StyleSheetSpecification.h"
 #include "../../Include/RmlUi/Core/TransformPrimitive.h"
+#ifdef RMLUI_MATH_EXPRESSIONS
+	#include "CalculationResolver.h"
+#endif
 
 namespace Rml {
 
@@ -19,12 +23,82 @@ Property Transform::MakeProperty(PrimitiveList primitives)
 void Transform::ClearPrimitives()
 {
 	primitives.clear();
+#ifdef RMLUI_MATH_EXPRESSIONS
+	calculations.clear();
+#endif
 }
 
 void Transform::AddPrimitive(const TransformPrimitive& p)
 {
 	primitives.push_back(p);
 }
+
+#ifdef RMLUI_MATH_EXPRESSIONS
+void Transform::AddCalculation(int primitive_index, int argument_index, CalculationPtr calculation)
+{
+	RMLUI_ASSERT(calculation);
+	calculations.push_back({primitive_index, argument_index, std::move(calculation)});
+}
+
+TransformPrimitive Transform::ResolvePrimitive(int primitive_index, Element& element) const
+{
+	TransformPrimitive result = primitives[primitive_index];
+	const Vector2f border_size = element.GetBox().GetSize(BoxArea::Border);
+
+	auto set_argument = [&](int argument_index, float value) {
+		using namespace Transforms;
+		switch (result.type)
+		{
+		case TransformPrimitive::MATRIX2D: result.matrix_2d.values[argument_index] = value; break;
+		case TransformPrimitive::MATRIX3D: result.matrix_3d.values[argument_index] = value; break;
+		case TransformPrimitive::TRANSLATEX: result.translate_x.values[argument_index] = NumericValue(value, Unit::PX); break;
+		case TransformPrimitive::TRANSLATEY: result.translate_y.values[argument_index] = NumericValue(value, Unit::PX); break;
+		case TransformPrimitive::TRANSLATEZ: result.translate_z.values[argument_index] = NumericValue(value, Unit::PX); break;
+		case TransformPrimitive::TRANSLATE2D: result.translate_2d.values[argument_index] = NumericValue(value, Unit::PX); break;
+		case TransformPrimitive::TRANSLATE3D: result.translate_3d.values[argument_index] = NumericValue(value, Unit::PX); break;
+		case TransformPrimitive::SCALEX: result.scale_x.values[argument_index] = value; break;
+		case TransformPrimitive::SCALEY: result.scale_y.values[argument_index] = value; break;
+		case TransformPrimitive::SCALEZ: result.scale_z.values[argument_index] = value; break;
+		case TransformPrimitive::SCALE2D: result.scale_2d.values[argument_index] = value; break;
+		case TransformPrimitive::SCALE3D: result.scale_3d.values[argument_index] = value; break;
+		case TransformPrimitive::ROTATEX: result.rotate_x.values[argument_index] = value; break;
+		case TransformPrimitive::ROTATEY: result.rotate_y.values[argument_index] = value; break;
+		case TransformPrimitive::ROTATEZ: result.rotate_z.values[argument_index] = value; break;
+		case TransformPrimitive::ROTATE2D: result.rotate_2d.values[argument_index] = value; break;
+		case TransformPrimitive::ROTATE3D: result.rotate_3d.values[argument_index] = value; break;
+		case TransformPrimitive::SKEWX: result.skew_x.values[argument_index] = value; break;
+		case TransformPrimitive::SKEWY: result.skew_y.values[argument_index] = value; break;
+		case TransformPrimitive::SKEW2D: result.skew_2d.values[argument_index] = value; break;
+		case TransformPrimitive::PERSPECTIVE: result.perspective.values[argument_index] = NumericValue(value, Unit::PX); break;
+		case TransformPrimitive::DECOMPOSEDMATRIX4: break;
+		}
+	};
+
+	for (const CalculationEntry& entry : calculations)
+	{
+		if (entry.primitive_index != primitive_index || !entry.calculation)
+			continue;
+
+		float percentage_basis = 0.f;
+		switch (result.type)
+		{
+		case TransformPrimitive::TRANSLATEX: percentage_basis = border_size.x; break;
+		case TransformPrimitive::TRANSLATEY: percentage_basis = border_size.y; break;
+		case TransformPrimitive::TRANSLATE2D: percentage_basis = (entry.argument_index == 0 ? border_size.x : border_size.y); break;
+		case TransformPrimitive::TRANSLATE3D:
+			percentage_basis = (entry.argument_index == 0 ? border_size.x : (entry.argument_index == 1 ? border_size.y : 0.f));
+			break;
+		default: break;
+		}
+
+		float value = 0.f;
+		if (ResolveElementCalculation(*entry.calculation, element, percentage_basis, value))
+			set_argument(entry.argument_index, value);
+	}
+
+	return result;
+}
+#endif
 
 int Transform::GetNumPrimitives() const noexcept
 {

--- a/Source/Core/TypeConverter.cpp
+++ b/Source/Core/TypeConverter.cpp
@@ -12,6 +12,9 @@
 #include "PropertyParserColour.h"
 #include "PropertyParserDecorator.h"
 #include "TransformUtilities.h"
+#ifdef RMLUI_MATH_EXPRESSIONS
+	#include "Calculation.h"
+#endif
 
 namespace Rml {
 
@@ -71,6 +74,22 @@ bool TypeConverter<TransformPtr, String>::Convert(const TransformPtr& src, Strin
 	}
 	return true;
 }
+
+#ifdef RMLUI_MATH_EXPRESSIONS
+bool TypeConverter<CalculationPtr, CalculationPtr>::Convert(const CalculationPtr& src, CalculationPtr& dest)
+{
+	dest = src;
+	return true;
+}
+
+bool TypeConverter<CalculationPtr, String>::Convert(const CalculationPtr& src, String& dest)
+{
+	if (!src)
+		return false;
+	dest = src->ToString();
+	return true;
+}
+#endif
 
 bool TypeConverter<TransitionList, TransitionList>::Convert(const TransitionList& src, TransitionList& dest)
 {

--- a/Source/Core/Variant.cpp
+++ b/Source/Core/Variant.cpp
@@ -1,5 +1,8 @@
 #include "../../Include/RmlUi/Core/Variant.h"
 #include "../../Include/RmlUi/Core/DecorationTypes.h"
+#ifdef RMLUI_MATH_EXPRESSIONS
+	#include "Calculation.h"
+#endif
 #include <string.h>
 
 namespace Rml {
@@ -12,6 +15,9 @@ Variant::Variant()
 	static_assert(sizeof(Vector4f) <= LOCAL_DATA_SIZE, "Local data too small for Vector4f");
 	static_assert(sizeof(String) <= LOCAL_DATA_SIZE, "Local data too small for String");
 	static_assert(sizeof(TransformPtr) <= LOCAL_DATA_SIZE, "Local data too small for TransformPtr");
+#ifdef RMLUI_MATH_EXPRESSIONS
+	static_assert(sizeof(CalculationPtr) <= LOCAL_DATA_SIZE, "Local data too small for CalculationPtr");
+#endif
 	static_assert(sizeof(TransitionList) <= LOCAL_DATA_SIZE, "Local data too small for TransitionList");
 	static_assert(sizeof(AnimationList) <= LOCAL_DATA_SIZE, "Local data too small for AnimationList");
 	static_assert(sizeof(DecoratorsPtr) <= LOCAL_DATA_SIZE, "Local data too small for DecoratorsPtr");
@@ -55,6 +61,14 @@ void Variant::Clear()
 		transform->~TransformPtr();
 	}
 	break;
+#ifdef RMLUI_MATH_EXPRESSIONS
+	case CALCULATIONPTR:
+	{
+		CalculationPtr* calculation = (CalculationPtr*)data;
+		calculation->~CalculationPtr();
+	}
+	break;
+#endif
 	case TRANSITIONLIST:
 	{
 		// Clean up the transition list.
@@ -112,6 +126,9 @@ void Variant::Set(const Variant& copy)
 	{
 	case STRING: Set(*reinterpret_cast<const String*>(copy.data)); break;
 	case TRANSFORMPTR: Set(*reinterpret_cast<const TransformPtr*>(copy.data)); break;
+#ifdef RMLUI_MATH_EXPRESSIONS
+	case CALCULATIONPTR: Set(*reinterpret_cast<const CalculationPtr*>(copy.data)); break;
+#endif
 	case TRANSITIONLIST: Set(*reinterpret_cast<const TransitionList*>(copy.data)); break;
 	case ANIMATIONLIST: Set(*reinterpret_cast<const AnimationList*>(copy.data)); break;
 	case DECORATORSPTR: Set(*reinterpret_cast<const DecoratorsPtr*>(copy.data)); break;
@@ -133,6 +150,9 @@ void Variant::Set(Variant&& other)
 	{
 	case STRING: Set(std::move(*reinterpret_cast<String*>(other.data))); break;
 	case TRANSFORMPTR: Set(std::move(*reinterpret_cast<TransformPtr*>(other.data))); break;
+#ifdef RMLUI_MATH_EXPRESSIONS
+	case CALCULATIONPTR: Set(std::move(*reinterpret_cast<CalculationPtr*>(other.data))); break;
+#endif
 	case TRANSITIONLIST: Set(std::move(*reinterpret_cast<TransitionList*>(other.data))); break;
 	case ANIMATIONLIST: Set(std::move(*reinterpret_cast<AnimationList*>(other.data))); break;
 	case DECORATORSPTR: Set(std::move(*reinterpret_cast<DecoratorsPtr*>(other.data))); break;
@@ -298,6 +318,29 @@ void Variant::Set(TransformPtr&& value)
 		new (data) TransformPtr(std::move(value));
 	}
 }
+
+#ifdef RMLUI_MATH_EXPRESSIONS
+void Variant::Set(const CalculationPtr& value)
+{
+	if (type == CALCULATIONPTR)
+		*(CalculationPtr*)data = value;
+	else
+	{
+		type = CALCULATIONPTR;
+		new (data) CalculationPtr(value);
+	}
+}
+void Variant::Set(CalculationPtr&& value)
+{
+	if (type == CALCULATIONPTR)
+		*(CalculationPtr*)data = std::move(value);
+	else
+	{
+		type = CALCULATIONPTR;
+		new (data) CalculationPtr(std::move(value));
+	}
+}
+#endif
 
 void Variant::Set(const TransitionList& value)
 {
@@ -517,6 +560,16 @@ bool Variant::operator==(const Variant& other) const
 	case SCRIPTINTERFACE: return DEFAULT_VARIANT_COMPARE(ScriptInterface*);
 	case VOIDPTR: return DEFAULT_VARIANT_COMPARE(void*);
 	case TRANSFORMPTR: return DEFAULT_VARIANT_COMPARE(TransformPtr);
+#ifdef RMLUI_MATH_EXPRESSIONS
+	case CALCULATIONPTR:
+	{
+		const CalculationPtr& lhs = *reinterpret_cast<const CalculationPtr*>(data);
+		const CalculationPtr& rhs = *reinterpret_cast<const CalculationPtr*>(other.data);
+		if (!lhs || !rhs)
+			return lhs == rhs;
+		return *lhs == *rhs;
+	}
+#endif
 	case TRANSITIONLIST: return DEFAULT_VARIANT_COMPARE(TransitionList);
 	case ANIMATIONLIST: return DEFAULT_VARIANT_COMPARE(AnimationList);
 	case DECORATORSPTR: return DEFAULT_VARIANT_COMPARE(DecoratorsPtr);

--- a/Tests/Source/Benchmarks/CMakeLists.txt
+++ b/Tests/Source/Benchmarks/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(TARGET_NAME "rmlui_benchmarks")
 
 add_executable(${TARGET_NAME}
+	Calculation.cpp
 	CustomProperties.cpp
 	DataExpression.cpp
 	Element.cpp

--- a/Tests/Source/Benchmarks/Calculation.cpp
+++ b/Tests/Source/Benchmarks/Calculation.cpp
@@ -1,0 +1,87 @@
+#include "../Common/TestsShell.h"
+#include <RmlUi/Core/ComputedValues.h>
+#include <RmlUi/Core/Context.h>
+#include <RmlUi/Core/ElementDocument.h>
+#include <doctest.h>
+#include <nanobench.h>
+
+using namespace ankerl;
+using namespace Rml;
+
+namespace {
+void ConfigureBench(nanobench::Bench& bench, const char* title)
+{
+	bench.title(title);
+	bench.timeUnit(std::chrono::nanoseconds(1), "ns");
+	bench.minEpochIterations(1000);
+}
+} // namespace
+
+TEST_CASE("calculation")
+{
+	Context* context = TestsShell::GetContext();
+	REQUIRE(context);
+	ElementDocument* document = context->CreateDocument();
+	REQUIRE(document);
+
+	nanobench::Bench parse_bench;
+	ConfigureBench(parse_bench, "Calculation parsing");
+	parse_bench.run("calc/ordinary/number", [&] { nanobench::doNotOptimizeAway(document->SetProperty("opacity", "0.625")); });
+	parse_bench.run("calc/ordinary/length", [&] { nanobench::doNotOptimizeAway(document->SetProperty("border-left-width", "13px")); });
+	parse_bench.run("calc/ordinary/length-percentage", [&] { nanobench::doNotOptimizeAway(document->SetProperty("width", "37%")); });
+	parse_bench.run("calc/ordinary/declaration", [&] { nanobench::doNotOptimizeAway(document->SetProperty("margin", "3px 7% 11px 13%")); });
+
+#ifdef RMLUI_MATH_EXPRESSIONS
+	parse_bench.run("calc/math/definite", [&] { nanobench::doNotOptimizeAway(document->SetProperty("width", "calc(10px + 3px)")); });
+	parse_bench.run("calc/math/affine", [&] { nanobench::doNotOptimizeAway(document->SetProperty("width", "calc(37% - 13px)")); });
+	parse_bench.run("calc/math/tree",
+		[&] { nanobench::doNotOptimizeAway(document->SetProperty("width", "max(calc(20% + 3px), min(240px, calc(70% - 11px)))")); });
+#endif
+
+	REQUIRE(document->SetProperty("width", "131px"));
+	document->UpdateDocument();
+	const auto ordinary_fixed = document->GetComputedValues().width();
+	REQUIRE(document->SetProperty("width", "37%"));
+	document->UpdateDocument();
+	const auto ordinary_percent = document->GetComputedValues().width();
+#ifdef RMLUI_MATH_EXPRESSIONS
+	REQUIRE(ordinary_fixed.type != Style::LengthPercentageAuto::Calculation);
+	REQUIRE(ordinary_percent.type != Style::LengthPercentageAuto::Calculation);
+#endif
+
+	nanobench::Bench layout_bench;
+	ConfigureBench(layout_bench, "Calculation used values");
+	layout_bench.run("calc/layout/ordinary-fixed", [&] { nanobench::doNotOptimizeAway(ResolveValue(ordinary_fixed, 640.f)); });
+	layout_bench.run("calc/layout/ordinary-percentage", [&] { nanobench::doNotOptimizeAway(ResolveValue(ordinary_percent, 640.f)); });
+
+#ifdef RMLUI_MATH_EXPRESSIONS
+	REQUIRE(document->SetProperty("width", "calc(37% - 13px)"));
+	document->UpdateDocument();
+	const auto affine = document->GetComputedValues().width();
+	REQUIRE(document->SetProperty("width", "max(calc(20% + 3px), min(240px, calc(70% - 11px)))"));
+	document->UpdateDocument();
+	const auto tree = document->GetComputedValues().width();
+	REQUIRE(affine.type == Style::LengthPercentageAuto::Calculation);
+	REQUIRE(tree.type == Style::LengthPercentageAuto::Calculation);
+	REQUIRE(bool(affine.calculation));
+	REQUIRE(bool(tree.calculation));
+	const Calculation* affine_identity = affine.calculation.get();
+	const Calculation* tree_identity = tree.calculation.get();
+
+	layout_bench.run("calc/layout/affine", [&] { nanobench::doNotOptimizeAway(ResolveValue(affine, 640.f)); });
+	layout_bench.run("calc/layout/tree", [&] { nanobench::doNotOptimizeAway(ResolveValue(tree, 640.f)); });
+
+	// Repeated used-value resolution operates on the already-parsed immutable residual. Keeping the
+	// same owner identity here catches accidental reparse/replacement in this benchmarked hot path.
+	for (int i = 0; i < 100; ++i)
+	{
+		nanobench::doNotOptimizeAway(ResolveValue(affine, 320.f + float(i)));
+		nanobench::doNotOptimizeAway(ResolveValue(tree, 320.f + float(i)));
+	}
+	CHECK(affine.calculation.get() == affine_identity);
+	CHECK(tree.calculation.get() == tree_identity);
+#endif
+
+	document->Close();
+	TestsShell::ShutdownShell();
+}

--- a/Tests/Source/UnitTests/CMakeLists.txt
+++ b/Tests/Source/UnitTests/CMakeLists.txt
@@ -2,6 +2,8 @@ set(TARGET_NAME "rmlui_unit_tests")
 
 add_executable(${TARGET_NAME}
 	Animation.cpp
+	Calculation.cpp
+	CalculationTypes.cpp
 	Core.cpp
 	CustomProperties.cpp
 	DataBinding.cpp

--- a/Tests/Source/UnitTests/Calculation.cpp
+++ b/Tests/Source/UnitTests/Calculation.cpp
@@ -1,0 +1,3178 @@
+#include "../Common/TestsInterface.h"
+#include "../Common/TestsShell.h"
+#include <RmlUi/Core/Animation.h>
+#include <RmlUi/Core/ComputedValues.h>
+#include <RmlUi/Core/Context.h>
+#include <RmlUi/Core/DecorationTypes.h>
+#include <RmlUi/Core/ElementDocument.h>
+#include <RmlUi/Core/Factory.h>
+#include <RmlUi/Core/StreamMemory.h>
+#include <RmlUi/Core/StyleSheet.h>
+#include <RmlUi/Core/StyleSheetContainer.h>
+#include <RmlUi/Core/Transform.h>
+#include <RmlUi/Core/TransformPrimitive.h>
+#include <algorithm>
+#include <array>
+#include <cstdlib>
+#include <doctest.h>
+#ifdef RMLUI_MATH_EXPRESSIONS
+	#include "../../../Source/Core/CalculationParser.h"
+	#include "../../../Source/Core/CalculationResolver.h"
+	#include "../../../Source/Core/ElementAnimation.h"
+	#include "../../../Source/Core/GeometryBoxShadow.h"
+	#include "../../../Source/Core/PropertyParserAnimation.h"
+	#include <RmlUi/Core/Filter.h>
+	#include <RmlUi/Core/ID.h>
+	#include <RmlUi/Core/PropertyParser.h>
+	#include <RmlUi/Core/PropertyDefinition.h>
+	#include <RmlUi/Core/StyleSheetSpecification.h>
+#endif
+
+using namespace Rml;
+
+namespace {
+
+// WPT-derived test data below is adapted from web-platform-tests/wpt at
+// 5b6a1e61dbf639ebea0b7f19d9df0e313ae5d959 (BSD-3-Clause). Source paths are
+// recorded alongside the adapted cases. Tests requiring unsupported CSS functions, units, or
+// browser-only semantics are intentionally omitted.
+
+struct CalculationCorpusCase {
+	const char* source;
+	const char* expression;
+	const char* expected;
+};
+
+enum class CalculationCorpusTarget {
+	Number,
+	Percentage,
+	Length,
+	LengthPercentage,
+	Angle,
+	Time,
+	LineHeight,
+};
+
+struct InvalidCalculationCorpusCase {
+	const char* source;
+	CalculationCorpusTarget target;
+	const char* expression;
+};
+
+struct WptParseCase {
+	CalculationCorpusTarget target;
+	const char* source;
+	const char* expression;
+};
+
+// Sources:
+//   css/css-values/calc-unit-analysis.html
+//   css/css-values/calc-nesting.html
+//   css/css-values/calc-numbers.html
+//   css/css-values/minmax-number-computed.html
+constexpr CalculationCorpusCase pure_number_cases[] = {
+	{"calc-numbers.html", "calc(2 * 3)", "6"},
+	{"calc-numbers.html", "calc(2 / 4)", "0.5"},
+	{"adapted:calc-nesting.html", "calc(calc(2) * calc(50))", "100"},
+	{"minmax-number-computed.html", "min(1)", "1"},
+	{"minmax-number-computed.html", "max(1)", "1"},
+	{"minmax-number-computed.html", "min(0.2, max(0.1, 0.15))", "0.15"},
+	{"minmax-number-computed.html", "max(0.1, min(0.2, 0.15))", "0.15"},
+	{"minmax-number-computed.html", "calc(min(0.1, 0.2) + 0.05)", "0.15"},
+	{"minmax-number-computed.html", "calc(min(0.1, 0.2) - 0.05)", "0.05"},
+	{"minmax-number-computed.html", "calc(min(0.1, 0.2) * 2)", "0.2"},
+	{"minmax-number-computed.html", "calc(min(0.1, 0.2) / 2)", "0.05"},
+	{"minmax-number-computed.html", "calc(max(0.1, 0.2) + 0.05)", "0.25"},
+	{"minmax-number-computed.html", "calc(max(0.1, 0.2) - 0.05)", "0.15"},
+	{"minmax-number-computed.html", "calc(max(0.1, 0.2) * 2)", "0.4"},
+	{"minmax-number-computed.html", "calc(max(0.1, 0.2) / 2)", "0.1"},
+	{"minmax-number-computed.html", "calc(min(0.1, 0.2) + max(0.1, 0.05))", "0.2"},
+	{"minmax-number-computed.html", "calc(min(0.1, 0.2) - max(0.1, 0.05))", "0"},
+};
+
+// Sources:
+//   css/css-values/calc-unit-analysis.html
+//   css/css-values/calc-invalid-parsing.html
+//   css/css-values/minmax-number-invalid.html
+//   css/css-values/minmax-length-invalid.html
+//   css/css-values/minmax-length-percent-invalid.html
+//   css/css-values/clamp-length-invalid.html
+constexpr InvalidCalculationCorpusCase pure_invalid_cases[] = {
+	{"calc-unit-analysis.html", CalculationCorpusTarget::Length, "calc(0)"},
+	{"calc-unit-analysis.html", CalculationCorpusTarget::Length, "calc(1px + 2)"},
+	{"calc-unit-analysis.html", CalculationCorpusTarget::Length, "calc(2 + 1px)"},
+	{"calc-unit-analysis.html", CalculationCorpusTarget::Length, "calc(1px - 2)"},
+	{"calc-unit-analysis.html", CalculationCorpusTarget::Length, "calc(2 - 1px)"},
+	{"calc-invalid-parsing.html", CalculationCorpusTarget::Length, "calc(7px * up)"},
+	{"calc-invalid-parsing.html", CalculationCorpusTarget::Length, "calc([])"},
+	{"minmax-number-invalid.html", CalculationCorpusTarget::Number, "min()"},
+	{"minmax-number-invalid.html", CalculationCorpusTarget::Number, "min( )"},
+	{"minmax-number-invalid.html", CalculationCorpusTarget::Number, "min(,)"},
+	{"minmax-number-invalid.html", CalculationCorpusTarget::Number, "min(1, )"},
+	{"minmax-number-invalid.html", CalculationCorpusTarget::Number, "min(, 1)"},
+	{"minmax-number-invalid.html", CalculationCorpusTarget::Number, "min(1 + )"},
+	{"minmax-number-invalid.html", CalculationCorpusTarget::Number, "min(1 - )"},
+	{"minmax-number-invalid.html", CalculationCorpusTarget::Number, "min(1 * )"},
+	{"minmax-number-invalid.html", CalculationCorpusTarget::Number, "min(1 / )"},
+	{"minmax-number-invalid.html", CalculationCorpusTarget::Number, "min(1 2)"},
+	{"minmax-number-invalid.html", CalculationCorpusTarget::Number, "min(1, , 2)"},
+	{"minmax-number-invalid.html", CalculationCorpusTarget::Number, "max()"},
+	{"minmax-number-invalid.html", CalculationCorpusTarget::Number, "max( )"},
+	{"minmax-number-invalid.html", CalculationCorpusTarget::Number, "max(,)"},
+	{"minmax-number-invalid.html", CalculationCorpusTarget::Number, "max(1, )"},
+	{"minmax-number-invalid.html", CalculationCorpusTarget::Number, "max(, 1)"},
+	{"minmax-number-invalid.html", CalculationCorpusTarget::Number, "max(1 + )"},
+	{"minmax-number-invalid.html", CalculationCorpusTarget::Number, "max(1 - )"},
+	{"minmax-number-invalid.html", CalculationCorpusTarget::Number, "max(1 * )"},
+	{"minmax-number-invalid.html", CalculationCorpusTarget::Number, "max(1 / )"},
+	{"minmax-number-invalid.html", CalculationCorpusTarget::Number, "max(1 2)"},
+	{"minmax-number-invalid.html", CalculationCorpusTarget::Number, "max(1, , 2)"},
+	{"minmax-number-invalid.html", CalculationCorpusTarget::Number, "min(0px)"},
+	{"minmax-number-invalid.html", CalculationCorpusTarget::Number, "min(1, 1%)"},
+	{"minmax-number-invalid.html", CalculationCorpusTarget::Number, "min(1, 0px)"},
+	{"minmax-number-invalid.html", CalculationCorpusTarget::Number, "max(0px)"},
+	{"minmax-number-invalid.html", CalculationCorpusTarget::Number, "max(1, 1%)"},
+	{"minmax-number-invalid.html", CalculationCorpusTarget::Number, "max(1, 0px)"},
+	{"minmax-length-percent-invalid.html", CalculationCorpusTarget::LengthPercentage, "min(1px, 0)"},
+	{"minmax-length-percent-invalid.html", CalculationCorpusTarget::LengthPercentage, "min(1%, 0)"},
+	{"minmax-length-percent-invalid.html", CalculationCorpusTarget::LengthPercentage, "max(1px, 0)"},
+	{"minmax-length-percent-invalid.html", CalculationCorpusTarget::LengthPercentage, "max(1%, 0)"},
+	{"clamp-length-invalid.html", CalculationCorpusTarget::Length, "clamp()"},
+	{"clamp-length-invalid.html", CalculationCorpusTarget::Length, "clamp( )"},
+	{"clamp-length-invalid.html", CalculationCorpusTarget::Length, "clamp(,)"},
+	{"clamp-length-invalid.html", CalculationCorpusTarget::Length, "clamp(1px, )"},
+	{"clamp-length-invalid.html", CalculationCorpusTarget::Length, "clamp(, 1px)"},
+	{"clamp-length-invalid.html", CalculationCorpusTarget::Length, "clamp(1px, 1px)"},
+	{"clamp-length-invalid.html", CalculationCorpusTarget::Length, "clamp(1px, , 1px)"},
+	{"clamp-length-invalid.html", CalculationCorpusTarget::Length, "clamp(1px, 1px, )"},
+	{"clamp-length-invalid.html", CalculationCorpusTarget::Length, "clamp(1px, 1px, 1px, )"},
+	{"clamp-length-invalid.html", CalculationCorpusTarget::Length, "clamp(1px 1px 1px)"},
+	{"clamp-length-invalid.html", CalculationCorpusTarget::Length, "clamp(none, none, none)"},
+	{"clamp-length-invalid.html", CalculationCorpusTarget::Length, "clamp(none, none + none, none)"},
+	{"clamp-length-invalid.html", CalculationCorpusTarget::Length, "clamp(-none, 1px, 1px)"},
+	{"clamp-length-invalid.html", CalculationCorpusTarget::Length, "clamp(10px, none * none, 20px)"},
+	{"clamp-length-invalid.html", CalculationCorpusTarget::Length, "clamp(10px, 2px + none, 20px)"},
+};
+
+// Sources:
+//   css/css-values/calc-angle-values.html
+// Only deg/rad vectors are in scope because RmlUi does not currently implement grad/turn.
+constexpr CalculationCorpusCase angle_cases[] = {
+	{"calc-angle-values.html", "calc(45deg + 45deg)", "90deg"},
+	{"calc-angle-values.html", "calc(45deg + 1rad)", "102.29578deg"},
+	{"calc-angle-values.html", "calc(45rad + 45rad)", "90rad"},
+	{"calc-angle-values.html", "calc(45deg - 15deg)", "30deg"},
+	{"calc-angle-values.html", "calc(90deg - 1rad)", "32.70422deg"},
+	{"calc-angle-values.html", "calc(45rad - 15rad)", "30rad"},
+	{"calc-angle-values.html", "calc(45deg * 2)", "90deg"},
+	{"calc-angle-values.html", "calc(2 * 45rad)", "90rad"},
+	{"calc-angle-values.html", "calc(90deg / 2)", "45deg"},
+	{"calc-angle-values.html", "calc(90rad / 2)", "45rad"},
+};
+
+// Source: css/css-values/minmax-percentage-computed.html. These rows are basis-independent raw
+// percentages, so these pure cases can be evaluated without a computed-value context.
+constexpr CalculationCorpusCase pure_percentage_cases[] = {
+	{"minmax-percentage-computed.html", "min(1%)", "1%"},
+	{"minmax-percentage-computed.html", "max(1%)", "1%"},
+	{"minmax-percentage-computed.html", "min(20%, max(10%, 15%))", "15%"},
+	{"minmax-percentage-computed.html", "max(10%, min(20%, 15%))", "15%"},
+	{"minmax-percentage-computed.html", "calc(min(10%, 20%) + 5%)", "15%"},
+	{"minmax-percentage-computed.html", "calc(min(10%, 20%) - 5%)", "5%"},
+	{"minmax-percentage-computed.html", "calc(min(10%, 20%) * 2)", "20%"},
+	{"minmax-percentage-computed.html", "calc(min(10%, 20%) / 2)", "5%"},
+	{"minmax-percentage-computed.html", "calc(max(10%, 20%) + 5%)", "25%"},
+	{"minmax-percentage-computed.html", "calc(max(10%, 20%) - 5%)", "15%"},
+	{"minmax-percentage-computed.html", "calc(max(10%, 20%) * 2)", "40%"},
+	{"minmax-percentage-computed.html", "calc(max(10%, 20%) / 2)", "10%"},
+	{"minmax-percentage-computed.html", "calc(min(10%, 20%) + max(10%, 5%))", "20%"},
+	{"minmax-percentage-computed.html", "calc(min(11%, 20%) - max(10%, 5%))", "1%"},
+};
+
+// Source: css/css-values/minmax-length-computed.html. Relative-unit rows require a computed-value
+// context; these are the complete supported absolute-unit rows whose WPT results are pure.
+constexpr CalculationCorpusCase pure_absolute_length_cases[] = {
+	{"minmax-length-computed.html", "min(1px)", "1px"},
+	{"minmax-length-computed.html", "min(1cm)", "1cm"},
+	{"minmax-length-computed.html", "min(1mm)", "1mm"},
+	{"minmax-length-computed.html", "min(1in)", "1in"},
+	{"minmax-length-computed.html", "min(1pc)", "1pc"},
+	{"minmax-length-computed.html", "min(1pt)", "1pt"},
+	{"minmax-length-computed.html", "max(1px)", "1px"},
+	{"minmax-length-computed.html", "max(1cm)", "1cm"},
+	{"minmax-length-computed.html", "max(1mm)", "1mm"},
+	{"minmax-length-computed.html", "max(1in)", "1in"},
+	{"minmax-length-computed.html", "max(1pc)", "1pc"},
+	{"minmax-length-computed.html", "max(1pt)", "1pt"},
+	{"minmax-length-computed.html", "min(1px, 2px)", "1px"},
+	{"minmax-length-computed.html", "min(1cm, 2cm)", "1cm"},
+	{"minmax-length-computed.html", "min(1mm, 2mm)", "1mm"},
+	{"minmax-length-computed.html", "min(1in, 2in)", "1in"},
+	{"minmax-length-computed.html", "min(1pc, 2pc)", "1pc"},
+	{"minmax-length-computed.html", "min(1pt, 2pt)", "1pt"},
+	{"minmax-length-computed.html", "max(1px, 2px)", "2px"},
+	{"minmax-length-computed.html", "max(1cm, 2cm)", "2cm"},
+	{"minmax-length-computed.html", "max(1mm, 2mm)", "2mm"},
+	{"minmax-length-computed.html", "max(1in, 2in)", "2in"},
+	{"minmax-length-computed.html", "max(1pc, 2pc)", "2pc"},
+	{"minmax-length-computed.html", "max(1pt, 2pt)", "2pt"},
+	{"minmax-length-computed.html", "min(95px, 1in)", "95px"},
+	{"minmax-length-computed.html", "max(95px, 1in)", "1in"},
+};
+
+// Source: css/css-values/minmax-angle-computed.html. RmlUi does not support grad/turn units here;
+// all remaining deg/rad rows are pure evaluation cases.
+constexpr CalculationCorpusCase pure_minmax_angle_cases[] = {
+	{"minmax-angle-computed.html", "min(1deg)", "1deg"},
+	{"minmax-angle-computed.html", "min(1rad)", "1rad"},
+	{"minmax-angle-computed.html", "max(1deg)", "1deg"},
+	{"minmax-angle-computed.html", "max(1rad)", "1rad"},
+	{"minmax-angle-computed.html", "min(1deg, 2deg)", "1deg"},
+	{"minmax-angle-computed.html", "min(1rad, 2rad)", "1rad"},
+	{"minmax-angle-computed.html", "max(1deg, 2deg)", "2deg"},
+	{"minmax-angle-computed.html", "max(1rad, 2rad)", "2rad"},
+	{"minmax-angle-computed.html", "min(1.57rad, 95deg)", "1.57rad"},
+	{"minmax-angle-computed.html", "max(1.58rad, 90deg)", "1.58rad"},
+	{"minmax-angle-computed.html", "calc(min(90deg, 1.58rad) * 1.5", "135deg"},
+	{"minmax-angle-computed.html", "calc(min(90deg, 1.58rad) / 2", "45deg"},
+	{"minmax-angle-computed.html", "calc(max(90deg, 1.56rad) * 1.5", "135deg"},
+	{"minmax-angle-computed.html", "calc(max(90deg, 1.56rad) / 2", "45deg"},
+};
+
+// Source: css/css-values/clamp-length-computed.html. The final em/rem rows are context-dependent;
+// every preceding px-only row has a pure expected result.
+constexpr CalculationCorpusCase pure_clamp_length_cases[] = {
+	{"clamp-length-computed.html", "clamp(10px, 20px, 30px)", "20px"},
+	{"clamp-length-computed.html", "clamp(10px, 5px, 30px)", "10px"},
+	{"clamp-length-computed.html", "clamp(10px, 35px, 30px)", "30px"},
+	{"clamp-length-computed.html", "clamp(10px, 35px , 30px)", "30px"},
+	{"clamp-length-computed.html", "clamp(10px, 35px /*foo*/, 30px)", "30px"},
+	{"clamp-length-computed.html", "clamp(10px /* foo */ , 35px, 30px)", "30px"},
+	{"clamp-length-computed.html", "clamp(10px , 35px, 30px)", "30px"},
+	{"clamp-length-computed.html", "clamp(30px, 100px, 20px)", "30px"},
+	{"clamp-length-computed.html", "clamp(-30px, -20px, -10px)", "-20px"},
+	{"clamp-length-computed.html", "clamp(-30px, -100px, -10px)", "-30px"},
+	{"clamp-length-computed.html", "clamp(-30px, 100px, -10px)", "-10px"},
+	{"clamp-length-computed.html", "clamp(-10px, 100px, -30px)", "-10px"},
+	{"clamp-length-computed.html", "clamp(-10px, -100px, -30px)", "-10px"},
+	{"clamp-length-computed.html", "calc(0px + clamp(10px, 20px, 30px))", "20px"},
+	{"clamp-length-computed.html", "calc(0px - clamp(10px, 20px, 30px))", "-20px"},
+	{"clamp-length-computed.html", "calc(0px + clamp(30px, 100px, 20px))", "30px"},
+	{"clamp-length-computed.html", "calc(0px - clamp(30px, 100px, 20px))", "-30px"},
+	{"clamp-length-computed.html", "clamp(none, 30px, 33px)", "30px"},
+	{"clamp-length-computed.html", "clamp(none, 33px, 30px)", "30px"},
+	{"clamp-length-computed.html", "clamp(30px, 33px, none)", "33px"},
+	{"clamp-length-computed.html", "clamp(33px, 30px, none)", "33px"},
+	{"clamp-length-computed.html", "clamp(none, 30px, none)", "30px"},
+};
+
+// Sources:
+//   css/css-values/calc-time-values.html
+//   css/css-values/minmax-time-computed.html
+constexpr CalculationCorpusCase time_cases[] = {
+	{"calc-time-values.html", "calc(4s + 1s)", "5s"},
+	{"calc-time-values.html", "calc(4s + 1ms)", "4.001s"},
+	{"calc-time-values.html", "calc(4ms + 1ms)", "0.005s"},
+	{"calc-time-values.html", "calc(4s - 1s)", "3s"},
+	{"calc-time-values.html", "calc(4s - 1ms)", "3.999s"},
+	{"calc-time-values.html", "calc(4 * 1s)", "4s"},
+	{"calc-time-values.html", "calc(4 * 1ms)", "0.004s"},
+	{"calc-time-values.html", "calc(4s / 2)", "2s"},
+	{"calc-time-values.html", "calc(4ms / 2)", "0.002s"},
+	{"calc-time-values.html", "calc(4000ms)", "4s"},
+	{"minmax-time-computed.html", "min(1s)", "1s"},
+	{"minmax-time-computed.html", "min(1ms)", "1ms"},
+	{"minmax-time-computed.html", "max(1s)", "1s"},
+	{"minmax-time-computed.html", "max(1ms)", "1ms"},
+	{"minmax-time-computed.html", "min(1s, 2s)", "1s"},
+	{"minmax-time-computed.html", "min(1ms, 2ms)", "1ms"},
+	{"minmax-time-computed.html", "max(1s, 2s)", "2s"},
+	{"minmax-time-computed.html", "max(1ms, 2ms)", "2ms"},
+	{"minmax-time-computed.html", "min(1s, 1100ms)", "1s"},
+	{"minmax-time-computed.html", "max(0.9s, 1000ms)", "1000ms"},
+	{"minmax-time-computed.html", "min(2s, max(1s, 1500ms))", "1500ms"},
+	{"minmax-time-computed.html", "max(1000ms, min(2000ms, 1.5s))", "1.5s"},
+	{"minmax-time-computed.html", "calc(min(0.5s, 600ms) + 500ms)", "1s"},
+	{"minmax-time-computed.html", "calc(min(0.6s, 700ms) - 500ms)", "0.1s"},
+	{"minmax-time-computed.html", "calc(min(0.5s, 600ms) * 2)", "1s"},
+	{"minmax-time-computed.html", "calc(min(0.5s, 600ms) / 2)", "0.25s"},
+	{"minmax-time-computed.html", "calc(max(0.5s, 400ms) + 500ms)", "1s"},
+	{"minmax-time-computed.html", "calc(max(0.5s, 400ms) - 400ms)", "0.1s"},
+	{"minmax-time-computed.html", "calc(max(0.5s, 400ms) * 2)", "1s"},
+	{"minmax-time-computed.html", "calc(max(0.5s, 400ms) / 2)", "0.25s"},
+	{"minmax-time-computed.html", "calc(min(0.5s, 600ms) + max(500ms, 0.4s))", "1s"},
+	{"minmax-time-computed.html", "calc(min(0.6s, 700ms) - max(500ms, 0.4s))", "0.1s"},
+	{"minmax-time-computed.html", "min(1s + 100ms, 500ms * 3)", "1.1s"},
+	{"minmax-time-computed.html", "calc(min(1s, 2s) + max(3s, 4s) + 10s)", "15s"},
+};
+
+// Source: css/css-values/minmax-time-invalid.html. Rows using Hz/dpi/fr are excluded by the
+// unsupported-unit cases are omitted; every remaining adapted row is executable.
+constexpr const char* time_invalid_cases[] = {
+	"min()",
+	"min( )",
+	"min(,)",
+	"min(1mt)",
+	"min(1s, )",
+	"min(, 1s)",
+	"min(1s + )",
+	"min(1s - )",
+	"min(1s * )",
+	"min(1s / )",
+	"min(1s 2s)",
+	"min(1s, , 2s)",
+	"max()",
+	"max( )",
+	"max(,)",
+	"max(1dag)",
+	"max(1s, )",
+	"max(, 1s)",
+	"max(1s + )",
+	"max(1s - )",
+	"max(1s * )",
+	"max(1s / )",
+	"max(1s 2s)",
+	"max(1s, , 2s)",
+	"min(0)",
+	"min(0%)",
+	"min(0px)",
+	"min(0deg)",
+	"min(1s, 0)",
+	"min(1s, 0%)",
+	"min(1s, 0px)",
+	"min(1s, 0deg)",
+	"max(0)",
+	"max(0%)",
+	"max(0px)",
+	"max(0deg)",
+	"max(1s, 0)",
+	"max(1s, 0%)",
+	"max(1s, 0px)",
+	"max(1s, 0deg)",
+};
+
+constexpr CalculationCorpusCase time_clamp_cases[] = {
+	{"plan-required", "clamp(1s, 2s, 3s)", "2s"},
+	{"plan-required", "clamp(none, 2s, 3s)", "2s"},
+	{"plan-required", "clamp(1s, 2s, none)", "2s"},
+	{"plan-required", "clamp(none, 2s, none)", "2s"},
+	{"plan-required", "clamp(3s, 2s, 1s)", "3s"},
+};
+
+// Sources:
+//   css/css-values/minmax-length-computed.html
+//   css/css-values/clamp-length-computed.html
+constexpr CalculationCorpusCase definite_length_cases[] = {
+	{"minmax-length-computed.html", "min(1px, 2px)", "1px"},
+	{"minmax-length-computed.html", "max(1px, 2px)", "2px"},
+	{"minmax-length-computed.html", "min(95px, 1in)", "95px"},
+	{"minmax-length-computed.html", "max(95px, 1in)", "96px"},
+	{"minmax-length-computed.html", "min(15px, 1em)", "15px"},
+	{"minmax-length-computed.html", "min(25px, 1em)", "20px"},
+	{"minmax-length-computed.html", "max(15px, 1em)", "20px"},
+	{"minmax-length-computed.html", "max(25px, 1em)", "25px"},
+	{"minmax-length-computed.html", "min(25px, max(15px, 1em))", "20px"},
+	{"minmax-length-computed.html", "max(15px, min(25px, 1em))", "20px"},
+	{"minmax-length-computed.html", "calc(min(1em, 21px) + 10px)", "30px"},
+	{"minmax-length-computed.html", "calc(min(1em, 21px) - 10px)", "10px"},
+	{"minmax-length-computed.html", "calc(max(1em, 19px) + 10px)", "30px"},
+	{"adapted:minmax-length-computed.html", "calc(max(1em, 19px) / 2)", "10px"},
+	{"clamp-length-computed.html", "clamp(10px, 20px, 30px)", "20px"},
+	{"clamp-length-computed.html", "clamp(10px, 5px, 30px)", "10px"},
+	{"clamp-length-computed.html", "clamp(10px, 35px, 30px)", "30px"},
+	{"clamp-length-computed.html", "clamp(30px, 100px, 20px)", "30px"},
+	{"clamp-length-computed.html", "clamp(-30px, -20px, -10px)", "-20px"},
+	{"clamp-length-computed.html", "calc(0px - clamp(10px, 20px, 30px))", "-20px"},
+	{"clamp-length-computed.html", "clamp(none, 30px, 33px)", "30px"},
+	{"clamp-length-computed.html", "clamp(none, 33px, 30px)", "30px"},
+	{"clamp-length-computed.html", "clamp(30px, 33px, none)", "33px"},
+	{"clamp-length-computed.html", "clamp(33px, 30px, none)", "33px"},
+	{"clamp-length-computed.html", "clamp(none, 30px, none)", "30px"},
+};
+
+// Sources:
+//   css/css-values/minmax-length-percent-computed.html
+//   css/css-values/max-20-arguments.html
+//   css/css-values/calc-nesting.html
+constexpr CalculationCorpusCase used_length_percentage_cases[] = {
+	{"minmax-length-percent-computed.html", "min(20px, 10%)", "basis 400px -> 20px; basis 100px -> 10px"},
+	{"minmax-length-percent-computed.html", "max(20px, 10%)", "basis 400px -> 40px; basis 100px -> 20px"},
+	{"minmax-length-percent-computed.html", "min(30px + 10%, 60px + 5%)", "basis 400px -> 70px"},
+	{"minmax-length-percent-computed.html", "max(2em + 10%, 1em + 20%)", "font 20px/basis 400px -> 100px"},
+	{"minmax-length-percent-computed.html", "calc(min(1.5em, 10%) + 10px)", "font 20px/basis 400px -> 40px"},
+	{"minmax-length-percent-computed.html", "calc(min(1.5em, 10%) - 10px)", "font 20px/basis 400px -> 20px"},
+	{"minmax-length-percent-computed.html", "calc(min(1.5em, 10%) * 2)", "font 20px/basis 400px -> 60px"},
+	{"minmax-length-percent-computed.html", "calc(min(1.5em, 10%) / 2)", "font 20px/basis 400px -> 15px"},
+	{"minmax-length-percent-computed.html", "calc(max(1em, 15%) + 10px)", "font 20px/basis 400px -> 70px"},
+	{"minmax-length-percent-computed.html", "calc(max(1em, 15%) / 2)", "font 20px/basis 400px -> 30px"},
+	{"max-20-arguments.html", "max(5%, 10%, 15%, 20%, 25%, 30%, 35%, 40%, 45%, 50%, 55%, 60%, 65%, 70%, 75%, 80%, 85%, 90%, 95%, 100%)", "100%"},
+	{"calc-nesting.html", "calc(calc(60%) - 20px)", "nested length-percentage"},
+	{"calc-nesting.html", "calc(calc(3 * 25%))", "75%"},
+};
+
+// Sources:
+//   css/css-values/clamp-none-whitespace.html
+constexpr const char* clamp_none_whitespace_cases[] = {
+	"clamp(none, 5px, 10px)",
+	"clamp(none , 5px, 10px)",
+	"clamp(5px, 6px, none)",
+	"clamp(5px, 6px, none )",
+	"clamp(none, 5px, none)",
+	"clamp( none , 5px , none )",
+};
+
+// Sources:
+//   css/css-values/typed_arithmetic.html
+// These are the finite, in-scope dimensional-cancellation vectors. sign()/pow()/NaN/infinity rows
+// from the WPT source use unsupported functions and are intentionally omitted.
+constexpr CalculationCorpusCase typed_arithmetic_cases[] = {
+	{"typed_arithmetic.html", "min(1em, 110px / 10px * 1px)", "font 20px -> 10px"},
+	{"typed_arithmetic.html", "max(10px, 110px / 10px * 1px)", "11px"},
+	{"typed_arithmetic.html", "max(1em + 2px, 110px / 10px * 1px)", "font 10px -> 12px"},
+	{"typed_arithmetic.html", "calc(10em / 1em)", "10"},
+	{"typed_arithmetic.html", "calc(10em / 1rem)", "context-equal em/rem -> 10"},
+	{"typed_arithmetic.html", "calc(1px * 2deg / 1deg)", "2px"},
+	{"typed_arithmetic.html", "calc(1px * 3deg / 1deg / 1px)", "3"},
+};
+
+// Targeted owning-property source outside css/css-values:
+//   css/css-inline/parsing/line-height-computed.html
+constexpr CalculationCorpusCase line_height_cases[] = {
+	{"line-height-computed.html", "calc(200% + 10px)", "font 40px -> 90px"},
+	{"line-height-computed.html", "calc(10px - 0.5em)", "font 40px -> -10px then existing line-height range behavior"},
+	{"line-height-computed.html", "calc(10px + 0.5em)", "font 40px -> 30px"},
+	{"plan-required", "calc(200%)", "font 40px -> 80px final Length"},
+	{"plan-required", "calc(2)", "final Number 2"},
+};
+
+// Exhaustive adapted parser/type rows from the supported WPT math-function corpus. Context-dependent
+// rows assert parse/type behavior here and are covered separately by computed/used-value fixtures.
+constexpr WptParseCase wpt_valid_parse_cases[] = {
+	// css/css-values/minmax-number-computed.html
+	{CalculationCorpusTarget::Number, "minmax-number-computed.html", "min(1)"},
+	{CalculationCorpusTarget::Number, "minmax-number-computed.html", "max(1)"},
+	{CalculationCorpusTarget::Number, "minmax-number-computed.html", "min(0.2, max(0.1, 0.15))"},
+	{CalculationCorpusTarget::Number, "minmax-number-computed.html", "max(0.1, min(0.2, 0.15))"},
+	{CalculationCorpusTarget::Number, "minmax-number-computed.html", "calc(min(0.1, 0.2) + 0.05)"},
+	{CalculationCorpusTarget::Number, "minmax-number-computed.html", "calc(min(0.1, 0.2) - 0.05)"},
+	{CalculationCorpusTarget::Number, "minmax-number-computed.html", "calc(min(0.1, 0.2) * 2)"},
+	{CalculationCorpusTarget::Number, "minmax-number-computed.html", "calc(min(0.1, 0.2) / 2)"},
+	{CalculationCorpusTarget::Number, "minmax-number-computed.html", "calc(max(0.1, 0.2) + 0.05)"},
+	{CalculationCorpusTarget::Number, "minmax-number-computed.html", "calc(max(0.1, 0.2) - 0.05)"},
+	{CalculationCorpusTarget::Number, "minmax-number-computed.html", "calc(max(0.1, 0.2) * 2)"},
+	{CalculationCorpusTarget::Number, "minmax-number-computed.html", "calc(max(0.1, 0.2) / 2)"},
+	{CalculationCorpusTarget::Number, "minmax-number-computed.html", "calc(min(0.1, 0.2) + max(0.1, 0.05))"},
+	{CalculationCorpusTarget::Number, "minmax-number-computed.html", "calc(min(0.1, 0.2) - max(0.1, 0.05))"},
+
+	// css/css-values/minmax-percentage-computed.html
+	{CalculationCorpusTarget::Percentage, "minmax-percentage-computed.html", "min(1%)"},
+	{CalculationCorpusTarget::Percentage, "minmax-percentage-computed.html", "max(1%)"},
+	{CalculationCorpusTarget::Percentage, "minmax-percentage-computed.html", "min(20%, max(10%, 15%))"},
+	{CalculationCorpusTarget::Percentage, "minmax-percentage-computed.html", "max(10%, min(20%, 15%))"},
+	{CalculationCorpusTarget::Percentage, "minmax-percentage-computed.html", "calc(min(10%, 20%) + 5%)"},
+	{CalculationCorpusTarget::Percentage, "minmax-percentage-computed.html", "calc(min(10%, 20%) - 5%)"},
+	{CalculationCorpusTarget::Percentage, "minmax-percentage-computed.html", "calc(min(10%, 20%) * 2)"},
+	{CalculationCorpusTarget::Percentage, "minmax-percentage-computed.html", "calc(min(10%, 20%) / 2)"},
+	{CalculationCorpusTarget::Percentage, "minmax-percentage-computed.html", "calc(max(10%, 20%) + 5%)"},
+	{CalculationCorpusTarget::Percentage, "minmax-percentage-computed.html", "calc(max(10%, 20%) - 5%)"},
+	{CalculationCorpusTarget::Percentage, "minmax-percentage-computed.html", "calc(max(10%, 20%) * 2)"},
+	{CalculationCorpusTarget::Percentage, "minmax-percentage-computed.html", "calc(max(10%, 20%) / 2)"},
+	{CalculationCorpusTarget::Percentage, "minmax-percentage-computed.html", "calc(min(10%, 20%) + max(10%, 5%))"},
+	{CalculationCorpusTarget::Percentage, "minmax-percentage-computed.html", "calc(min(11%, 20%) - max(10%, 5%))"},
+
+	// css/css-values/minmax-length-computed.html, excluding unsupported Q/ex/ch/vmin/vmax rows.
+	{CalculationCorpusTarget::Length, "minmax-length-computed.html", "min(1px)"},
+	{CalculationCorpusTarget::Length, "minmax-length-computed.html", "min(1cm)"},
+	{CalculationCorpusTarget::Length, "minmax-length-computed.html", "min(1mm)"},
+	{CalculationCorpusTarget::Length, "minmax-length-computed.html", "min(1in)"},
+	{CalculationCorpusTarget::Length, "minmax-length-computed.html", "min(1pc)"},
+	{CalculationCorpusTarget::Length, "minmax-length-computed.html", "min(1pt)"},
+	{CalculationCorpusTarget::Length, "minmax-length-computed.html", "min(1em)"},
+	{CalculationCorpusTarget::Length, "minmax-length-computed.html", "min(1rem)"},
+	{CalculationCorpusTarget::Length, "minmax-length-computed.html", "min(1vh)"},
+	{CalculationCorpusTarget::Length, "minmax-length-computed.html", "min(1vw)"},
+	{CalculationCorpusTarget::Length, "minmax-length-computed.html", "max(1px)"},
+	{CalculationCorpusTarget::Length, "minmax-length-computed.html", "max(1cm)"},
+	{CalculationCorpusTarget::Length, "minmax-length-computed.html", "max(1mm)"},
+	{CalculationCorpusTarget::Length, "minmax-length-computed.html", "max(1in)"},
+	{CalculationCorpusTarget::Length, "minmax-length-computed.html", "max(1pc)"},
+	{CalculationCorpusTarget::Length, "minmax-length-computed.html", "max(1pt)"},
+	{CalculationCorpusTarget::Length, "minmax-length-computed.html", "max(1em)"},
+	{CalculationCorpusTarget::Length, "minmax-length-computed.html", "max(1rem)"},
+	{CalculationCorpusTarget::Length, "minmax-length-computed.html", "max(1vh)"},
+	{CalculationCorpusTarget::Length, "minmax-length-computed.html", "max(1vw)"},
+	{CalculationCorpusTarget::Length, "minmax-length-computed.html", "min(1px, 2px)"},
+	{CalculationCorpusTarget::Length, "minmax-length-computed.html", "min(1cm, 2cm)"},
+	{CalculationCorpusTarget::Length, "minmax-length-computed.html", "min(1mm, 2mm)"},
+	{CalculationCorpusTarget::Length, "minmax-length-computed.html", "min(1in, 2in)"},
+	{CalculationCorpusTarget::Length, "minmax-length-computed.html", "min(1pc, 2pc)"},
+	{CalculationCorpusTarget::Length, "minmax-length-computed.html", "min(1pt, 2pt)"},
+	{CalculationCorpusTarget::Length, "minmax-length-computed.html", "min(1em, 2em)"},
+	{CalculationCorpusTarget::Length, "minmax-length-computed.html", "min(1rem, 2rem)"},
+	{CalculationCorpusTarget::Length, "minmax-length-computed.html", "min(1vh, 2vh)"},
+	{CalculationCorpusTarget::Length, "minmax-length-computed.html", "min(1vw, 2vw)"},
+	{CalculationCorpusTarget::Length, "minmax-length-computed.html", "max(1px, 2px)"},
+	{CalculationCorpusTarget::Length, "minmax-length-computed.html", "max(1cm, 2cm)"},
+	{CalculationCorpusTarget::Length, "minmax-length-computed.html", "max(1mm, 2mm)"},
+	{CalculationCorpusTarget::Length, "minmax-length-computed.html", "max(1in, 2in)"},
+	{CalculationCorpusTarget::Length, "minmax-length-computed.html", "max(1pc, 2pc)"},
+	{CalculationCorpusTarget::Length, "minmax-length-computed.html", "max(1pt, 2pt)"},
+	{CalculationCorpusTarget::Length, "minmax-length-computed.html", "max(1em, 2em)"},
+	{CalculationCorpusTarget::Length, "minmax-length-computed.html", "max(1rem, 2rem)"},
+	{CalculationCorpusTarget::Length, "minmax-length-computed.html", "max(1vh, 2vh)"},
+	{CalculationCorpusTarget::Length, "minmax-length-computed.html", "max(1vw, 2vw)"},
+	{CalculationCorpusTarget::Length, "minmax-length-computed.html", "min(95px, 1in)"},
+	{CalculationCorpusTarget::Length, "minmax-length-computed.html", "max(95px, 1in)"},
+	{CalculationCorpusTarget::Length, "minmax-length-computed.html", "min(15px, 1em)"},
+	{CalculationCorpusTarget::Length, "minmax-length-computed.html", "min(25px, 1em)"},
+	{CalculationCorpusTarget::Length, "minmax-length-computed.html", "max(15px, 1em)"},
+	{CalculationCorpusTarget::Length, "minmax-length-computed.html", "max(25px, 1em)"},
+	{CalculationCorpusTarget::Length, "minmax-length-computed.html", "min(15px, 1em)"},
+	{CalculationCorpusTarget::Length, "minmax-length-computed.html", "max(15px, 2em)"},
+	{CalculationCorpusTarget::Length, "minmax-length-computed.html", "min(25px, max(15px, 1em))"},
+	{CalculationCorpusTarget::Length, "minmax-length-computed.html", "max(15px, min(25px, 1em))"},
+	{CalculationCorpusTarget::Length, "minmax-length-computed.html", "calc(min(1em, 21px) + 10px)"},
+	{CalculationCorpusTarget::Length, "minmax-length-computed.html", "calc(min(1em, 21px) - 10px)"},
+	{CalculationCorpusTarget::Length, "minmax-length-computed.html", "calc(min(1em, 21px) * 2"},
+	{CalculationCorpusTarget::Length, "minmax-length-computed.html", "calc(min(1em, 21px) / 2"},
+	{CalculationCorpusTarget::Length, "minmax-length-computed.html", "calc(max(1em, 19px) + 10px)"},
+	{CalculationCorpusTarget::Length, "minmax-length-computed.html", "calc(max(1em, 19px) - 10px)"},
+	{CalculationCorpusTarget::Length, "minmax-length-computed.html", "calc(max(1em, 19px) * 2"},
+	{CalculationCorpusTarget::Length, "minmax-length-computed.html", "calc(max(1em, 19px) / 2"},
+	{CalculationCorpusTarget::Length, "minmax-length-computed.html", "calc(min(1em, 21px) + max(0.9em, 20px))"},
+	{CalculationCorpusTarget::Length, "minmax-length-computed.html", "calc(min(1em + 1px, 22px) - max(0.9em, 20px))"},
+
+	// css/css-values/minmax-length-percent-computed.html, same supported-unit filter.
+	{CalculationCorpusTarget::LengthPercentage, "minmax-length-percent-computed.html", "min(1px + 1%)"},
+	{CalculationCorpusTarget::LengthPercentage, "minmax-length-percent-computed.html", "min(1cm + 1%)"},
+	{CalculationCorpusTarget::LengthPercentage, "minmax-length-percent-computed.html", "min(1mm + 1%)"},
+	{CalculationCorpusTarget::LengthPercentage, "minmax-length-percent-computed.html", "min(1in + 1%)"},
+	{CalculationCorpusTarget::LengthPercentage, "minmax-length-percent-computed.html", "min(1pc + 1%)"},
+	{CalculationCorpusTarget::LengthPercentage, "minmax-length-percent-computed.html", "min(1pt + 1%)"},
+	{CalculationCorpusTarget::LengthPercentage, "minmax-length-percent-computed.html", "min(1em + 1%)"},
+	{CalculationCorpusTarget::LengthPercentage, "minmax-length-percent-computed.html", "min(1rem + 1%)"},
+	{CalculationCorpusTarget::LengthPercentage, "minmax-length-percent-computed.html", "min(1vh + 1%)"},
+	{CalculationCorpusTarget::LengthPercentage, "minmax-length-percent-computed.html", "min(1vw + 1%)"},
+	{CalculationCorpusTarget::LengthPercentage, "minmax-length-percent-computed.html", "max(1px + 1%)"},
+	{CalculationCorpusTarget::LengthPercentage, "minmax-length-percent-computed.html", "max(1cm + 1%)"},
+	{CalculationCorpusTarget::LengthPercentage, "minmax-length-percent-computed.html", "max(1mm + 1%)"},
+	{CalculationCorpusTarget::LengthPercentage, "minmax-length-percent-computed.html", "max(1in + 1%)"},
+	{CalculationCorpusTarget::LengthPercentage, "minmax-length-percent-computed.html", "max(1pc + 1%)"},
+	{CalculationCorpusTarget::LengthPercentage, "minmax-length-percent-computed.html", "max(1pt + 1%)"},
+	{CalculationCorpusTarget::LengthPercentage, "minmax-length-percent-computed.html", "max(1em + 1%)"},
+	{CalculationCorpusTarget::LengthPercentage, "minmax-length-percent-computed.html", "max(1rem + 1%)"},
+	{CalculationCorpusTarget::LengthPercentage, "minmax-length-percent-computed.html", "max(1vh + 1%)"},
+	{CalculationCorpusTarget::LengthPercentage, "minmax-length-percent-computed.html", "max(1vw + 1%)"},
+	{CalculationCorpusTarget::LengthPercentage, "minmax-length-percent-computed.html", "min(20px, 10%)"},
+	{CalculationCorpusTarget::LengthPercentage, "minmax-length-percent-computed.html", "min(1em, 10%)"},
+	{CalculationCorpusTarget::LengthPercentage, "minmax-length-percent-computed.html", "max(20px, 10%)"},
+	{CalculationCorpusTarget::LengthPercentage, "minmax-length-percent-computed.html", "max(1em, 10%)"},
+	{CalculationCorpusTarget::LengthPercentage, "minmax-length-percent-computed.html", "min(20px, 10%)"},
+	{CalculationCorpusTarget::LengthPercentage, "minmax-length-percent-computed.html", "min(1em, 10%)"},
+	{CalculationCorpusTarget::LengthPercentage, "minmax-length-percent-computed.html", "max(20px, 10%)"},
+	{CalculationCorpusTarget::LengthPercentage, "minmax-length-percent-computed.html", "max(1em, 10%)"},
+	{CalculationCorpusTarget::LengthPercentage, "minmax-length-percent-computed.html", "min(30px + 10%, 60px + 5%)"},
+	{CalculationCorpusTarget::LengthPercentage, "minmax-length-percent-computed.html", "max(2em + 10%, 1em + 20%)"},
+	{CalculationCorpusTarget::LengthPercentage, "minmax-length-percent-computed.html", "calc(min(1.5em, 10%) + 10px)"},
+	{CalculationCorpusTarget::LengthPercentage, "minmax-length-percent-computed.html", "calc(min(1.5em, 10%) - 10px)"},
+	{CalculationCorpusTarget::LengthPercentage, "minmax-length-percent-computed.html", "calc(min(1.5em, 10%) * 2)"},
+	{CalculationCorpusTarget::LengthPercentage, "minmax-length-percent-computed.html", "calc(min(1.5em, 10%) / 2)"},
+	{CalculationCorpusTarget::LengthPercentage, "minmax-length-percent-computed.html", "calc(max(1em, 15%) + 10px)"},
+	{CalculationCorpusTarget::LengthPercentage, "minmax-length-percent-computed.html", "calc(max(1em, 15%) - 10px)"},
+	{CalculationCorpusTarget::LengthPercentage, "minmax-length-percent-computed.html", "calc(max(1em, 15%) * 2)"},
+	{CalculationCorpusTarget::LengthPercentage, "minmax-length-percent-computed.html", "calc(max(1em, 15%) / 2)"},
+	{CalculationCorpusTarget::LengthPercentage, "minmax-length-percent-computed.html", "calc(min(1.5em, 10%) + max(1em, 15%))"},
+	{CalculationCorpusTarget::LengthPercentage, "minmax-length-percent-computed.html", "calc(min(1.5em, 10%) - max(1em, 15%))"},
+
+	// css/css-values/minmax-angle-computed.html, excluding grad/turn rows.
+	{CalculationCorpusTarget::Angle, "minmax-angle-computed.html", "min(1deg)"},
+	{CalculationCorpusTarget::Angle, "minmax-angle-computed.html", "min(1rad)"},
+	{CalculationCorpusTarget::Angle, "minmax-angle-computed.html", "max(1deg)"},
+	{CalculationCorpusTarget::Angle, "minmax-angle-computed.html", "max(1rad)"},
+	{CalculationCorpusTarget::Angle, "minmax-angle-computed.html", "min(1deg, 2deg)"},
+	{CalculationCorpusTarget::Angle, "minmax-angle-computed.html", "min(1rad, 2rad)"},
+	{CalculationCorpusTarget::Angle, "minmax-angle-computed.html", "max(1deg, 2deg)"},
+	{CalculationCorpusTarget::Angle, "minmax-angle-computed.html", "max(1rad, 2rad)"},
+	{CalculationCorpusTarget::Angle, "minmax-angle-computed.html", "min(1.57rad, 95deg)"},
+	{CalculationCorpusTarget::Angle, "minmax-angle-computed.html", "max(1.58rad, 90deg)"},
+	{CalculationCorpusTarget::Angle, "minmax-angle-computed.html", "calc(min(90deg, 1.58rad) * 1.5"},
+	{CalculationCorpusTarget::Angle, "minmax-angle-computed.html", "calc(min(90deg, 1.58rad) / 2"},
+	{CalculationCorpusTarget::Angle, "minmax-angle-computed.html", "calc(max(90deg, 1.56rad) * 1.5"},
+	{CalculationCorpusTarget::Angle, "minmax-angle-computed.html", "calc(max(90deg, 1.56rad) / 2"},
+
+	// css/css-values/clamp-length-computed.html
+	{CalculationCorpusTarget::Length, "clamp-length-computed.html", "clamp(10px, 20px, 30px)"},
+	{CalculationCorpusTarget::Length, "clamp-length-computed.html", "clamp(10px, 5px, 30px)"},
+	{CalculationCorpusTarget::Length, "clamp-length-computed.html", "clamp(10px, 35px, 30px)"},
+	{CalculationCorpusTarget::Length, "clamp-length-computed.html", "clamp(10px, 35px , 30px)"},
+	{CalculationCorpusTarget::Length, "clamp-length-computed.html", "clamp(10px, 35px /*foo*/, 30px)"},
+	{CalculationCorpusTarget::Length, "clamp-length-computed.html", "clamp(10px /* foo */ , 35px, 30px)"},
+	{CalculationCorpusTarget::Length, "clamp-length-computed.html", "clamp(10px , 35px, 30px)"},
+	{CalculationCorpusTarget::Length, "clamp-length-computed.html", "clamp(30px, 100px, 20px)"},
+	{CalculationCorpusTarget::Length, "clamp-length-computed.html", "clamp(-30px, -20px, -10px)"},
+	{CalculationCorpusTarget::Length, "clamp-length-computed.html", "clamp(-30px, -100px, -10px)"},
+	{CalculationCorpusTarget::Length, "clamp-length-computed.html", "clamp(-30px, 100px, -10px)"},
+	{CalculationCorpusTarget::Length, "clamp-length-computed.html", "clamp(-10px, 100px, -30px)"},
+	{CalculationCorpusTarget::Length, "clamp-length-computed.html", "clamp(-10px, -100px, -30px)"},
+	{CalculationCorpusTarget::Length, "clamp-length-computed.html", "calc(0px + clamp(10px, 20px, 30px))"},
+	{CalculationCorpusTarget::Length, "clamp-length-computed.html", "calc(0px - clamp(10px, 20px, 30px))"},
+	{CalculationCorpusTarget::Length, "clamp-length-computed.html", "calc(0px + clamp(30px, 100px, 20px))"},
+	{CalculationCorpusTarget::Length, "clamp-length-computed.html", "calc(0px - clamp(30px, 100px, 20px))"},
+	{CalculationCorpusTarget::Length, "clamp-length-computed.html", "clamp(none, 30px, 33px)"},
+	{CalculationCorpusTarget::Length, "clamp-length-computed.html", "clamp(none, 33px, 30px)"},
+	{CalculationCorpusTarget::Length, "clamp-length-computed.html", "clamp(30px, 33px, none)"},
+	{CalculationCorpusTarget::Length, "clamp-length-computed.html", "clamp(33px, 30px, none)"},
+	{CalculationCorpusTarget::Length, "clamp-length-computed.html", "clamp(none, 30px, none)"},
+	{CalculationCorpusTarget::Length, "clamp-length-computed.html", "clamp(1000px, 1em / 1rem * 1px, none)"},
+	{CalculationCorpusTarget::Length, "clamp-length-computed.html", "clamp(1600px / 1em * 1px, 1em / 1rem * 1px, none)"},
+};
+
+constexpr WptParseCase wpt_invalid_parse_cases[] = {
+	// css/css-values/minmax-number-invalid.html, excluding unsupported Hz/dpi/fr rows.
+	{CalculationCorpusTarget::Number, "minmax-number-invalid.html", "min()"},
+	{CalculationCorpusTarget::Number, "minmax-number-invalid.html", "min( )"},
+	{CalculationCorpusTarget::Number, "minmax-number-invalid.html", "min(,)"},
+	{CalculationCorpusTarget::Number, "minmax-number-invalid.html", "min(1, )"},
+	{CalculationCorpusTarget::Number, "minmax-number-invalid.html", "min(, 1)"},
+	{CalculationCorpusTarget::Number, "minmax-number-invalid.html", "min(1 + )"},
+	{CalculationCorpusTarget::Number, "minmax-number-invalid.html", "min(1 - )"},
+	{CalculationCorpusTarget::Number, "minmax-number-invalid.html", "min(1 * )"},
+	{CalculationCorpusTarget::Number, "minmax-number-invalid.html", "min(1 / )"},
+	{CalculationCorpusTarget::Number, "minmax-number-invalid.html", "min(1 2)"},
+	{CalculationCorpusTarget::Number, "minmax-number-invalid.html", "min(1, , 2)"},
+	{CalculationCorpusTarget::Number, "minmax-number-invalid.html", "max()"},
+	{CalculationCorpusTarget::Number, "minmax-number-invalid.html", "max( )"},
+	{CalculationCorpusTarget::Number, "minmax-number-invalid.html", "max(,)"},
+	{CalculationCorpusTarget::Number, "minmax-number-invalid.html", "max(1, )"},
+	{CalculationCorpusTarget::Number, "minmax-number-invalid.html", "max(, 1)"},
+	{CalculationCorpusTarget::Number, "minmax-number-invalid.html", "max(1 + )"},
+	{CalculationCorpusTarget::Number, "minmax-number-invalid.html", "max(1 - )"},
+	{CalculationCorpusTarget::Number, "minmax-number-invalid.html", "max(1 * )"},
+	{CalculationCorpusTarget::Number, "minmax-number-invalid.html", "max(1 / )"},
+	{CalculationCorpusTarget::Number, "minmax-number-invalid.html", "max(1 2)"},
+	{CalculationCorpusTarget::Number, "minmax-number-invalid.html", "max(1, , 2)"},
+	{CalculationCorpusTarget::Number, "minmax-number-invalid.html", "min(0px)"},
+	{CalculationCorpusTarget::Number, "minmax-number-invalid.html", "min(0s)"},
+	{CalculationCorpusTarget::Number, "minmax-number-invalid.html", "min(0deg)"},
+	{CalculationCorpusTarget::Number, "minmax-number-invalid.html", "min(1, 1%)"},
+	{CalculationCorpusTarget::Number, "minmax-number-invalid.html", "min(1, 0px)"},
+	{CalculationCorpusTarget::Number, "minmax-number-invalid.html", "min(1, 0s)"},
+	{CalculationCorpusTarget::Number, "minmax-number-invalid.html", "min(1, 0deg)"},
+	{CalculationCorpusTarget::Number, "minmax-number-invalid.html", "max(0px)"},
+	{CalculationCorpusTarget::Number, "minmax-number-invalid.html", "max(0s)"},
+	{CalculationCorpusTarget::Number, "minmax-number-invalid.html", "max(0deg)"},
+	{CalculationCorpusTarget::Number, "minmax-number-invalid.html", "max(1, 1%)"},
+	{CalculationCorpusTarget::Number, "minmax-number-invalid.html", "max(1, 0px)"},
+	{CalculationCorpusTarget::Number, "minmax-number-invalid.html", "max(1, 0s)"},
+	{CalculationCorpusTarget::Number, "minmax-number-invalid.html", "max(1, 0deg)"},
+
+	// css/css-values/minmax-percentage-invalid.html, excluding unsupported Hz/dpi/fr rows.
+	{CalculationCorpusTarget::Percentage, "minmax-percentage-invalid.html", "min()"},
+	{CalculationCorpusTarget::Percentage, "minmax-percentage-invalid.html", "min( )"},
+	{CalculationCorpusTarget::Percentage, "minmax-percentage-invalid.html", "min(,)"},
+	{CalculationCorpusTarget::Percentage, "minmax-percentage-invalid.html", "min(1#)"},
+	{CalculationCorpusTarget::Percentage, "minmax-percentage-invalid.html", "min(%1)"},
+	{CalculationCorpusTarget::Percentage, "minmax-percentage-invalid.html", "min(1%, )"},
+	{CalculationCorpusTarget::Percentage, "minmax-percentage-invalid.html", "min(, 1%)"},
+	{CalculationCorpusTarget::Percentage, "minmax-percentage-invalid.html", "min(1% + )"},
+	{CalculationCorpusTarget::Percentage, "minmax-percentage-invalid.html", "min(1% - )"},
+	{CalculationCorpusTarget::Percentage, "minmax-percentage-invalid.html", "min(1% * )"},
+	{CalculationCorpusTarget::Percentage, "minmax-percentage-invalid.html", "min(1% / )"},
+	{CalculationCorpusTarget::Percentage, "minmax-percentage-invalid.html", "min(1% 2%)"},
+	{CalculationCorpusTarget::Percentage, "minmax-percentage-invalid.html", "min(1%, , 2%)"},
+	{CalculationCorpusTarget::Percentage, "minmax-percentage-invalid.html", "max()"},
+	{CalculationCorpusTarget::Percentage, "minmax-percentage-invalid.html", "max( )"},
+	{CalculationCorpusTarget::Percentage, "minmax-percentage-invalid.html", "max(,)"},
+	{CalculationCorpusTarget::Percentage, "minmax-percentage-invalid.html", "max(1#)"},
+	{CalculationCorpusTarget::Percentage, "minmax-percentage-invalid.html", "max(%1)"},
+	{CalculationCorpusTarget::Percentage, "minmax-percentage-invalid.html", "max(1%, )"},
+	{CalculationCorpusTarget::Percentage, "minmax-percentage-invalid.html", "max(, 1%)"},
+	{CalculationCorpusTarget::Percentage, "minmax-percentage-invalid.html", "max(1% + )"},
+	{CalculationCorpusTarget::Percentage, "minmax-percentage-invalid.html", "max(1% - )"},
+	{CalculationCorpusTarget::Percentage, "minmax-percentage-invalid.html", "max(1% * )"},
+	{CalculationCorpusTarget::Percentage, "minmax-percentage-invalid.html", "max(1% / )"},
+	{CalculationCorpusTarget::Percentage, "minmax-percentage-invalid.html", "max(1% 2%)"},
+	{CalculationCorpusTarget::Percentage, "minmax-percentage-invalid.html", "max(1%, , 2%)"},
+	{CalculationCorpusTarget::Percentage, "minmax-percentage-invalid.html", "min(0s)"},
+	{CalculationCorpusTarget::Percentage, "minmax-percentage-invalid.html", "min(0deg)"},
+	{CalculationCorpusTarget::Percentage, "minmax-percentage-invalid.html", "min(1%, 0)"},
+	{CalculationCorpusTarget::Percentage, "minmax-percentage-invalid.html", "min(1%, 0s)"},
+	{CalculationCorpusTarget::Percentage, "minmax-percentage-invalid.html", "min(1%, 0deg)"},
+	{CalculationCorpusTarget::Percentage, "minmax-percentage-invalid.html", "max(0s)"},
+	{CalculationCorpusTarget::Percentage, "minmax-percentage-invalid.html", "max(0deg)"},
+	{CalculationCorpusTarget::Percentage, "minmax-percentage-invalid.html", "max(1%, 0)"},
+	{CalculationCorpusTarget::Percentage, "minmax-percentage-invalid.html", "max(1%, 0s)"},
+	{CalculationCorpusTarget::Percentage, "minmax-percentage-invalid.html", "max(1%, 0deg)"},
+
+	// css/css-values/minmax-length-invalid.html, excluding unsupported Hz/dpi/fr rows.
+	{CalculationCorpusTarget::Length, "minmax-length-invalid.html", "min()"},
+	{CalculationCorpusTarget::Length, "minmax-length-invalid.html", "min( )"},
+	{CalculationCorpusTarget::Length, "minmax-length-invalid.html", "min(,)"},
+	{CalculationCorpusTarget::Length, "minmax-length-invalid.html", "min(1py)"},
+	{CalculationCorpusTarget::Length, "minmax-length-invalid.html", "min(1px, )"},
+	{CalculationCorpusTarget::Length, "minmax-length-invalid.html", "min(, 1px)"},
+	{CalculationCorpusTarget::Length, "minmax-length-invalid.html", "min(1px + )"},
+	{CalculationCorpusTarget::Length, "minmax-length-invalid.html", "min(1px - )"},
+	{CalculationCorpusTarget::Length, "minmax-length-invalid.html", "min(1px * )"},
+	{CalculationCorpusTarget::Length, "minmax-length-invalid.html", "min(1px / )"},
+	{CalculationCorpusTarget::Length, "minmax-length-invalid.html", "min(1px 2px)"},
+	{CalculationCorpusTarget::Length, "minmax-length-invalid.html", "min(1px, , 2px)"},
+	{CalculationCorpusTarget::Length, "minmax-length-invalid.html", "max()"},
+	{CalculationCorpusTarget::Length, "minmax-length-invalid.html", "max( )"},
+	{CalculationCorpusTarget::Length, "minmax-length-invalid.html", "max(,)"},
+	{CalculationCorpusTarget::Length, "minmax-length-invalid.html", "max(1py)"},
+	{CalculationCorpusTarget::Length, "minmax-length-invalid.html", "max(1px, )"},
+	{CalculationCorpusTarget::Length, "minmax-length-invalid.html", "max(, 1px)"},
+	{CalculationCorpusTarget::Length, "minmax-length-invalid.html", "max(1px + )"},
+	{CalculationCorpusTarget::Length, "minmax-length-invalid.html", "max(1px - )"},
+	{CalculationCorpusTarget::Length, "minmax-length-invalid.html", "max(1px * )"},
+	{CalculationCorpusTarget::Length, "minmax-length-invalid.html", "max(1px / )"},
+	{CalculationCorpusTarget::Length, "minmax-length-invalid.html", "max(1px 2px)"},
+	{CalculationCorpusTarget::Length, "minmax-length-invalid.html", "max(1px, , 2px)"},
+	{CalculationCorpusTarget::Length, "minmax-length-invalid.html", "min(0)"},
+	{CalculationCorpusTarget::Length, "minmax-length-invalid.html", "min(0%)"},
+	{CalculationCorpusTarget::Length, "minmax-length-invalid.html", "min(0s)"},
+	{CalculationCorpusTarget::Length, "minmax-length-invalid.html", "min(1px, 0)"},
+	{CalculationCorpusTarget::Length, "minmax-length-invalid.html", "min(1px, 0%)"},
+	{CalculationCorpusTarget::Length, "minmax-length-invalid.html", "min(1px, 0s)"},
+	{CalculationCorpusTarget::Length, "minmax-length-invalid.html", "max(0)"},
+	{CalculationCorpusTarget::Length, "minmax-length-invalid.html", "max(0%)"},
+	{CalculationCorpusTarget::Length, "minmax-length-invalid.html", "max(0s)"},
+	{CalculationCorpusTarget::Length, "minmax-length-invalid.html", "max(1px, 0)"},
+	{CalculationCorpusTarget::Length, "minmax-length-invalid.html", "max(1px, 0%)"},
+	{CalculationCorpusTarget::Length, "minmax-length-invalid.html", "max(1px, 0s)"},
+
+	// css/css-values/minmax-length-percent-invalid.html, excluding unsupported Hz/dpi/fr rows.
+	{CalculationCorpusTarget::LengthPercentage, "minmax-length-percent-invalid.html", "min(1px, 0)"},
+	{CalculationCorpusTarget::LengthPercentage, "minmax-length-percent-invalid.html", "min(1px, 0s)"},
+	{CalculationCorpusTarget::LengthPercentage, "minmax-length-percent-invalid.html", "min(1%, 0)"},
+	{CalculationCorpusTarget::LengthPercentage, "minmax-length-percent-invalid.html", "min(1%, 0s)"},
+	{CalculationCorpusTarget::LengthPercentage, "minmax-length-percent-invalid.html", "max(1px, 0)"},
+	{CalculationCorpusTarget::LengthPercentage, "minmax-length-percent-invalid.html", "max(1px, 0s)"},
+	{CalculationCorpusTarget::LengthPercentage, "minmax-length-percent-invalid.html", "max(1%, 0)"},
+	{CalculationCorpusTarget::LengthPercentage, "minmax-length-percent-invalid.html", "max(1%, 0s)"},
+
+	// css/css-values/minmax-angle-invalid.html, excluding unsupported Hz/dpi/fr rows.
+	{CalculationCorpusTarget::Angle, "minmax-angle-invalid.html", "min()"},
+	{CalculationCorpusTarget::Angle, "minmax-angle-invalid.html", "min( )"},
+	{CalculationCorpusTarget::Angle, "minmax-angle-invalid.html", "min(,)"},
+	{CalculationCorpusTarget::Angle, "minmax-angle-invalid.html", "min(1dag)"},
+	{CalculationCorpusTarget::Angle, "minmax-angle-invalid.html", "min(1deg, )"},
+	{CalculationCorpusTarget::Angle, "minmax-angle-invalid.html", "min(, 1deg)"},
+	{CalculationCorpusTarget::Angle, "minmax-angle-invalid.html", "min(1deg + )"},
+	{CalculationCorpusTarget::Angle, "minmax-angle-invalid.html", "min(1deg - )"},
+	{CalculationCorpusTarget::Angle, "minmax-angle-invalid.html", "min(1deg * )"},
+	{CalculationCorpusTarget::Angle, "minmax-angle-invalid.html", "min(1deg / )"},
+	{CalculationCorpusTarget::Angle, "minmax-angle-invalid.html", "min(1deg 2deg)"},
+	{CalculationCorpusTarget::Angle, "minmax-angle-invalid.html", "min(1deg, , 2deg)"},
+	{CalculationCorpusTarget::Angle, "minmax-angle-invalid.html", "max()"},
+	{CalculationCorpusTarget::Angle, "minmax-angle-invalid.html", "max( )"},
+	{CalculationCorpusTarget::Angle, "minmax-angle-invalid.html", "max(,)"},
+	{CalculationCorpusTarget::Angle, "minmax-angle-invalid.html", "max(1dag)"},
+	{CalculationCorpusTarget::Angle, "minmax-angle-invalid.html", "max(1deg, )"},
+	{CalculationCorpusTarget::Angle, "minmax-angle-invalid.html", "max(, 1deg)"},
+	{CalculationCorpusTarget::Angle, "minmax-angle-invalid.html", "max(1deg + )"},
+	{CalculationCorpusTarget::Angle, "minmax-angle-invalid.html", "max(1deg - )"},
+	{CalculationCorpusTarget::Angle, "minmax-angle-invalid.html", "max(1deg * )"},
+	{CalculationCorpusTarget::Angle, "minmax-angle-invalid.html", "max(1deg / )"},
+	{CalculationCorpusTarget::Angle, "minmax-angle-invalid.html", "max(1deg 2deg)"},
+	{CalculationCorpusTarget::Angle, "minmax-angle-invalid.html", "max(1deg, , 2deg)"},
+	{CalculationCorpusTarget::Angle, "minmax-angle-invalid.html", "min(0)"},
+	{CalculationCorpusTarget::Angle, "minmax-angle-invalid.html", "min(0%)"},
+	{CalculationCorpusTarget::Angle, "minmax-angle-invalid.html", "min(0px)"},
+	{CalculationCorpusTarget::Angle, "minmax-angle-invalid.html", "min(0s)"},
+	{CalculationCorpusTarget::Angle, "minmax-angle-invalid.html", "min(1deg, 0)"},
+	{CalculationCorpusTarget::Angle, "minmax-angle-invalid.html", "min(1deg, 0%)"},
+	{CalculationCorpusTarget::Angle, "minmax-angle-invalid.html", "min(1deg, 0px)"},
+	{CalculationCorpusTarget::Angle, "minmax-angle-invalid.html", "min(1deg, 0s)"},
+	{CalculationCorpusTarget::Angle, "minmax-angle-invalid.html", "max(0)"},
+	{CalculationCorpusTarget::Angle, "minmax-angle-invalid.html", "max(0%)"},
+	{CalculationCorpusTarget::Angle, "minmax-angle-invalid.html", "max(0px)"},
+	{CalculationCorpusTarget::Angle, "minmax-angle-invalid.html", "max(0s)"},
+	{CalculationCorpusTarget::Angle, "minmax-angle-invalid.html", "max(1deg, 0)"},
+	{CalculationCorpusTarget::Angle, "minmax-angle-invalid.html", "max(1deg, 0%)"},
+	{CalculationCorpusTarget::Angle, "minmax-angle-invalid.html", "max(1deg, 0px)"},
+	{CalculationCorpusTarget::Angle, "minmax-angle-invalid.html", "max(1deg, 0s)"},
+
+	// css/css-values/clamp-length-invalid.html, excluding the abs() rows owned by O_ADVANCED.
+	{CalculationCorpusTarget::Length, "clamp-length-invalid.html", "clamp()"},
+	{CalculationCorpusTarget::Length, "clamp-length-invalid.html", "clamp( )"},
+	{CalculationCorpusTarget::Length, "clamp-length-invalid.html", "clamp(,)"},
+	{CalculationCorpusTarget::Length, "clamp-length-invalid.html", "clamp(1px, )"},
+	{CalculationCorpusTarget::Length, "clamp-length-invalid.html", "clamp(, 1px)"},
+	{CalculationCorpusTarget::Length, "clamp-length-invalid.html", "clamp(1px, 1px)"},
+	{CalculationCorpusTarget::Length, "clamp-length-invalid.html", "clamp(1px, , 1px)"},
+	{CalculationCorpusTarget::Length, "clamp-length-invalid.html", "clamp(, 1px, 1px)"},
+	{CalculationCorpusTarget::Length, "clamp-length-invalid.html", "clamp(1px, 1px, )"},
+	{CalculationCorpusTarget::Length, "clamp-length-invalid.html", "clamp(1px, 1px, 1px, )"},
+	{CalculationCorpusTarget::Length, "clamp-length-invalid.html", "clamp(1px 1px 1px)"},
+	{CalculationCorpusTarget::Length, "clamp-length-invalid.html", "clamp(0, 10rem, 100%)"},
+	{CalculationCorpusTarget::Length, "clamp-length-invalid.html", "clamp(none, none, none)"},
+	{CalculationCorpusTarget::Length, "clamp-length-invalid.html", "clamp(none, none + none, none)"},
+	{CalculationCorpusTarget::Length, "clamp-length-invalid.html", "clamp(none, none + 1, none)"},
+	{CalculationCorpusTarget::Length, "clamp-length-invalid.html", "clamp(-none, 1px, 1px)"},
+	{CalculationCorpusTarget::Length, "clamp-length-invalid.html", "clamp(10px, none * none, 20px)"},
+	{CalculationCorpusTarget::Length, "clamp-length-invalid.html", "clamp(10px, 2px * none, 20px)"},
+	{CalculationCorpusTarget::Length, "clamp-length-invalid.html", "clamp(10px, 2px + none, 20px)"},
+	{CalculationCorpusTarget::Length, "clamp-length-invalid.html", "clamp(10px + none, 10px / 2px + none, 20px / none)"},
+	{CalculationCorpusTarget::Length, "clamp-length-invalid.html", "clamp(10px, -none, 20px)"},
+};
+
+template <typename T, size_t N>
+constexpr size_t Count(const T (&)[N])
+{
+	return N;
+}
+
+} // namespace
+
+#ifndef RMLUI_MATH_EXPRESSIONS
+
+TEST_CASE("Calculation.feature_off.rejects_math_functions")
+{
+	Context* context = TestsShell::GetContext();
+	REQUIRE(context);
+	ElementDocument* document = context->LoadDocumentFromMemory("<rml><head><style>body { display: block; }</style></head><body/></rml>");
+	REQUIRE(document);
+
+	CHECK(document->SetProperty("width", "10px"));
+	CHECK(document->SetProperty("opacity", "0.5"));
+
+	TestsShell::SetNumExpectedWarnings(5);
+	CHECK_FALSE(document->SetProperty("width", "calc(10px + 5px)"));
+	CHECK_FALSE(document->SetProperty("width", "min(10px, 20px)"));
+	CHECK_FALSE(document->SetProperty("width", "max(10px, 20px)"));
+	CHECK_FALSE(document->SetProperty("width", "clamp(10px, 15px, 20px)"));
+	CHECK_FALSE(document->SetProperty("opacity", "calc(1 / 2)"));
+
+	document->Close();
+	TestsShell::ShutdownShell();
+}
+
+#else
+
+namespace {
+
+CalculationParseTarget Target(CalculationCorpusTarget target)
+{
+	switch (target)
+	{
+	case CalculationCorpusTarget::Number: return MakeCalculationParseTarget(CalculationFinalType::Number);
+	case CalculationCorpusTarget::Percentage: return MakeCalculationParseTarget(CalculationFinalType::Percent);
+	case CalculationCorpusTarget::Length: return MakeCalculationParseTarget(CalculationFinalType::Length);
+	case CalculationCorpusTarget::LengthPercentage:
+		return MakeCalculationParseTarget(CalculationFinalType::Length, CalculationPercentageHint::Length);
+	case CalculationCorpusTarget::Angle: return MakeCalculationParseTarget(CalculationFinalType::Angle);
+	case CalculationCorpusTarget::Time: return MakeCalculationParseTarget(CalculationFinalType::Time);
+	case CalculationCorpusTarget::LineHeight: break;
+	}
+	return {};
+}
+
+bool Parses(CalculationCorpusTarget target, const String& expression, CalculationPtr* result_out = nullptr)
+{
+	CalculationPtr result;
+	const bool parsed = ParseCalculation(expression, Target(target), result);
+	if (result_out)
+		*result_out = std::move(result);
+	return parsed;
+}
+
+void CheckEvaluates(CalculationCorpusTarget target, const char* expression, float expected, Unit unit)
+{
+	CAPTURE(String(expression));
+	CalculationPtr calculation;
+	if (!Parses(target, expression, &calculation))
+	{
+		FAIL_CHECK("Expression failed to parse before evaluation");
+		return;
+	}
+	CalculationConstantValue value;
+	if (!EvaluateCalculation(*calculation, value))
+	{
+		FAIL_CHECK("Expression did not reduce to a pure constant");
+		return;
+	}
+	CHECK(value.value == doctest::Approx(expected));
+	CHECK(value.unit == unit);
+}
+
+void CheckEvaluates(CalculationCorpusTarget target, const CalculationCorpusCase& test)
+{
+	char* suffix_begin = nullptr;
+	float expected = strtof(test.expected, &suffix_begin);
+	if (suffix_begin == test.expected)
+	{
+		FAIL_CHECK("WPT expected value is not a pure numeric constant");
+		return;
+	}
+
+	const String suffix(suffix_begin);
+	Unit unit = Unit::UNKNOWN;
+	if (suffix.empty())
+		unit = Unit::NUMBER;
+	else if (suffix == "%")
+		unit = Unit::PERCENT;
+	else if (suffix == "px")
+		unit = Unit::PX;
+	else if (suffix == "in")
+	{
+		expected *= 96.f;
+		unit = Unit::PX;
+	}
+	else if (suffix == "cm")
+	{
+		expected *= 96.f / 2.54f;
+		unit = Unit::PX;
+	}
+	else if (suffix == "mm")
+	{
+		expected *= 96.f / 25.4f;
+		unit = Unit::PX;
+	}
+	else if (suffix == "pt")
+	{
+		expected *= 96.f / 72.f;
+		unit = Unit::PX;
+	}
+	else if (suffix == "pc")
+	{
+		expected *= 16.f;
+		unit = Unit::PX;
+	}
+	else if (suffix == "deg")
+		unit = Unit::DEG;
+	else if (suffix == "rad")
+	{
+		expected *= 180.f / float(3.14159265358979323846);
+		unit = Unit::DEG;
+	}
+	else
+	{
+		FAIL_CHECK("WPT expected value requires later contextual resolution or an unsupported unit");
+		return;
+	}
+
+	CAPTURE(String(test.source));
+	CheckEvaluates(target, test.expression, expected, unit);
+}
+
+void CheckEvaluatesTime(const CalculationCorpusCase& test)
+{
+	CAPTURE(String(test.source));
+	CAPTURE(String(test.expression));
+	CalculationPtr calculation;
+	REQUIRE(ParseCalculation(test.expression, MakeCalculationParseTarget(CalculationFinalType::Time), calculation));
+	float seconds = 0.f;
+	REQUIRE(EvaluateCalculationTime(*calculation, seconds));
+	char* suffix_begin = nullptr;
+	float expected = strtof(test.expected, &suffix_begin);
+	REQUIRE(suffix_begin != test.expected);
+	const String suffix(suffix_begin);
+	if (suffix == "ms")
+		expected *= 0.001f;
+	else
+		REQUIRE(suffix == "s");
+	CHECK(seconds == doctest::Approx(expected));
+}
+
+String MakeSum(size_t terms)
+{
+	String result = "calc(";
+	for (size_t i = 0; i < terms; ++i)
+	{
+		if (i)
+			result += " + ";
+		result += "1";
+	}
+	return result + ')';
+}
+
+String MakeNested(size_t depth)
+{
+	String result = "calc(";
+	result.append(depth, '(');
+	result += "1px";
+	result.append(depth, ')');
+	return result + ')';
+}
+
+String MakeNestedPercent(size_t depth)
+{
+	String result = "calc(";
+	result.append(depth, '(');
+	result += "100%";
+	result.append(depth, ')');
+	return result + ')';
+}
+
+String MakeArguments(size_t arguments)
+{
+	String result = "max(";
+	for (size_t i = 0; i < arguments; ++i)
+	{
+		if (i)
+			result += ", ";
+		result += CreateString("%zu", i + 1);
+	}
+	return result + ')';
+}
+
+} // namespace
+
+TEST_CASE("Calculation.parser.wpt_number_and_angle")
+{
+	// Sources: calc-numbers.html, calc-nesting.html, minmax-number-computed.html.
+	for (const auto& test : pure_number_cases)
+	{
+		CAPTURE(String(test.source));
+		CAPTURE(String(test.expression));
+		CheckEvaluates(CalculationCorpusTarget::Number, test);
+	}
+
+	// Source: minmax-percentage-computed.html. Raw percentages have no external basis dependency.
+	for (const auto& test : pure_percentage_cases)
+		CheckEvaluates(CalculationCorpusTarget::Percentage, test);
+
+	// Source: calc-angle-values.html. Only the deg/rad rows are in scope.
+	for (const auto& test : angle_cases)
+	{
+		CAPTURE(String(test.source));
+		CAPTURE(String(test.expression));
+		CheckEvaluates(CalculationCorpusTarget::Angle, test);
+	}
+	for (const auto& test : pure_minmax_angle_cases)
+		CheckEvaluates(CalculationCorpusTarget::Angle, test);
+}
+
+TEST_CASE("Calculation.parser.wpt_exhaustive_parse_rows")
+{
+	for (const auto& test : wpt_valid_parse_cases)
+	{
+		CAPTURE(String(test.source));
+		CAPTURE(String(test.expression));
+		CHECK(Parses(test.target, test.expression));
+	}
+	for (const auto& test : wpt_invalid_parse_cases)
+	{
+		CAPTURE(String(test.source));
+		CAPTURE(String(test.expression));
+		CHECK_FALSE(Parses(test.target, test.expression));
+	}
+}
+
+TEST_CASE("Calculation.parser.wpt_core_remaining_rows")
+{
+	// calc-in-calc.html, calc-in-max.html, calc-nesting.html.
+	const char* nested_values[] = {
+		"calc(calc(100%))",
+		"max(calc(100%))",
+		"calc(20px + calc(80px))",
+		"calc(calc(100px))",
+		"calc(calc(2) * calc(50px))",
+		"calc(calc(150px*2/3))",
+		"calc(calc(2 * calc(calc(3)) + 4) * 10px)",
+		"calc(50px + calc(40%))",
+	};
+	for (const char* expression : nested_values)
+	{
+		CAPTURE(String(expression));
+		CHECK(Parses(CalculationCorpusTarget::LengthPercentage, expression));
+	}
+	CheckEvaluates(CalculationCorpusTarget::LengthPercentage, "calc(calc(100%))", 100.f, Unit::PERCENT);
+	CheckEvaluates(CalculationCorpusTarget::LengthPercentage, "max(calc(100%))", 100.f, Unit::PERCENT);
+	CheckEvaluates(CalculationCorpusTarget::LengthPercentage, "calc(20px + calc(80px))", 100.f, Unit::PX);
+	CheckEvaluates(CalculationCorpusTarget::LengthPercentage, "calc(calc(100px))", 100.f, Unit::PX);
+	CheckEvaluates(CalculationCorpusTarget::LengthPercentage, "calc(calc(2) * calc(50px))", 100.f, Unit::PX);
+	CheckEvaluates(CalculationCorpusTarget::LengthPercentage, "calc(calc(150px*2/3))", 100.f, Unit::PX);
+	CheckEvaluates(CalculationCorpusTarget::LengthPercentage, "calc(calc(2 * calc(calc(3)) + 4) * 10px)", 100.f, Unit::PX);
+
+	// calc-parenthesis-stack.html requires exactly 32 nested pairs inside calc().
+	CHECK(Parses(CalculationCorpusTarget::LengthPercentage, MakeNestedPercent(32)));
+	CheckEvaluates(CalculationCorpusTarget::LengthPercentage, MakeNestedPercent(32).c_str(), 100.f, Unit::PERCENT);
+
+	// calc-rounding-001.html has a pure parser/type row. The var()-dependent rows in
+	// calc-rounding-002/003 require variable substitution and are covered by the integration tests.
+	CHECK(Parses(CalculationCorpusTarget::LengthPercentage, "calc((100% - 4.5em) / 4)"));
+
+	// max-20-arguments.html, min-length-percent-001.html, max-length-percent-001.html.
+	CHECK(Parses(CalculationCorpusTarget::LengthPercentage,
+		"max(5%, 10%, 15%, 20%, 25%, 30%, 35%, 40%, 45%, 50%, 55%, 60%, 65%, 70%, 75%, 80%, 85%, 90%, 95%, 100%)"));
+	CHECK(Parses(CalculationCorpusTarget::LengthPercentage, "min(300px, 25% + 100px, 50px + 50%)"));
+	CHECK(Parses(CalculationCorpusTarget::LengthPercentage, "max(100px, 25% + 100px, 150px + 10%)"));
+	CHECK_FALSE(Parses(CalculationCorpusTarget::LengthPercentage, "min(0, 100%)"));
+
+	// calc-unit-analysis.html.
+	CHECK(Parses(CalculationCorpusTarget::Length, "calc(0px)"));
+	CHECK(Parses(CalculationCorpusTarget::Length, "calc(2px * 2)"));
+	CHECK(Parses(CalculationCorpusTarget::Length, "calc(2 * 2px)"));
+	CheckEvaluates(CalculationCorpusTarget::Length, "calc(0px)", 0.f, Unit::PX);
+	CheckEvaluates(CalculationCorpusTarget::Length, "calc(2px * 2)", 4.f, Unit::PX);
+	CheckEvaluates(CalculationCorpusTarget::Length, "calc(2 * 2px)", 4.f, Unit::PX);
+	CHECK_FALSE(Parses(CalculationCorpusTarget::Length, "calc(0)"));
+	CHECK_FALSE(Parses(CalculationCorpusTarget::Length, "calc(1px + 2)"));
+	CHECK_FALSE(Parses(CalculationCorpusTarget::Length, "calc(2 + 1px)"));
+	CHECK_FALSE(Parses(CalculationCorpusTarget::Length, "calc(1px - 2)"));
+	CHECK_FALSE(Parses(CalculationCorpusTarget::Length, "calc(2 - 1px)"));
+	CHECK_FALSE(Parses(CalculationCorpusTarget::Length, "calc(2px * 1px)"));
+	CHECK_FALSE(Parses(CalculationCorpusTarget::Length, "calc(20 / 0.75rem)"));
+
+	// calc-numbers.html's pure numeric rows and applicable trailing-token rejection.
+	CheckEvaluates(CalculationCorpusTarget::Number, "calc(2 * 3)", 6.f, Unit::NUMBER);
+	CheckEvaluates(CalculationCorpusTarget::Number, "calc(2 * -4)", -8.f, Unit::NUMBER);
+	CheckEvaluates(CalculationCorpusTarget::Number, "calc(2 / 4)", 0.5f, Unit::NUMBER);
+	CheckEvaluates(CalculationCorpusTarget::LengthPercentage,
+		"max(5%, 10%, 15%, 20%, 25%, 30%, 35%, 40%, 45%, 50%, 55%, 60%, 65%, 70%, 75%, 80%, 85%, 90%, 95%, 100%)", 100.f, Unit::PERCENT);
+	CHECK_FALSE(Parses(CalculationCorpusTarget::Number, "calc(2 / 4) * 1px"));
+	CHECK_FALSE(Parses(CalculationCorpusTarget::Number, "calc(1 + 1px)"));
+	CHECK_FALSE(Parses(CalculationCorpusTarget::Number, "calc(1 + 100%)"));
+	CHECK_FALSE(Parses(CalculationCorpusTarget::Number, "calc(10px) bla"));
+	CHECK_FALSE(Parses(CalculationCorpusTarget::Number, "calc(bla) 10px"));
+}
+
+TEST_CASE("Calculation.parser.wpt_typed_arithmetic_remaining_rows")
+{
+	const CalculationParseTarget length_percentage = MakeCalculationParseTarget(CalculationFinalType::Length, CalculationPercentageHint::Length);
+	const CalculationParseTarget line_height = {
+		CalculationFinalType::Number | CalculationFinalType::Length,
+		CalculationPercentageHint::Length,
+	};
+	CalculationPtr calculation;
+
+	const char* length_rows[] = {
+		"min(1em, 110px / 10px * 1px)",
+		"max(10px, 110px / 10px * 1px)",
+		"max(1em + 2px, 110px / 10px * 1px)",
+	};
+	for (const char* expression : length_rows)
+	{
+		CAPTURE(String(expression));
+		CHECK(ParseCalculation(expression, MakeCalculationParseTarget(CalculationFinalType::Length), calculation));
+	}
+
+	const char* length_percentage_rows[] = {
+		"max(1em + 2%, 110px / 10px * 1px)",
+		"clamp(110px / 10px * 1px, 1em + 200%, 200% * 1% / 1em)",
+		"calc((10% * 1%) / 1px)",
+	};
+	for (const char* expression : length_percentage_rows)
+	{
+		CAPTURE(String(expression));
+		CHECK(ParseCalculation(expression, length_percentage, calculation));
+	}
+
+	const char* number_rows[] = {
+		"calc(10em / 1em)",
+		"calc(10em / 1rem)",
+		"calc(10em / 1px)",
+	};
+	for (const char* expression : number_rows)
+	{
+		CAPTURE(String(expression));
+		CHECK(ParseCalculation(expression, MakeCalculationParseTarget(CalculationFinalType::Number), calculation));
+	}
+
+	const char* line_height_rows[] = {
+		"calc(10% / 1px)",
+		"calc(1% * 100% / 10%)",
+		"calc(10% / 10%)",
+		"calc(10% * 10% / 1px * 10deg / 1deg / 10px)",
+		"calc(10% * 10% / 1px * 1deg / 1deg)",
+		"calc(1px * 2deg / 1deg)",
+		"calc(1px * 3deg / 1deg / 1px)",
+	};
+	for (const char* expression : line_height_rows)
+	{
+		CAPTURE(String(expression));
+		CHECK(ParseCalculation(expression, line_height, calculation));
+	}
+
+	CHECK_FALSE(ParseCalculation("calc((1% * 1deg) / 1px)", length_percentage, calculation));
+	CHECK_FALSE(ParseCalculation("calc((1% * 1% * 1%) / 1px)", length_percentage, calculation));
+
+	String excessive_product = "calc(1px * 1px";
+	String excessive_sum = "calc(1px + 1em";
+	for (size_t i = 0; i < 200; ++i)
+	{
+		excessive_product += " * 2";
+		excessive_sum += " + 1em";
+	}
+	excessive_product += ')';
+	excessive_sum += ')';
+	CHECK_FALSE(ParseCalculation(excessive_product, length_percentage, calculation));
+	CHECK_FALSE(ParseCalculation(excessive_sum, length_percentage, calculation));
+}
+
+TEST_CASE("Calculation.parser.wpt_length_percentage_and_comparisons")
+{
+	for (const auto& test : pure_absolute_length_cases)
+		CheckEvaluates(CalculationCorpusTarget::Length, test);
+	for (const auto& test : pure_clamp_length_cases)
+		CheckEvaluates(CalculationCorpusTarget::Length, test);
+
+	// Sources: minmax-length-computed.html, clamp-length-computed.html.
+	for (const auto& test : definite_length_cases)
+	{
+		CAPTURE(String(test.source));
+		CAPTURE(String(test.expression));
+		CHECK(Parses(CalculationCorpusTarget::Length, test.expression));
+	}
+	CheckEvaluates(CalculationCorpusTarget::Length, "min(95px, 1in)", 95.f, Unit::PX);
+	CheckEvaluates(CalculationCorpusTarget::Length, "max(95px, 1in)", 96.f, Unit::PX);
+	CheckEvaluates(CalculationCorpusTarget::Length, "clamp(30px, 100px, 20px)", 30.f, Unit::PX);
+	CheckEvaluates(CalculationCorpusTarget::Length, "clamp(none, 33px, 30px)", 30.f, Unit::PX);
+	CheckEvaluates(CalculationCorpusTarget::Length, "clamp(33px, 30px, none)", 33.f, Unit::PX);
+	CheckEvaluates(CalculationCorpusTarget::Length, "clamp(none, 30px, none)", 30.f, Unit::PX);
+
+	// Sources: minmax-length-percent-computed.html, max-20-arguments.html, calc-nesting.html.
+	for (const auto& test : used_length_percentage_cases)
+	{
+		CAPTURE(String(test.source));
+		CAPTURE(String(test.expression));
+		CHECK(Parses(CalculationCorpusTarget::LengthPercentage, test.expression));
+	}
+	for (const char* expression : clamp_none_whitespace_cases)
+	{
+		CAPTURE(expression);
+		CHECK(Parses(CalculationCorpusTarget::LengthPercentage, expression));
+	}
+	CheckEvaluates(CalculationCorpusTarget::LengthPercentage, "max(5%, 10%, 15%, 20%)", 20.f, Unit::PERCENT);
+}
+
+TEST_CASE("Calculation.parser.wpt_invalid_and_type_algebra")
+{
+	// Sources: calc-unit-analysis.html, calc-invalid-parsing.html and the min/max/clamp invalid suites.
+	for (const auto& test : pure_invalid_cases)
+	{
+		CAPTURE(String(test.source));
+		CAPTURE(String(test.expression));
+		CHECK_FALSE(Parses(test.target, test.expression));
+	}
+	CHECK_FALSE(Parses(CalculationCorpusTarget::Length, "calc(2px * 1px)"));
+	CHECK_FALSE(Parses(CalculationCorpusTarget::Length, "calc(20 / 0.75rem)"));
+	CHECK_FALSE(Parses(CalculationCorpusTarget::Length, "min(0, 100%)"));
+
+	// Source: typed_arithmetic.html. Finite dimensional products may carry powers which later cancel.
+	for (const auto& test : typed_arithmetic_cases)
+	{
+		CAPTURE(String(test.source));
+		CAPTURE(String(test.expression));
+		const CalculationCorpusTarget target =
+			String(test.expected).find("px") != String::npos ? CalculationCorpusTarget::Length : CalculationCorpusTarget::Number;
+		CHECK(Parses(target, test.expression));
+	}
+	CheckEvaluates(CalculationCorpusTarget::Length, "calc(1px * 2deg / 1deg)", 2.f, Unit::PX);
+	CheckEvaluates(CalculationCorpusTarget::Number, "calc(1px * 3deg / 1deg / 1px)", 3.f, Unit::NUMBER);
+	CHECK_FALSE(Parses(CalculationCorpusTarget::Length, "calc((1% * 1deg) / 1px)"));
+}
+
+TEST_CASE("Calculation.parser.targets_whitespace_and_limits")
+{
+	// Supplemental parser boundary cases not represented exactly in the adapted WPT corpus.
+	CHECK(Parses(CalculationCorpusTarget::Number, "calc(1 + 2)"));
+	CHECK(Parses(CalculationCorpusTarget::Number, "calc(1 - -2)"));
+	CHECK(Parses(CalculationCorpusTarget::Number, "calc(2*-4)"));
+	CHECK(Parses(CalculationCorpusTarget::Number, "calc(.5 + 1e2)"));
+	CHECK_FALSE(Parses(CalculationCorpusTarget::Number, "calc(1+ 2)"));
+	CHECK_FALSE(Parses(CalculationCorpusTarget::Number, "calc(1 +2)"));
+	CHECK_FALSE(Parses(CalculationCorpusTarget::Number, "calc(1+2)"));
+	CHECK_FALSE(Parses(CalculationCorpusTarget::Number, "calc(0x1)"));
+	CHECK_FALSE(Parses(CalculationCorpusTarget::Number, "calc(0x1p2)"));
+	CHECK_FALSE(Parses(CalculationCorpusTarget::Number, "calc(1.)"));
+	CHECK_FALSE(Parses(CalculationCorpusTarget::Number, "calc (1 + 2)"));
+	CHECK_FALSE(Parses(CalculationCorpusTarget::Number, "min (1, 2)"));
+	CHECK_FALSE(Parses(CalculationCorpusTarget::Number, "calc(1/*comment*/+/*comment*/2)"));
+	CHECK(Parses(CalculationCorpusTarget::Number, "calc(1 /*comment*/ + /*comment*/ 2)"));
+	CHECK_FALSE(Parses(CalculationCorpusTarget::Number, "calc/**/(1 + 2)"));
+	CHECK_FALSE(Parses(CalculationCorpusTarget::Length, "calc(1/**/px)"));
+	CHECK(Parses(CalculationCorpusTarget::Number, "calc(1\f+\f2)"));
+
+	CHECK(Parses(CalculationCorpusTarget::Number, MakeSum(31)));
+	CHECK(Parses(CalculationCorpusTarget::Number, MakeSum(32)));
+	CHECK_FALSE(Parses(CalculationCorpusTarget::Number, MakeSum(33)));
+	CHECK(Parses(CalculationCorpusTarget::Length, MakeNested(31)));
+	CHECK(Parses(CalculationCorpusTarget::Length, MakeNested(32)));
+	CHECK_FALSE(Parses(CalculationCorpusTarget::Length, MakeNested(33)));
+	CHECK(Parses(CalculationCorpusTarget::Number, MakeArguments(31)));
+	CHECK(Parses(CalculationCorpusTarget::Number, MakeArguments(32)));
+	CHECK_FALSE(Parses(CalculationCorpusTarget::Number, MakeArguments(33)));
+	String max_arguments_trailing_comma = MakeArguments(32);
+	max_arguments_trailing_comma.pop_back();
+	max_arguments_trailing_comma += ',';
+	CHECK_FALSE(Parses(CalculationCorpusTarget::Number, max_arguments_trailing_comma));
+
+	CalculationPtr calculation;
+	CHECK(ParseCalculation("calc(50% / 2)", {CalculationFinalType::Percent | CalculationFinalType::Number, CalculationPercentageHint::None},
+		calculation));
+	CHECK_FALSE(ParseCalculation("calc(0.25 + 25%)", {CalculationFinalType::Percent | CalculationFinalType::Number, CalculationPercentageHint::None},
+		calculation));
+	CHECK(ParseCalculation("calc(50% + 10px)", MakeCalculationParseTarget(CalculationFinalType::Length, CalculationPercentageHint::Length),
+		calculation));
+	CHECK(ParseCalculation("calc(25% + 10deg)", MakeCalculationParseTarget(CalculationFinalType::Angle, CalculationPercentageHint::Angle),
+		calculation));
+	CHECK_FALSE(ParseCalculation("calc(50% + 10px)", MakeCalculationParseTarget(CalculationFinalType::Length), calculation));
+	CHECK_FALSE(Parses(CalculationCorpusTarget::Length, "calc(0)"));
+
+	const CalculationParseTarget line_height = {
+		CalculationFinalType::Number | CalculationFinalType::Length,
+		CalculationPercentageHint::Length,
+	};
+	CHECK(ParseCalculation("calc(20% / 10px)", line_height, calculation));
+	CHECK(ParseCalculation("calc(20% + 10px)", line_height, calculation));
+	CHECK_FALSE(ParseCalculation("calc(20% + 10deg)", line_height, calculation));
+
+	CHECK(ParseCalculation("calc(2x * 3)", MakeCalculationParseTarget(CalculationFinalType::Resolution), calculation));
+	CalculationConstantValue resolution;
+	CHECK(EvaluateCalculation(*calculation, resolution));
+	CHECK(resolution.value == doctest::Approx(6.f));
+	CHECK(resolution.unit == Unit::X);
+
+	CHECK_FALSE(ParseCalculation("calc(10px)", {}, calculation));
+	CHECK_FALSE(ParseCalculation("calc(25% + 1)", {CalculationFinalType::Number | CalculationFinalType::Percent, CalculationPercentageHint::None},
+		calculation));
+
+	const char* rmlui_length_units[] = {"px", "dp", "vw", "vh", "em", "rem", "in", "cm", "mm", "pt", "pc"};
+	for (const char* unit : rmlui_length_units)
+	{
+		CAPTURE(String(unit));
+		CHECK(ParseCalculation(String("calc(1") + unit + ')', MakeCalculationParseTarget(CalculationFinalType::Length), calculation));
+	}
+}
+
+TEST_CASE("Calculation.parser.non_finite_and_unsupported")
+{
+	CHECK_FALSE(Parses(CalculationCorpusTarget::Number, "calc(1 / 0)"));
+	CHECK_FALSE(Parses(CalculationCorpusTarget::Number, "calc(1 / (2 - 2))"));
+	CHECK_FALSE(Parses(CalculationCorpusTarget::Number, "calc(1e1000)"));
+	CHECK_FALSE(Parses(CalculationCorpusTarget::Length, "calc(3e38in)"));
+	CHECK_FALSE(Parses(CalculationCorpusTarget::Angle, "calc(3e38rad)"));
+	CHECK_FALSE(Parses(CalculationCorpusTarget::Number, "calc(infinity)"));
+	CHECK_FALSE(Parses(CalculationCorpusTarget::Number, "calc(-infinity)"));
+	CHECK_FALSE(Parses(CalculationCorpusTarget::Number, "calc(NaN)"));
+	CHECK_FALSE(Parses(CalculationCorpusTarget::Number, "round(1, 1)"));
+	CHECK_FALSE(Parses(CalculationCorpusTarget::Number, "calc(pow(2, 3))"));
+	CHECK_FALSE(Parses(CalculationCorpusTarget::Length, "calc(1Q)"));
+	CHECK_FALSE(Parses(CalculationCorpusTarget::Angle, "calc(1turn)"));
+}
+
+TEST_CASE("Calculation.serialization.round_trip")
+{
+	CalculationPtr first;
+	if (!Parses(CalculationCorpusTarget::LengthPercentage, "calc((50% - 20px) * 2)", &first))
+	{
+		FAIL_CHECK("Round-trip source failed to parse");
+		return;
+	}
+	const String serialized = first->ToString();
+	CHECK(serialized.find(" - ") != String::npos);
+
+	CalculationPtr reparsed;
+	if (!ParseCalculation(serialized, Target(CalculationCorpusTarget::LengthPercentage), reparsed))
+	{
+		FAIL_CHECK("Serialized calculation failed to parse");
+		return;
+	}
+	CHECK(*first == *reparsed);
+
+	Property property(first, Unit::CALCULATION);
+	CHECK(property.ToString() == serialized);
+
+	PropertyDefinition definition(PropertyId::Width, "auto", false, true);
+	property.definition = &definition;
+	String definition_value;
+	CHECK(definition.GetValue(definition_value, property));
+	CHECK(definition_value == serialized);
+	CHECK(property.ToString() == serialized);
+}
+
+TEST_CASE("Calculation.parser.pure_simplification")
+{
+	CalculationPtr calculation;
+	REQUIRE(ParseCalculation("calc((2 + 3) * 4)", MakeCalculationParseTarget(CalculationFinalType::Number), calculation));
+	CHECK(calculation->GetRoot()->kind == Calculation::Kind::Value);
+	CHECK(calculation->GetRoot()->value == doctest::Approx(20.f));
+	CHECK(calculation->GetRoot()->unit == Unit::NUMBER);
+
+	REQUIRE(ParseCalculation("calc(1in + 48px)", MakeCalculationParseTarget(CalculationFinalType::Length), calculation));
+	// Physical lengths remain lexical until computed-value resolution because RmlUi scales them by
+	// the mutable dp ratio. Pure evaluation can still prove the context-free 96ppi result.
+	CalculationConstantValue physical_value;
+	REQUIRE(EvaluateCalculation(*calculation, physical_value));
+	CHECK(physical_value.value == doctest::Approx(144.f));
+	CHECK(physical_value.unit == Unit::PX);
+	CHECK(Any(calculation->GetDependencyMask() & Unit::INCH));
+
+	REQUIRE(ParseCalculation("calc(1em + 20px + 10px)", MakeCalculationParseTarget(CalculationFinalType::Length), calculation));
+	CHECK(calculation->GetRoot()->kind == Calculation::Kind::Sum);
+	CHECK(calculation->GetRoot()->children.size() == 3);
+	CHECK(calculation->GetRoot()->children[1]->kind == Calculation::Kind::Value);
+	CHECK(calculation->GetRoot()->children[2]->kind == Calculation::Kind::Value);
+
+	CalculationPtr simplified;
+	CHECK(SimplifyCalculation(*calculation, simplified));
+	CHECK(*simplified == *calculation);
+
+	CheckEvaluates(CalculationCorpusTarget::Number, "calc(2 + 3 * 4)", 14.f, Unit::NUMBER);
+	CheckEvaluates(CalculationCorpusTarget::Number, "calc((2 + 3) * 4)", 20.f, Unit::NUMBER);
+	CheckEvaluates(CalculationCorpusTarget::Number, "calc(20 / 5 * 2)", 8.f, Unit::NUMBER);
+	CheckEvaluates(CalculationCorpusTarget::Number, "calc(20 / (5 * 2))", 2.f, Unit::NUMBER);
+
+	CalculationPtr equivalent;
+	REQUIRE(ParseCalculation("calc(3)", MakeCalculationParseTarget(CalculationFinalType::Number), equivalent));
+	CalculationPtr folded;
+	REQUIRE(ParseCalculation("calc(1 + 2)", MakeCalculationParseTarget(CalculationFinalType::Number), folded));
+	CHECK(*equivalent == *folded);
+
+	// A percentage hint changes the CSS numeric type, but it does not supply the percentage basis.
+	// Pure simplification must preserve that dependency even when dimensional exponents cancel.
+	const CalculationParseTarget line_height = {
+		CalculationFinalType::Number | CalculationFinalType::Length,
+		CalculationPercentageHint::Length,
+	};
+	REQUIRE(ParseCalculation("calc(10% / 1px)", line_height, calculation));
+	CalculationConstantValue unresolved_value;
+	CHECK_FALSE(EvaluateCalculation(*calculation, unresolved_value));
+	CHECK(calculation->ToString().find('%') != String::npos);
+
+	const CalculationParseTarget length_percentage = MakeCalculationParseTarget(CalculationFinalType::Length, CalculationPercentageHint::Length);
+	REQUIRE(ParseCalculation("calc((10% * 1%) / 1px)", length_percentage, calculation));
+	CHECK_FALSE(EvaluateCalculation(*calculation, unresolved_value));
+	CHECK(calculation->ToString().find('%') != String::npos);
+
+	REQUIRE(ParseCalculation("calc(10% / 10%)", line_height, calculation));
+	REQUIRE(EvaluateCalculation(*calculation, unresolved_value));
+	CHECK(unresolved_value.value == doctest::Approx(1.f));
+	CHECK(unresolved_value.unit == Unit::NUMBER);
+}
+
+TEST_CASE("Calculation.computed.scalar_parser_and_values")
+{
+	Context* context = TestsShell::GetContext();
+	REQUIRE(context);
+	context->SetDimensions(Vector2i(800, 400));
+	context->SetDensityIndependentPixelRatio(1.f);
+	ElementDocument* document = context->CreateDocument();
+	REQUIRE(document);
+
+	// Central scalar-parser entry point and exact shared parse-target behavior.
+	CHECK(document->SetProperty("opacity", "calc(1 / 2)"));
+	CHECK(document->SetProperty("width", "calc(1em + 1rem + 1vw + 1vh + 1dp + 1in)"));
+	CHECK(document->SetProperty("width", "calc(50% - 20px)"));
+	CHECK(document->SetProperty("width", "CaLc(10px + 5px)"));
+	CHECK(document->SetProperty("width", "MiN(10px, 20px)"));
+	CHECK(document->SetProperty("width", "MaX(10px, 20px)"));
+	CHECK(document->SetProperty("width", "ClAmP(10px, 15px, 20px)"));
+	TestsShell::SetNumExpectedWarnings(2);
+	CHECK_FALSE(document->SetProperty("width", "calc(1 + 2)"));
+	CHECK_FALSE(document->SetProperty("line-height", "calc(20% + 10deg)"));
+
+	// Generic number_length_percent is intentionally not a calculation grammar.
+	PropertyParser* legacy_parser = StyleSheetSpecification::GetParser("number_length_percent");
+	REQUIRE(legacy_parser);
+	Property legacy_property;
+	CHECK_FALSE(legacy_parser->ParseValue(legacy_property, "calc(10px + 10%)", {}));
+
+	struct ParserCase {
+		const char* parser;
+		const char* valid;
+		const char* invalid;
+	};
+	const ParserCase parser_cases[] = {
+		{"number", "calc(1 / 2)", "calc(1px)"},
+		{"length", "calc(1px + 2px)", "calc(1% + 2px)"},
+		{"length_percent", "calc(1% + 2px)", "calc(1 + 2px)"},
+		{"number_percent", "calc(50% / 2)", "calc(0.25 + 25%)"},
+		{"angle", "calc(45deg + 0.5rad)", "calc(1% + 10deg)"},
+		{"resolution", "calc(2x * 3)", "calc(1px)"},
+		{"line_height", "calc(20% + 10px)", "calc(20% + 10deg)"},
+	};
+	for (const auto& test : parser_cases)
+	{
+		CAPTURE(String(test.parser));
+		PropertyParser* parser = StyleSheetSpecification::GetParser(test.parser);
+		REQUIRE(parser);
+		Property parsed;
+		CHECK(parser->ParseValue(parsed, test.valid, {}));
+		CHECK(parsed.unit == Unit::CALCULATION);
+		CHECK_FALSE(parser->ParseValue(parsed, test.invalid, {}));
+	}
+
+	// WPT-derived computed length rows. A 20px font is the fixture context used by these rows.
+	CHECK(document->SetProperty("font-size", "20px"));
+	for (const auto& test : definite_length_cases)
+	{
+		CAPTURE(String(test.source));
+		CAPTURE(String(test.expression));
+		REQUIRE(document->SetProperty("width", test.expression));
+		document->UpdateDocument();
+		const auto width = document->GetComputedValues().width();
+		REQUIRE(width.type == Style::LengthPercentageAuto::Length);
+		CHECK(width.value == doctest::Approx(strtof(test.expected, nullptr)));
+	}
+
+	// WPT line-height computed rows and the plan-required Number-vs-Length inheritance split.
+	CHECK(document->SetProperty("font-size", "40px"));
+	CHECK(document->SetProperty("line-height", "200%"));
+	document->UpdateDocument();
+	CHECK(document->GetComputedValues().line_height().value == doctest::Approx(80.f));
+	CHECK(document->GetComputedValues().line_height().inherit_type == Style::LineHeight::Number);
+	CHECK(document->SetProperty("line-height", "calc(200% + 10px)"));
+	document->UpdateDocument();
+	CHECK(document->GetComputedValues().line_height().value == doctest::Approx(90.f));
+	CHECK(document->GetComputedValues().line_height().inherit_type == Style::LineHeight::Length);
+	CHECK(document->SetProperty("line-height", "calc(10px + 0.5em)"));
+	document->UpdateDocument();
+	CHECK(document->GetComputedValues().line_height().value == doctest::Approx(30.f));
+	CHECK(document->GetComputedValues().line_height().inherit_type == Style::LineHeight::Length);
+	CHECK(document->SetProperty("line-height", "calc(10px - 0.5em)"));
+	document->UpdateDocument();
+	CHECK(document->GetComputedValues().line_height().value == doctest::Approx(-10.f));
+	CHECK(document->GetComputedValues().line_height().inherit_type == Style::LineHeight::Length);
+	CHECK(document->SetProperty("line-height", "calc(200%)"));
+	document->UpdateDocument();
+	CHECK(document->GetComputedValues().line_height().value == doctest::Approx(80.f));
+	CHECK(document->GetComputedValues().line_height().inherit_type == Style::LineHeight::Length);
+	CHECK(document->SetProperty("line-height", "calc(2)"));
+	document->UpdateDocument();
+	CHECK(document->GetComputedValues().line_height().value == doctest::Approx(80.f));
+	CHECK(document->GetComputedValues().line_height().inherit_type == Style::LineHeight::Number);
+
+	Element* child = document->AppendChild(document->CreateElement("div"));
+	REQUIRE(child);
+	CHECK(child->SetProperty("font-size", "calc(50% + 2px)"));
+	document->UpdateDocument();
+	CHECK(child->GetComputedValues().font_size() == doctest::Approx(22.f));
+	CHECK(child->SetProperty("width", "calc(1em + 1rem + 1vw + 1vh + 1dp + 1in)"));
+	document->UpdateDocument();
+	CHECK(child->GetComputedValues().width().type == Style::LengthPercentageAuto::Length);
+	CHECK(child->GetComputedValues().width().value == doctest::Approx(171.f));
+
+	// Physical-unit canonicalization must preserve the existing RmlUi dp-scaled ordinary semantics.
+	context->SetDensityIndependentPixelRatio(2.f);
+	CHECK(child->SetProperty("width", "1in"));
+	document->UpdateDocument();
+	const float ordinary_physical = child->GetComputedValues().width().value;
+	CHECK(child->SetProperty("width", "calc(1in)"));
+	document->UpdateDocument();
+	CHECK(child->GetComputedValues().width().type == Style::LengthPercentageAuto::Length);
+	CHECK(child->GetComputedValues().width().value == doctest::Approx(ordinary_physical));
+	CHECK(ordinary_physical == doctest::Approx(192.f));
+
+	document->Close();
+	TestsShell::ShutdownShell();
+}
+
+TEST_CASE("Calculation.computed.residual_storage_and_var_reparse")
+{
+	Context* context = TestsShell::GetContext();
+	REQUIRE(context);
+	ElementDocument* document = context->CreateDocument();
+	REQUIRE(document);
+
+	CHECK(document->SetProperty("width", "calc(50% - 20px)"));
+	document->UpdateDocument();
+	auto width = document->GetComputedValues().width();
+	CHECK(width.type == Style::LengthPercentageAuto::Calculation);
+	REQUIRE(bool(width.calculation));
+	CHECK(width.calculation->GetResidualForm() == Calculation::ResidualForm::LinearLengthPercentage);
+	CHECK(width.calculation->GetLinearPx() == doctest::Approx(-20.f));
+	CHECK(width.calculation->GetLinearPercent() == doctest::Approx(50.f));
+
+	CHECK(document->SetProperty("width", "max(50%, 300px)"));
+	document->UpdateDocument();
+	width = document->GetComputedValues().width();
+	CHECK(width.type == Style::LengthPercentageAuto::Calculation);
+	REQUIRE(bool(width.calculation));
+	CHECK(width.calculation->GetResidualForm() == Calculation::ResidualForm::Tree);
+
+	// Replacing a residual by a definite value must erase the stale sidecar entry.
+	CHECK(document->SetProperty("width", "calc(10px + 20px)"));
+	document->UpdateDocument();
+	width = document->GetComputedValues().width();
+	CHECK(width.type == Style::LengthPercentageAuto::Length);
+	CHECK(width.value == doctest::Approx(30.f));
+	CHECK_FALSE(bool(width.calculation));
+
+	// Existing var() substitution reparses through the calculation-aware owning property definition.
+	CHECK(document->SetProperty("--w", "80px"));
+	CHECK(document->SetProperty("width", "calc(var(--w) / 2)"));
+	document->UpdateDocument();
+	width = document->GetComputedValues().width();
+	CHECK(width.type == Style::LengthPercentageAuto::Length);
+	CHECK(width.value == doctest::Approx(40.f));
+
+	CHECK(document->SetProperty("--w", "100px"));
+	document->UpdateDocument();
+	width = document->GetComputedValues().width();
+	CHECK(width.type == Style::LengthPercentageAuto::Length);
+	CHECK(width.value == doctest::Approx(50.f));
+
+	CHECK(document->SetProperty("width", "calc(var(--missing, 60px) / 2)"));
+	document->UpdateDocument();
+	width = document->GetComputedValues().width();
+	CHECK(width.type == Style::LengthPercentageAuto::Length);
+	CHECK(width.value == doctest::Approx(30.f));
+
+	document->Close();
+	TestsShell::ShutdownShell();
+}
+
+TEST_CASE("Calculation.computed.wpt_length_percentage_forms")
+{
+	Context* context = TestsShell::GetContext();
+	REQUIRE(context);
+	ElementDocument* document = context->CreateDocument();
+	REQUIRE(document);
+	CHECK(document->SetProperty("font-size", "20px"));
+
+	for (const auto& test : used_length_percentage_cases)
+	{
+		CAPTURE(String(test.source));
+		CAPTURE(String(test.expression));
+		REQUIRE(document->SetProperty("width", test.expression));
+		document->UpdateDocument();
+		const auto width = document->GetComputedValues().width();
+		if (String(test.expression) == "max(5%, 10%, 15%, 20%, 25%, 30%, 35%, 40%, 45%, 50%, 55%, 60%, 65%, 70%, 75%, 80%, 85%, 90%, 95%, 100%)")
+		{
+			CHECK(width.type == Style::LengthPercentageAuto::Percentage);
+			CHECK(width.value == doctest::Approx(100.f));
+		}
+		else if (String(test.expression) == "calc(calc(3 * 25%))")
+		{
+			CHECK(width.type == Style::LengthPercentageAuto::Percentage);
+			CHECK(width.value == doctest::Approx(75.f));
+		}
+		else
+		{
+			CHECK(width.type == Style::LengthPercentageAuto::Calculation);
+			REQUIRE(bool(width.calculation));
+			if (String(test.expression) == "calc(calc(60%) - 20px)")
+				CHECK(width.calculation->GetResidualForm() == Calculation::ResidualForm::LinearLengthPercentage);
+		}
+	}
+
+	document->Close();
+	TestsShell::ShutdownShell();
+}
+
+TEST_CASE("Calculation.computed.resolver_canonicalization_and_dependencies")
+{
+	CalculationPtr calculation;
+	const CalculationParseTarget length = MakeCalculationParseTarget(CalculationFinalType::Length);
+	REQUIRE(ParseCalculation("calc(1in + 1dp + 1vw + 1vh + 1em + 1rem)", length, calculation));
+	REQUIRE(bool(calculation));
+	const Units dependencies = calculation->GetDependencyMask();
+	CHECK(Any(dependencies & Unit::INCH));
+	CHECK(Any(dependencies & Unit::DP));
+	CHECK(Any(dependencies & Unit::VW));
+	CHECK(Any(dependencies & Unit::VH));
+	CHECK(Any(dependencies & Unit::EM));
+	CHECK(Any(dependencies & Unit::REM));
+
+	CalculationResolverContext context;
+	context.font_size = 20.f;
+	context.parent_font_size = 30.f;
+	context.document_font_size = 16.f;
+	context.viewport_dimensions = Vector2f(800.f, 400.f);
+	context.dp_ratio = 2.f;
+	ResolvedCalculation resolved;
+	REQUIRE(ResolveCalculation(*calculation, context, resolved));
+	CHECK(resolved.form == Calculation::ResidualForm::Constant);
+	CHECK(resolved.is_constant);
+	CHECK(resolved.unit == Unit::PX);
+	CHECK(resolved.value == doctest::Approx(242.f));
+
+	REQUIRE(ParseCalculation("calc(50% + 2px)", MakeCalculationParseTarget(CalculationFinalType::Length, CalculationPercentageHint::Length),
+		calculation));
+	context.relative_target = RelativeTarget::ParentFontSize;
+	REQUIRE(ResolveCalculation(*calculation, context, resolved));
+	CHECK(resolved.is_constant);
+	CHECK(resolved.value == doctest::Approx(17.f));
+
+	REQUIRE(ParseCalculation("calc(90deg + 0.5rad)", MakeCalculationParseTarget(CalculationFinalType::Angle), calculation));
+	REQUIRE(ResolveCalculation(*calculation, context, resolved));
+	CHECK(resolved.is_constant);
+	CHECK(resolved.unit == Unit::RAD);
+	CHECK(resolved.value == doctest::Approx(float(3.14159265358979323846 * 0.5 + 0.5)));
+
+	REQUIRE(ParseCalculation("calc(2x * 3)", MakeCalculationParseTarget(CalculationFinalType::Resolution), calculation));
+	REQUIRE(ResolveCalculation(*calculation, context, resolved));
+	CHECK(resolved.is_constant);
+	CHECK(resolved.unit == Unit::X);
+	CHECK(resolved.value == doctest::Approx(6.f));
+
+	// Dependency collection is from the raw parsed tree, before pure/context simplification.
+	REQUIRE(ParseCalculation("calc(1em - 1em + 5px)", length, calculation));
+	CHECK(Any(calculation->GetDependencyMask() & Unit::EM));
+}
+
+TEST_CASE("Calculation.used_values.wpt_basis_sensitive")
+{
+	Context* context = TestsShell::GetContext();
+	REQUIRE(context);
+	ElementDocument* document = context->CreateDocument();
+	REQUIRE(document);
+	CHECK(document->SetProperty("font-size", "20px"));
+	document->UpdateDocument();
+
+	struct Case {
+		const char* expression;
+		float basis;
+		float expected;
+	};
+	const Case cases[] = {
+		{"min(20px, 10%)", 400.f, 20.f},
+		{"min(20px, 10%)", 100.f, 10.f},
+		{"max(20px, 10%)", 400.f, 40.f},
+		{"max(20px, 10%)", 100.f, 20.f},
+		{"min(30px + 10%, 60px + 5%)", 400.f, 70.f},
+		{"max(2em + 10%, 1em + 20%)", 400.f, 100.f},
+		{"calc(min(1.5em, 10%) + 10px)", 400.f, 40.f},
+		{"calc(min(1.5em, 10%) - 10px)", 400.f, 20.f},
+		{"calc(min(1.5em, 10%) * 2)", 400.f, 60.f},
+		{"calc(min(1.5em, 10%) / 2)", 400.f, 15.f},
+		{"calc(max(1em, 15%) + 10px)", 400.f, 70.f},
+		{"calc(max(1em, 15%) / 2)", 400.f, 30.f},
+		{"calc(calc(60%) - 20px)", 400.f, 220.f},
+	};
+
+	for (const Case& test : cases)
+	{
+		CAPTURE(String(test.expression));
+		REQUIRE(document->SetProperty("width", test.expression));
+		document->UpdateDocument();
+		const auto width = document->GetComputedValues().width();
+		CHECK(ResolveValue(width, test.basis) == doctest::Approx(test.expected));
+	}
+
+	// Invalid used-value bases take the existing fallback without mutating the calculation.
+	REQUIRE(document->SetProperty("width", "max(50%, 300px)"));
+	document->UpdateDocument();
+	const auto width = document->GetComputedValues().width();
+	REQUIRE(width.type == Style::LengthPercentageAuto::Calculation);
+	REQUIRE(bool(width.calculation));
+	CHECK(ResolveValueOr(width, -1.f, 123.f) == doctest::Approx(123.f));
+
+	document->Close();
+	TestsShell::ShutdownShell();
+}
+
+TEST_CASE("Calculation.used_values.layout_reuses_residual_with_current_geometry")
+{
+	Context* context = TestsShell::GetContext();
+	REQUIRE(context);
+	const String rml = R"RML(
+<rml><head><link type="text/rcss" href="/../Tests/Data/style.rcss"/><style>
+body { margin: 0; }
+#parent { width: 400px; height: 300px; position: relative; }
+#child { width: calc(50% - 20px); height: calc(50% - 10px); min-width: calc(25% + 10px); max-width: calc(75% - 10px);
+         margin-left: calc(10% + 2px); margin-top: calc(10% + 2px); padding-left: calc(5% + 1px); padding-top: calc(5% + 1px);
+         position: relative; left: calc(25% - 5px); }
+#absolute { position: absolute; width: 10px; height: 10px; left: calc(25% - 5px); top: calc(50% - 10px); }
+</style></head><body><div id="parent"><div id="child"/><div id="absolute"/></div></body></rml>)RML";
+	ElementDocument* document = context->LoadDocumentFromMemory(rml);
+	REQUIRE(document);
+	document->Show();
+	TestsShell::RenderLoop();
+
+	Element* parent = document->GetElementById("parent");
+	Element* child = document->GetElementById("child");
+	Element* absolute = document->GetElementById("absolute");
+	REQUIRE(parent);
+	REQUIRE(child);
+	REQUIRE(absolute);
+	const auto initial_width = child->GetComputedValues().width();
+	REQUIRE(initial_width.type == Style::LengthPercentageAuto::Calculation);
+	REQUIRE(bool(initial_width.calculation));
+	const Calculation* calculation_identity = initial_width.calculation.get();
+	CHECK(child->GetBox().GetSize().x == doctest::Approx(180.f));
+	CHECK(child->GetBox().GetSize().y == doctest::Approx(140.f));
+	CHECK(child->GetBox().GetEdge(BoxArea::Margin, BoxEdge::Left) == doctest::Approx(42.f));
+	CHECK(child->GetBox().GetEdge(BoxArea::Margin, BoxEdge::Top) == doctest::Approx(32.f));
+	CHECK(child->GetBox().GetEdge(BoxArea::Padding, BoxEdge::Left) == doctest::Approx(21.f));
+	CHECK(child->GetBox().GetEdge(BoxArea::Padding, BoxEdge::Top) == doctest::Approx(21.f));
+	CHECK(absolute->GetOffsetLeft() == doctest::Approx(95.f));
+	CHECK(absolute->GetOffsetTop() == doctest::Approx(140.f));
+
+	REQUIRE(parent->SetProperty("width", "1000px"));
+	REQUIRE(parent->SetProperty("height", "600px"));
+	TestsShell::RenderLoop();
+	const auto resized_width = child->GetComputedValues().width();
+	REQUIRE(bool(resized_width.calculation));
+	CHECK(resized_width.calculation.get() == calculation_identity);
+	CHECK(child->GetBox().GetSize().x == doctest::Approx(480.f));
+	CHECK(child->GetBox().GetSize().y == doctest::Approx(290.f));
+	CHECK(child->GetBox().GetEdge(BoxArea::Margin, BoxEdge::Left) == doctest::Approx(102.f));
+	CHECK(child->GetBox().GetEdge(BoxArea::Margin, BoxEdge::Top) == doctest::Approx(62.f));
+	CHECK(child->GetBox().GetEdge(BoxArea::Padding, BoxEdge::Left) == doctest::Approx(51.f));
+	CHECK(child->GetBox().GetEdge(BoxArea::Padding, BoxEdge::Top) == doctest::Approx(51.f));
+	CHECK(absolute->GetOffsetLeft() == doctest::Approx(245.f));
+	CHECK(absolute->GetOffsetTop() == doctest::Approx(290.f));
+
+	document->Close();
+	TestsShell::ShutdownShell();
+}
+
+TEST_CASE("Calculation.used_values.flex_table_gap_and_origins")
+{
+	Context* context = TestsShell::GetContext();
+	REQUIRE(context);
+	const String rml = R"RML(
+<rml><head><link type="text/rcss" href="/../Tests/Data/style.rcss"/><style>
+body { margin: 0; }
+#flex { display: flex; width: 400px; height: 100px; column-gap: calc(10% + 2px); }
+#flex > div { flex: 0 0 calc(25% - 5px); height: 20px; }
+#table { display: table; width: 400px; }
+#row { display: table-row; }
+#cell { display: table-cell; width: calc(50% + 1px); height: 20px; }
+#origin { width: 200px; height: 100px; transform-origin: calc(50% + 10px) calc(25% - 5px); perspective-origin: calc(25% + 5px) calc(75% - 5px); }
+#origin-wpt-one { width: 200px; height: 100px; transform-origin: calc(50px + 50%) calc(100% - 30px); }
+#origin-wpt-two { width: 200px; height: 100px; transform-origin: calc(-12.5% + 3px) calc(-10px - 50%); }
+</style></head><body>
+<div id="flex"><div id="f1"/><div id="f2"/></div>
+<div id="table"><div id="row"><div id="cell"/></div></div>
+<div id="origin"/>
+<div id="origin-wpt-one"/>
+<div id="origin-wpt-two"/>
+</body></rml>)RML";
+	ElementDocument* document = context->LoadDocumentFromMemory(rml);
+	REQUIRE(document);
+	document->Show();
+	TestsShell::RenderLoop();
+
+	Element* flex = document->GetElementById("flex");
+	Element* f1 = document->GetElementById("f1");
+	Element* f2 = document->GetElementById("f2");
+	Element* cell = document->GetElementById("cell");
+	Element* origin = document->GetElementById("origin");
+	Element* origin_wpt_one = document->GetElementById("origin-wpt-one");
+	Element* origin_wpt_two = document->GetElementById("origin-wpt-two");
+	REQUIRE(flex);
+	REQUIRE(f1);
+	REQUIRE(f2);
+	REQUIRE(cell);
+	REQUIRE(origin);
+	REQUIRE(origin_wpt_one);
+	REQUIRE(origin_wpt_two);
+	CHECK(f1->GetBox().GetSize().x == doctest::Approx(95.f));
+	CHECK(f2->GetAbsoluteLeft() - (f1->GetAbsoluteLeft() + f1->GetBox().GetSize(BoxArea::Border).x) == doctest::Approx(42.f));
+	CHECK(ResolveValue(cell->GetComputedValues().width(), 400.f) == doctest::Approx(201.f));
+	CHECK(cell->GetBox().GetSize().x > 0.f);
+
+	const auto& computed = origin->GetComputedValues();
+	CHECK(ResolveValue(computed.transform_origin_x(), 200.f) == doctest::Approx(110.f));
+	CHECK(ResolveValue(computed.transform_origin_y(), 100.f) == doctest::Approx(20.f));
+	CHECK(ResolveValue(computed.perspective_origin_x(), 200.f) == doctest::Approx(55.f));
+	CHECK(ResolveValue(computed.perspective_origin_y(), 100.f) == doctest::Approx(70.f));
+	const auto& wpt_one = origin_wpt_one->GetComputedValues();
+	CHECK(ResolveValue(wpt_one.transform_origin_x(), 200.f) == doctest::Approx(150.f));
+	CHECK(ResolveValue(wpt_one.transform_origin_y(), 100.f) == doctest::Approx(70.f));
+	const auto& wpt_two = origin_wpt_two->GetComputedValues();
+	CHECK(ResolveValue(wpt_two.transform_origin_x(), 200.f) == doctest::Approx(-22.f));
+	CHECK(ResolveValue(wpt_two.transform_origin_y(), 100.f) == doctest::Approx(-60.f));
+
+	document->Close();
+	TestsShell::ShutdownShell();
+}
+
+TEST_CASE("Calculation.used_values.wpt_layout_expression_matrix")
+{
+	Context* context = TestsShell::GetContext();
+	REQUIRE(context);
+	ElementDocument* document = context->CreateDocument();
+	REQUIRE(document);
+
+	enum class Accessor { Width, Height, MinWidth, MaxWidth, MinHeight, MaxHeight, Left, Right, Top, Bottom, MarginLeft, PaddingLeft };
+	struct Case {
+		const char* source;
+		const char* property;
+		const char* expression;
+		Accessor accessor;
+		float basis;
+		float expected;
+	};
+
+	const Case cases[] = {
+		// calc-width-block-1.html, calc-min-width-block-1.html, calc-max-width-block-1.html.
+		{"calc-width-block-1.html", "width", "calc(50% - 3px)", Accessor::Width, 500.f, 247.f},
+		{"calc-width-block-1.html", "width", "calc(25% - 3px + 25%)", Accessor::Width, 500.f, 247.f},
+		{"calc-width-block-1.html", "width", "calc(25% - 3px + 12.5% * 2)", Accessor::Width, 500.f, 247.f},
+		{"calc-width-block-1.html", "width", "calc(25% - 3px + 12.5%*2)", Accessor::Width, 500.f, 247.f},
+		{"calc-width-block-1.html", "width", "calc(25% - 3px + 2*12.5%)", Accessor::Width, 500.f, 247.f},
+		{"calc-width-block-1.html", "width", "calc(25% - 3px + 2 * 12.5%)", Accessor::Width, 500.f, 247.f},
+		{"calc-width-block-1.html", "width", "calc(30% + 20%)", Accessor::Width, 500.f, 250.f},
+		{"calc-min-width-block-1.html", "min-width", "calc(50% - 3px)", Accessor::MinWidth, 500.f, 247.f},
+		{"calc-min-width-block-1.html", "min-width", "calc(25% - 3px + 25%)", Accessor::MinWidth, 500.f, 247.f},
+		{"calc-min-width-block-1.html", "min-width", "calc(25% - 3px + 12.5% * 2)", Accessor::MinWidth, 500.f, 247.f},
+		{"calc-min-width-block-1.html", "min-width", "calc(25% - 3px + 12.5%*2)", Accessor::MinWidth, 500.f, 247.f},
+		{"calc-min-width-block-1.html", "min-width", "calc(25% - 3px + 2*12.5%)", Accessor::MinWidth, 500.f, 247.f},
+		{"calc-min-width-block-1.html", "min-width", "calc(25% - 3px + 2 * 12.5%)", Accessor::MinWidth, 500.f, 247.f},
+		{"calc-min-width-block-1.html", "min-width", "calc(30% + 20%)", Accessor::MinWidth, 500.f, 250.f},
+		{"calc-max-width-block-1.html", "max-width", "calc(50% - 3px)", Accessor::MaxWidth, 500.f, 247.f},
+		{"calc-max-width-block-1.html", "max-width", "calc(25% - 3px + 25%)", Accessor::MaxWidth, 500.f, 247.f},
+		{"calc-max-width-block-1.html", "max-width", "calc(25% - 3px + 12.5% * 2)", Accessor::MaxWidth, 500.f, 247.f},
+		{"calc-max-width-block-1.html", "max-width", "calc(25% - 3px + 12.5%*2)", Accessor::MaxWidth, 500.f, 247.f},
+		{"calc-max-width-block-1.html", "max-width", "calc(25% - 3px + 2*12.5%)", Accessor::MaxWidth, 500.f, 247.f},
+		{"calc-max-width-block-1.html", "max-width", "calc(25% - 3px + 2 * 12.5%)", Accessor::MaxWidth, 500.f, 247.f},
+		{"calc-max-width-block-1.html", "max-width", "calc(30% + 20%)", Accessor::MaxWidth, 500.f, 250.f},
+
+		// calc-height-block-1.html and min/max-height variants share the same six arithmetic rows.
+		{"calc-height-block-1.html", "height", "calc(50px)", Accessor::Height, 100.f, 50.f},
+		{"calc-height-block-1.html", "height", "calc(50%)", Accessor::Height, 100.f, 50.f},
+		{"calc-height-block-1.html", "height", "calc(25px + 50%)", Accessor::Height, 100.f, 75.f},
+		{"calc-height-block-1.html", "height", "calc(150% / 2 - 30px)", Accessor::Height, 100.f, 45.f},
+		{"calc-height-block-1.html", "height", "calc(40px + 10% - 20% / 2)", Accessor::Height, 100.f, 40.f},
+		{"calc-height-block-1.html", "height", "calc(40px - 10%)", Accessor::Height, 100.f, 30.f},
+		{"calc-min-height-block-1.html", "min-height", "calc(50%)", Accessor::MinHeight, 100.f, 50.f},
+		{"calc-min-height-block-1.html", "min-height", "calc(25px + 50%)", Accessor::MinHeight, 100.f, 75.f},
+		{"calc-min-height-block-1.html", "min-height", "calc(150% / 2 - 30px)", Accessor::MinHeight, 100.f, 45.f},
+		{"calc-min-height-block-1.html", "min-height", "calc(40px + 10% - 20% / 2)", Accessor::MinHeight, 100.f, 40.f},
+		{"calc-min-height-block-1.html", "min-height", "calc(40px - 10%)", Accessor::MinHeight, 100.f, 30.f},
+		{"calc-max-height-block-1.html", "max-height", "calc(50%)", Accessor::MaxHeight, 100.f, 50.f},
+		{"calc-max-height-block-1.html", "max-height", "calc(25px + 50%)", Accessor::MaxHeight, 100.f, 75.f},
+		{"calc-max-height-block-1.html", "max-height", "calc(150% / 2 - 30px)", Accessor::MaxHeight, 100.f, 45.f},
+		{"calc-max-height-block-1.html", "max-height", "calc(40px + 10% - 20% / 2)", Accessor::MaxHeight, 100.f, 40.f},
+		{"calc-max-height-block-1.html", "max-height", "calc(40px - 10%)", Accessor::MaxHeight, 100.f, 30.f},
+		{"calc-min-height.html", "min-height", "calc(50% - 100px)", Accessor::MinHeight, 400.f, 100.f},
+
+		// Absolute/relative offset WPT arithmetic. The owning positioning mode is exercised separately by the layout fixture.
+		{"calc-offsets-absolute-left-1.html", "left", "calc(50px)", Accessor::Left, 100.f, 50.f},
+		{"calc-offsets-absolute-left-1.html", "left", "calc(-25%)", Accessor::Left, 100.f, -25.f},
+		{"calc-offsets-absolute-left-1.html", "left", "calc(25px + 25%)", Accessor::Left, 100.f, 50.f},
+		{"calc-offsets-absolute-left-1.html", "left", "calc(-75% / 2 + 30px)", Accessor::Left, 100.f, -7.5f},
+		{"calc-offsets-absolute-left-1.html", "left", "calc(40px + 5% - 10% / 2)", Accessor::Left, 100.f, 40.f},
+		{"calc-offsets-absolute-left-1.html", "left", "calc(5% - 40px)", Accessor::Left, 100.f, -35.f},
+		{"calc-offsets-absolute-right-1.html", "right", "calc(-50px)", Accessor::Right, 100.f, -50.f},
+		{"calc-offsets-absolute-right-1.html", "right", "calc(25%)", Accessor::Right, 100.f, 25.f},
+		{"calc-offsets-absolute-right-1.html", "right", "calc(-25px - 25%)", Accessor::Right, 100.f, -50.f},
+		{"calc-offsets-absolute-right-1.html", "right", "calc(75% / 2 - 30px)", Accessor::Right, 100.f, 7.5f},
+		{"calc-offsets-absolute-right-1.html", "right", "calc(-40px - 5% + 10% / 2)", Accessor::Right, 100.f, -40.f},
+		{"calc-offsets-absolute-right-1.html", "right", "calc(-5% + 40px)", Accessor::Right, 100.f, 35.f},
+		{"calc-offsets-absolute-top-1.html", "top", "calc(50px)", Accessor::Top, 100.f, 50.f},
+		{"calc-offsets-absolute-top-1.html", "top", "calc(50%)", Accessor::Top, 100.f, 50.f},
+		{"calc-offsets-absolute-top-1.html", "top", "calc(25px + 50%)", Accessor::Top, 100.f, 75.f},
+		{"calc-offsets-absolute-top-1.html", "top", "calc(150% / 2 - 30px)", Accessor::Top, 100.f, 45.f},
+		{"calc-offsets-absolute-top-1.html", "top", "calc(40px + 10% - 20% / 2)", Accessor::Top, 100.f, 40.f},
+		{"calc-offsets-absolute-top-1.html", "top", "calc(40px - 10%)", Accessor::Top, 100.f, 30.f},
+		{"calc-offsets-absolute-bottom-1.html", "bottom", "calc(-50px)", Accessor::Bottom, 100.f, -50.f},
+		{"calc-offsets-absolute-bottom-1.html", "bottom", "calc(-50%)", Accessor::Bottom, 100.f, -50.f},
+		{"calc-offsets-absolute-bottom-1.html", "bottom", "calc(-25px - 50%)", Accessor::Bottom, 100.f, -75.f},
+		{"calc-offsets-absolute-bottom-1.html", "bottom", "calc(-150% / 2 + 30px)", Accessor::Bottom, 100.f, -45.f},
+		{"calc-offsets-absolute-bottom-1.html", "bottom", "calc(-40px - 10% + 20% / 2)", Accessor::Bottom, 100.f, -40.f},
+		{"calc-offsets-absolute-bottom-1.html", "bottom", "calc(-40px + 10%)", Accessor::Bottom, 100.f, -30.f},
+		{"calc-offsets-relative-left-1.html", "left", "calc(50px)", Accessor::Left, 100.f, 50.f},
+		{"calc-offsets-relative-left-1.html", "left", "calc(-50%)", Accessor::Left, 100.f, -50.f},
+		{"calc-offsets-relative-left-1.html", "left", "calc(25px + 50%)", Accessor::Left, 100.f, 75.f},
+		{"calc-offsets-relative-left-1.html", "left", "calc(-150% / 2 + 30px)", Accessor::Left, 100.f, -45.f},
+		{"calc-offsets-relative-left-1.html", "left", "calc(40px + 10% - 20% / 2)", Accessor::Left, 100.f, 40.f},
+		{"calc-offsets-relative-left-1.html", "left", "calc(10% - 40px)", Accessor::Left, 100.f, -30.f},
+		{"calc-offsets-relative-right-1.html", "right", "calc(-50px)", Accessor::Right, 100.f, -50.f},
+		{"calc-offsets-relative-right-1.html", "right", "calc(50%)", Accessor::Right, 100.f, 50.f},
+		{"calc-offsets-relative-right-1.html", "right", "calc(-25px - 50%)", Accessor::Right, 100.f, -75.f},
+		{"calc-offsets-relative-right-1.html", "right", "calc(150% / 2 - 30px)", Accessor::Right, 100.f, 45.f},
+		{"calc-offsets-relative-right-1.html", "right", "calc(-40px - 10% + 20% / 2)", Accessor::Right, 100.f, -40.f},
+		{"calc-offsets-relative-right-1.html", "right", "calc(-10% + 40px)", Accessor::Right, 100.f, 30.f},
+		{"calc-offsets-relative-top-1.html", "top", "calc(50px)", Accessor::Top, 100.f, 50.f},
+		{"calc-offsets-relative-top-1.html", "top", "calc(50%)", Accessor::Top, 100.f, 50.f},
+		{"calc-offsets-relative-top-1.html", "top", "calc(25px + 50%)", Accessor::Top, 100.f, 75.f},
+		{"calc-offsets-relative-top-1.html", "top", "calc(150% / 2 - 30px)", Accessor::Top, 100.f, 45.f},
+		{"calc-offsets-relative-top-1.html", "top", "calc(40px + 10% - 20% / 2)", Accessor::Top, 100.f, 40.f},
+		{"calc-offsets-relative-top-1.html", "top", "calc(40px - 10%)", Accessor::Top, 100.f, 30.f},
+		{"calc-offsets-relative-bottom-1.html", "bottom", "calc(-50px)", Accessor::Bottom, 100.f, -50.f},
+		{"calc-offsets-relative-bottom-1.html", "bottom", "calc(-50%)", Accessor::Bottom, 100.f, -50.f},
+		{"calc-offsets-relative-bottom-1.html", "bottom", "calc(-25px - 50%)", Accessor::Bottom, 100.f, -75.f},
+		{"calc-offsets-relative-bottom-1.html", "bottom", "calc(-150% / 2 + 30px)", Accessor::Bottom, 100.f, -45.f},
+		{"calc-offsets-relative-bottom-1.html", "bottom", "calc(-40px - 10% + 20% / 2)", Accessor::Bottom, 100.f, -40.f},
+		{"calc-offsets-relative-bottom-1.html", "bottom", "calc(-40px + 10%)", Accessor::Bottom, 100.f, -30.f},
+
+		// Margin and padding percentages use containing-block width on every side in RmlUi/CSS.
+		{"calc-margin-block-1.html", "margin-left", "calc(10px + 1%)", Accessor::MarginLeft, 500.f, 15.f},
+		{"calc-margin-block-1.html", "margin-left", "calc(30px - 1%)", Accessor::MarginLeft, 500.f, 25.f},
+		{"calc-padding-block-1.html", "padding-left", "calc(10px + 1%)", Accessor::PaddingLeft, 500.f, 15.f},
+		{"calc-padding-block-1.html", "padding-left", "calc(30px - 1%)", Accessor::PaddingLeft, 500.f, 25.f},
+	};
+
+	for (const Case& test : cases)
+	{
+		CAPTURE(String(test.source));
+		CAPTURE(String(test.property));
+		CAPTURE(String(test.expression));
+		REQUIRE(document->SetProperty(test.property, test.expression));
+		document->UpdateDocument();
+		const auto& computed = document->GetComputedValues();
+		float value = 0.f;
+		switch (test.accessor)
+		{
+		case Accessor::Width: value = ResolveValue(computed.width(), test.basis); break;
+		case Accessor::Height: value = ResolveValue(computed.height(), test.basis); break;
+		case Accessor::MinWidth: value = ResolveValue(computed.min_width(), test.basis); break;
+		case Accessor::MaxWidth: value = ResolveValue(computed.max_width(), test.basis); break;
+		case Accessor::MinHeight: value = ResolveValue(computed.min_height(), test.basis); break;
+		case Accessor::MaxHeight: value = ResolveValue(computed.max_height(), test.basis); break;
+		case Accessor::Left: value = ResolveValue(computed.left(), test.basis); break;
+		case Accessor::Right: value = ResolveValue(computed.right(), test.basis); break;
+		case Accessor::Top: value = ResolveValue(computed.top(), test.basis); break;
+		case Accessor::Bottom: value = ResolveValue(computed.bottom(), test.basis); break;
+		case Accessor::MarginLeft: value = ResolveValue(computed.margin_left(), test.basis); break;
+		case Accessor::PaddingLeft: value = ResolveValue(computed.padding_left(), test.basis); break;
+		}
+		CHECK(value == doctest::Approx(test.expected));
+	}
+
+	document->Close();
+	TestsShell::ShutdownShell();
+}
+
+TEST_CASE("Calculation.used_values.wpt_intrinsic_width_vectors")
+{
+	Context* context = TestsShell::GetContext();
+	REQUIRE(context);
+	const String rml = R"RML(
+<rml><head><link type="text/rcss" href="/../Tests/Data/style.rcss"/><style>
+body { width: 500px; font-size: 10px; }
+.outer { float: left; clear: left; height: 5px; }
+.inner { width: 200px; }
+</style></head><body>
+<div id="w1" class="outer" style="width: calc(50% - 3px)"><div class="inner"/></div>
+<div id="w2" class="outer" style="width: calc(5em - 3px)"><div class="inner"/></div>
+<div id="w3" class="outer" style="width: calc(5em - 0%)"><div class="inner"/></div>
+<div id="w4" class="outer" style="width: calc(50%)"><div class="inner"/></div>
+<div id="w5" class="outer" style="width: calc(50px)"><div class="inner"/></div>
+<div id="w6" class="outer" style="width: calc(25% + 25%)"><div class="inner"/></div>
+<div id="max1" class="outer" style="max-width: calc(50% - 3px)"><div class="inner"/></div>
+<div id="max2" class="outer" style="max-width: calc(5em - 3px)"><div class="inner"/></div>
+<div id="max3" class="outer" style="max-width: calc(5em - 0%)"><div class="inner"/></div>
+<div id="max4" class="outer" style="max-width: calc(50%)"><div class="inner"/></div>
+<div id="max5" class="outer" style="max-width: calc(50px)"><div class="inner"/></div>
+<div id="max6" class="outer" style="max-width: calc(25% + 25%)"><div class="inner"/></div>
+<div id="min1" class="outer" style="min-width: calc(50% - 3px)"><div class="inner"/></div>
+<div id="min2" class="outer" style="min-width: calc(5em - 3px)"><div class="inner"/></div>
+<div id="min3" class="outer" style="min-width: calc(5em - 0%)"><div class="inner"/></div>
+<div id="min4" class="outer" style="min-width: calc(50%)"><div class="inner"/></div>
+<div id="min5" class="outer" style="min-width: calc(50px)"><div class="inner"/></div>
+<div id="min6" class="outer" style="min-width: calc(25% + 25%)"><div class="inner"/></div>
+</body></rml>)RML";
+	ElementDocument* document = context->LoadDocumentFromMemory(rml);
+	REQUIRE(document);
+	document->Show();
+	TestsShell::RenderLoop();
+
+	const char* ids[] = {"w1", "w2", "w3", "w4", "w5", "w6", "max1", "max2", "max3", "max4", "max5", "max6", "min1", "min2", "min3", "min4", "min5",
+		"min6"};
+	const float expected[] = {247.f, 47.f, 50.f, 250.f, 50.f, 250.f, 200.f, 47.f, 50.f, 200.f, 50.f, 200.f, 247.f, 200.f, 200.f, 250.f, 200.f, 250.f};
+	for (size_t i = 0; i < Count(ids); ++i)
+	{
+		CAPTURE(String(ids[i]));
+		Element* element = document->GetElementById(ids[i]);
+		REQUIRE(element);
+		CHECK(element->GetBox().GetSize().x == doctest::Approx(expected[i]));
+	}
+
+	document->Close();
+	TestsShell::ShutdownShell();
+}
+
+TEST_CASE("Calculation.properties.direct_scalar_and_shorthand_coverage")
+{
+	Context* context = TestsShell::GetContext();
+	REQUIRE(context);
+	context->SetDimensions(Vector2i(800, 400));
+	context->SetDensityIndependentPixelRatio(1.f);
+	ElementDocument* document = context->CreateDocument();
+	REQUIRE(document);
+
+	// Source: css/css-values/calc-numbers.html. The in-scope authored opacity rows use Number math.
+	CHECK(document->SetProperty("opacity", "calc(2 / 4)"));
+	document->UpdateDocument();
+	CHECK(document->GetComputedValues().opacity() == doctest::Approx(0.5f));
+
+	// Direct scalar owners must resolve calculations before reaching legacy scalar extraction paths.
+	CHECK(document->SetProperty("clip", "calc(1 + 2)"));
+	CHECK(document->SetProperty("font-weight", "calc(300 + 100)"));
+	CHECK(document->SetProperty("flex-grow", "calc(1 + 2)"));
+	CHECK(document->SetProperty("flex-shrink", "calc(4 / 2)"));
+	CHECK(document->SetProperty("font-size", "20px"));
+	CHECK(document->SetProperty("letter-spacing", "calc(1em + 2px)"));
+	document->UpdateDocument();
+	CHECK(document->GetComputedValues().clip().GetNumber() == 3);
+	CHECK(document->GetComputedValues().font_weight() == static_cast<Style::FontWeight>(400));
+	CHECK(document->GetComputedValues().flex_grow() == doctest::Approx(3.f));
+	CHECK(document->GetComputedValues().flex_shrink() == doctest::Approx(2.f));
+	CHECK(document->GetComputedValues().letter_spacing() == doctest::Approx(22.f));
+
+	// Each registered longhand below must accept math through its
+	// existing parser category; this deliberately does not broaden any property's grammar.
+	struct DirectPropertyCase {
+		const char* property;
+		const char* expression;
+	};
+	const DirectPropertyCase direct_property_cases[] = {
+		{"margin-top", "calc(1px + 1%)"},
+		{"margin-right", "calc(1px + 1%)"},
+		{"margin-bottom", "calc(1px + 1%)"},
+		{"margin-left", "calc(1px + 1%)"},
+		{"padding-top", "calc(1px + 1%)"},
+		{"padding-right", "calc(1px + 1%)"},
+		{"padding-bottom", "calc(1px + 1%)"},
+		{"padding-left", "calc(1px + 1%)"},
+		{"border-top-width", "calc(1px + 2px)"},
+		{"border-right-width", "calc(1px + 2px)"},
+		{"border-bottom-width", "calc(1px + 2px)"},
+		{"border-left-width", "calc(1px + 2px)"},
+		{"border-top-left-radius", "calc(1px + 2px)"},
+		{"border-top-right-radius", "calc(1px + 2px)"},
+		{"border-bottom-right-radius", "calc(1px + 2px)"},
+		{"border-bottom-left-radius", "calc(1px + 2px)"},
+		{"top", "calc(1px + 1%)"},
+		{"right", "calc(1px + 1%)"},
+		{"bottom", "calc(1px + 1%)"},
+		{"left", "calc(1px + 1%)"},
+		{"z-index", "calc(1 + 2)"},
+		{"width", "calc(1px + 1%)"},
+		{"min-width", "calc(1px + 1%)"},
+		{"max-width", "calc(1px + 1%)"},
+		{"height", "calc(1px + 1%)"},
+		{"min-height", "calc(1px + 1%)"},
+		{"max-height", "calc(1px + 1%)"},
+		{"line-height", "calc(1em + 1px)"},
+		{"vertical-align", "calc(1px + 1%)"},
+		{"clip", "calc(1 + 2)"},
+		{"opacity", "calc(1 / 2)"},
+		{"font-weight", "calc(300 + 100)"},
+		{"font-size", "calc(1em + 1px)"},
+		{"letter-spacing", "calc(1em + 1px)"},
+		{"row-gap", "calc(1px + 1%)"},
+		{"column-gap", "calc(1px + 1%)"},
+		{"scrollbar-margin", "calc(1px + 2px)"},
+		{"perspective", "calc(1px + 2px)"},
+		{"perspective-origin-x", "calc(1px + 1%)"},
+		{"perspective-origin-y", "calc(1px + 1%)"},
+		{"transform-origin-x", "calc(1px + 1%)"},
+		{"transform-origin-y", "calc(1px + 1%)"},
+		{"transform-origin-z", "calc(1px + 2px)"},
+		{"flex-basis", "calc(1px + 1%)"},
+		{"flex-grow", "calc(1 + 2)"},
+		{"flex-shrink", "calc(4 / 2)"},
+	};
+	for (const DirectPropertyCase& test : direct_property_cases)
+	{
+		CAPTURE(String(test.property));
+		CAPTURE(String(test.expression));
+		CHECK(document->SetProperty(test.property, test.expression));
+	}
+	document->UpdateDocument();
+	CHECK(document->GetComputedValues().vertical_align().type == Style::VerticalAlign::Length);
+
+	// Required shorthands stay on PropertySpecification::ParsePropertyValues(). Nested function
+	// whitespace and commas must remain inside the shorthand component rather than being retokenized.
+	CHECK(document->SetProperty("margin", "calc(10px + min(5px, 10px)) calc(20px + max(1px, 2px))"));
+	CHECK(document->SetProperty("padding", "calc(1px + min(2px, 3px)) calc(4px + max(5px, 6px))"));
+	CHECK(document->SetProperty("border-width", "calc(1px + min(2px, 3px)) calc(4px + max(5px, 6px))"));
+	CHECK(document->SetProperty("border-top", "calc(1px + min(2px, 3px)) #fff"));
+	CHECK(document->SetProperty("border-right", "calc(1px + min(2px, 3px)) #fff"));
+	CHECK(document->SetProperty("border-bottom", "calc(1px + min(2px, 3px)) #fff"));
+	CHECK(document->SetProperty("border-left", "calc(1px + min(2px, 3px)) #fff"));
+	CHECK(document->SetProperty("border", "calc(1px + min(2px, 3px)) #fff"));
+	CHECK(document->SetProperty("border-radius", "calc(1px + min(2px, 3px)) calc(4px + max(5px, 6px))"));
+	CHECK(document->SetProperty("inset", "calc(1px + min(2px, 3px)) calc(4px + max(5px, 6px))"));
+	CHECK(document->SetProperty("font", "normal calc(300 + 100) calc(10px + min(10px, 20px)) LatoLatin"));
+	CHECK(document->SetProperty("gap", "calc(1px + min(2px, 3px)) calc(4px + max(5px, 6px))"));
+	CHECK(document->SetProperty("perspective-origin", "calc(25% + min(1px, 2px)) calc(75% - max(1px, 2px))"));
+	CHECK(document->SetProperty("transform-origin", "calc(25% + min(1px, 2px)) calc(75% - max(1px, 2px)) calc(1px + min(2px, 3px))"));
+	CHECK(document->SetProperty("flex", "calc(1 + 2) calc(4 / 2) calc(25% + min(1px, 2px))"));
+	document->UpdateDocument();
+	CHECK(ResolveValue(document->GetComputedValues().margin_top(), 100.f) == doctest::Approx(15.f));
+	CHECK(ResolveValue(document->GetComputedValues().margin_right(), 100.f) == doctest::Approx(22.f));
+	CHECK(ResolveValue(document->GetComputedValues().padding_top(), 100.f) == doctest::Approx(3.f));
+	CHECK(document->GetComputedValues().flex_grow() == doctest::Approx(3.f));
+	CHECK(document->GetComputedValues().flex_shrink() == doctest::Approx(2.f));
+	CHECK(ResolveValue(document->GetComputedValues().flex_basis(), 100.f) == doctest::Approx(26.f));
+	CHECK(document->GetComputedValues().border_top_width() == doctest::Approx(3.f));
+	CHECK(document->GetComputedValues().border_top_left_radius() == doctest::Approx(3.f));
+	CHECK(document->GetComputedValues().font_weight() == static_cast<Style::FontWeight>(400));
+	CHECK(document->GetComputedValues().font_size() == doctest::Approx(20.f));
+
+	document->Close();
+	TestsShell::ShutdownShell();
+}
+
+TEST_CASE("Calculation.properties.custom_property_and_context_invalidation")
+{
+	Context* context = TestsShell::GetContext();
+	REQUIRE(context);
+	context->SetDimensions(Vector2i(800, 400));
+	context->SetDensityIndependentPixelRatio(1.f);
+	const String rml = R"RML(
+<rml><head><link type="text/rcss" href="/../Tests/Data/style.rcss"/></head><body>
+<div id="parent" style="font-size: 20px; width: 400px">
+<div id="direct" style="width: calc(1em + 1rem + 1vw + 1vh + 1dp + 1in)"/>
+<div id="variable" style="--w: calc(1em + 1rem + 1vw + 1vh + 1dp + 1in); width: var(--w)"/>
+<div id="shorthand" style="--m: calc(1em + 1vw); margin: var(--m)"/>
+<div id="residual" style="width: calc(50% - 10px)"/>
+</div>
+</body></rml>)RML";
+	ElementDocument* document = context->LoadDocumentFromMemory(rml);
+	REQUIRE(document);
+	document->Show();
+	TestsShell::RenderLoop();
+
+	Element* parent = document->GetElementById("parent");
+	Element* direct = document->GetElementById("direct");
+	Element* variable = document->GetElementById("variable");
+	Element* shorthand = document->GetElementById("shorthand");
+	Element* residual = document->GetElementById("residual");
+	REQUIRE(parent);
+	REQUIRE(direct);
+	REQUIRE(variable);
+	REQUIRE(shorthand);
+	REQUIRE(residual);
+
+	auto direct_width = [&]() { return direct->GetComputedValues().width().value; };
+	auto variable_width = [&]() { return variable->GetComputedValues().width().value; };
+	CHECK(direct_width() == doctest::Approx(variable_width()));
+	const float initial = direct_width();
+	const float shorthand_initial = ResolveValue(shorthand->GetComputedValues().margin_left(), 400.f);
+
+	// Parent/local font-size changes must invalidate both direct and var-backed em calculations.
+	REQUIRE(parent->SetProperty("font-size", "30px"));
+	TestsShell::RenderLoop();
+	CHECK(direct_width() == doctest::Approx(variable_width()));
+	CHECK(direct_width() == doctest::Approx(initial + 10.f));
+	CHECK(ResolveValue(shorthand->GetComputedValues().margin_left(), 400.f) == doctest::Approx(shorthand_initial + 10.f));
+
+	// Root font-size changes invalidate rem hidden by var() as well as direct calculations.
+	const float before_root_font = direct_width();
+	REQUIRE(document->SetProperty("font-size", "24px"));
+	TestsShell::RenderLoop();
+	CHECK(direct_width() == doctest::Approx(variable_width()));
+	CHECK(direct_width() > before_root_font);
+
+	// Viewport and dp-ratio invalidation must inspect calculation dependencies rather than the
+	// outer Unit::CALCULATION / Unit::VAR_EXPRESSION token.
+	const float before_viewport = direct_width();
+	context->SetDimensions(Vector2i(1000, 500));
+	TestsShell::RenderLoop();
+	CHECK(direct_width() == doctest::Approx(variable_width()));
+	CHECK(direct_width() > before_viewport);
+	CHECK(ResolveValue(shorthand->GetComputedValues().margin_left(), 400.f) > shorthand_initial + 10.f);
+	const float before_dp = direct_width();
+	context->SetDensityIndependentPixelRatio(2.f);
+	TestsShell::RenderLoop();
+	CHECK(direct_width() == doctest::Approx(variable_width()));
+	CHECK(direct_width() > before_dp);
+
+	// A variable change reparses through the normal property path and must replace the cached
+	// dependency with the newly resolved px-only value.
+	REQUIRE(variable->SetProperty("--w", "50px"));
+	TestsShell::RenderLoop();
+	CHECK(variable_width() == doctest::Approx(50.f));
+	context->SetDimensions(Vector2i(1200, 600));
+	context->SetDensityIndependentPixelRatio(1.f);
+	TestsShell::RenderLoop();
+	CHECK(variable_width() == doctest::Approx(50.f));
+
+	// Pure containing-block changes re-evaluate residual used values without forcing computed-value
+	// canonicalization or reparsing.
+	const auto residual_before = residual->GetComputedValues().width();
+	REQUIRE(residual_before.type == Style::LengthPercentageAuto::Calculation);
+	REQUIRE(bool(residual_before.calculation));
+	const Calculation* residual_identity = residual_before.calculation.get();
+	CHECK(residual->GetBox().GetSize().x == doctest::Approx(190.f));
+	REQUIRE(parent->SetProperty("width", "600px"));
+	TestsShell::RenderLoop();
+	const auto residual_after = residual->GetComputedValues().width();
+	REQUIRE(bool(residual_after.calculation));
+	CHECK(residual_after.calculation.get() == residual_identity);
+	CHECK(residual->GetBox().GetSize().x == doctest::Approx(290.f));
+
+	// Existing fallback and invalid-substitution behavior stays in the normal var() resolver.
+	CHECK(variable->SetProperty("width", "calc(var(--missing, 60px) / 2)"));
+	TestsShell::RenderLoop();
+	CHECK(variable_width() == doctest::Approx(30.f));
+	CHECK(variable->SetProperty("--bad", "red"));
+	CHECK(variable->SetProperty("width", "calc(var(--bad) + 1px)"));
+	TestsShell::SetNumExpectedWarnings(1);
+	TestsShell::RenderLoop();
+
+	document->Close();
+	TestsShell::ShutdownShell();
+}
+
+TEST_CASE("Calculation.time.wpt")
+{
+	for (const auto& test : time_cases)
+		CheckEvaluatesTime(test);
+	for (const auto& test : time_clamp_cases)
+		CheckEvaluatesTime(test);
+	for (const char* expression : time_invalid_cases)
+	{
+		CAPTURE(String(expression));
+		CHECK_FALSE(Parses(CalculationCorpusTarget::Time, expression));
+	}
+
+	// Time units are lexical only for time-accepting calculation targets.
+	CHECK_FALSE(Parses(CalculationCorpusTarget::Number, "calc(1s)"));
+	CHECK_FALSE(Parses(CalculationCorpusTarget::Length, "calc(1ms)"));
+	CHECK_FALSE(Parses(CalculationCorpusTarget::Time, "calc(50%)"));
+	CHECK_FALSE(Parses(CalculationCorpusTarget::Time, "calc(1px)"));
+}
+
+TEST_CASE("Calculation.time.animation_transition_integration")
+{
+	Context* context = TestsShell::GetContext();
+	REQUIRE(context);
+	ElementDocument* document = context->CreateDocument();
+	REQUIRE(document);
+
+	REQUIRE(document->SetProperty("animation", "spin calc(4s + 1ms) calc(500ms) linear-in calc(2)"));
+	const Property* animation_property = document->GetLocalProperty("animation");
+	REQUIRE(animation_property);
+	REQUIRE(animation_property->unit == Unit::ANIMATION);
+	const AnimationList animation_list = animation_property->value.GetReference<AnimationList>();
+	REQUIRE(animation_list.size() == 1);
+	CHECK(animation_list[0].duration == doctest::Approx(4.001f));
+	CHECK(animation_list[0].delay == doctest::Approx(0.5f));
+	CHECK(animation_list[0].num_iterations == 2);
+	CHECK(animation_list[0].name == "spin");
+
+	// Nested spaces/commas stay inside the math component, while a top-level comma still separates list items.
+	REQUIRE(document->SetProperty("animation", "spin min(1s, max(500ms, 2s)), other clamp(none, 1500ms, 2s)"));
+	animation_property = document->GetLocalProperty("animation");
+	REQUIRE(animation_property);
+	const AnimationList nested_animations = animation_property->value.GetReference<AnimationList>();
+	REQUIRE(nested_animations.size() == 2);
+	CHECK(nested_animations[0].duration == doctest::Approx(1.f));
+	CHECK(nested_animations[1].duration == doctest::Approx(1.5f));
+	CHECK(nested_animations[1].name == "other");
+
+	// The shared splitter is quote-aware even though the outer inline-declaration parser does not
+	// admit quoted animation names. Exercise the property parser directly so a comma/space inside a
+	// quoted component cannot be mistaken for either kind of top-level separator.
+	PropertyParserAnimation direct_animation_parser(PropertyParserAnimation::ANIMATION_PARSER);
+	Property quoted_animation_property;
+	REQUIRE(direct_animation_parser.ParseValue(quoted_animation_property, "\"quoted, name\" min(1s, max(500ms, 2s)), other 1s", ParameterMap{}));
+	const AnimationList quoted_animations = quoted_animation_property.value.GetReference<AnimationList>();
+	REQUIRE(quoted_animations.size() == 2);
+	CHECK(quoted_animations[0].name == "\"quoted, name\"");
+	CHECK(quoted_animations[0].duration == doctest::Approx(1.f));
+
+	REQUIRE(document->SetProperty("transition", "opacity calc(1s - 200ms) calc(-250ms) linear-in 0.5"));
+	const Property* transition_property = document->GetLocalProperty("transition");
+	REQUIRE(transition_property);
+	REQUIRE(transition_property->unit == Unit::TRANSITION);
+	const TransitionList transition_list = transition_property->value.GetReference<TransitionList>();
+	REQUIRE(transition_list.transitions.size() == 1);
+	CHECK(transition_list.transitions[0].duration == doctest::Approx(0.8f));
+	CHECK(transition_list.transitions[0].delay == doctest::Approx(-0.25f));
+	CHECK(transition_list.transitions[0].reverse_adjustment_factor == doctest::Approx(0.5f));
+
+	REQUIRE(document->SetProperty("transition", "opacity min(1s, max(500ms, 2s)), width clamp(none, 1500ms, 2s)"));
+	transition_property = document->GetLocalProperty("transition");
+	REQUIRE(transition_property);
+	const TransitionList nested_transitions = transition_property->value.GetReference<TransitionList>();
+	REQUIRE(nested_transitions.transitions.size() == 2);
+	CHECK(nested_transitions.transitions[0].duration == doctest::Approx(1.f));
+	CHECK(nested_transitions.transitions[1].duration == doctest::Approx(1.5f));
+
+	// Final Number math in animation uses exactly the ordinary iteration-count rounding and validity policy.
+	REQUIRE(document->SetProperty("animation", "spin 1s 2.6"));
+	animation_property = document->GetLocalProperty("animation");
+	REQUIRE(animation_property);
+	const int ordinary_iterations = animation_property->value.GetReference<AnimationList>()[0].num_iterations;
+	REQUIRE(document->SetProperty("animation", "spin 1s calc(2.6)"));
+	animation_property = document->GetLocalProperty("animation");
+	REQUIRE(animation_property);
+	CHECK(animation_property->value.GetReference<AnimationList>()[0].num_iterations == ordinary_iterations);
+
+	TestsShell::SetNumExpectedWarnings(12);
+	CHECK_FALSE(document->SetProperty("animation", "spin calc(50%)"));
+	CHECK_FALSE(document->SetProperty("animation", "spin calc(1px)"));
+	CHECK_FALSE(document->SetProperty("animation", "calc(1px) 1s"));
+	CHECK_FALSE(document->SetProperty("animation", "calc(1s + ) 1s"));
+	CHECK_FALSE(document->SetProperty("transition", "opacity calc(50%)"));
+	CHECK_FALSE(document->SetProperty("transition", "opacity calc(1px)"));
+	CHECK_FALSE(document->SetProperty("transition", "opacity calc(2)"));
+	CHECK_FALSE(document->SetProperty("animation", "spin 0s"));
+	CHECK_FALSE(document->SetProperty("animation", "spin calc(0s)"));
+	CHECK_FALSE(document->SetProperty("transition", "opacity calc(0s)"));
+	CHECK_FALSE(document->SetProperty("animation", "spin 1s 0.4"));
+	CHECK_FALSE(document->SetProperty("animation", "spin 1s calc(0.4)"));
+
+	// Existing delay policy is unchanged: negative delays are accepted for both ordinary and calculated time values.
+	CHECK(document->SetProperty("animation", "spin 1s -0.5s"));
+	CHECK(document->SetProperty("animation", "spin calc(1s) calc(-500ms)"));
+
+	document->Close();
+	TestsShell::ShutdownShell();
+}
+
+TEST_CASE("Calculation.compound.angle_transform_wpt_and_arguments")
+{
+	Context* context = TestsShell::GetContext();
+	REQUIRE(context);
+	ElementDocument* document = context->CreateDocument();
+	REQUIRE(document);
+
+	// Sources: css/css-values/calc-angle-values.html and minmax-angle-computed.html.
+	// RmlUi does not support grad/turn units here; every adapted deg/rad row is exercised through the actual transform owner.
+	for (const CalculationCorpusCase& test : angle_cases)
+	{
+		CAPTURE(String(test.source));
+		CAPTURE(String(test.expression));
+		CHECK(document->SetProperty("transform", CreateString("rotate(%s)", test.expression)));
+	}
+	for (const CalculationCorpusCase& test : pure_minmax_angle_cases)
+	{
+		CAPTURE(String(test.source));
+		CAPTURE(String(test.expression));
+		String expression = test.expression;
+		int parenthesis_depth = 0;
+		for (const char c : expression)
+			parenthesis_depth += (c == '(' ? 1 : (c == ')' ? -1 : 0));
+		while (parenthesis_depth-- > 0)
+			expression += ')';
+		CHECK(document->SetProperty("transform", "rotate(" + expression + ")"));
+	}
+	// Every existing numeric transform argument accepts an appropriately typed calculation. Nested commas
+	// remain inside min/max/clamp rather than being mistaken for transform argument separators.
+	const char* transform_values[] = {
+		"matrix(calc(1), calc(0), calc(0), calc(1), calc(10), calc(20))",
+		"matrix3d(calc(1),calc(0),calc(0),calc(0),calc(0),calc(1),calc(0),calc(0),calc(0),calc(0),calc(1),calc(0),calc(10),calc(20),calc(30),calc(1)"
+		")",
+		"translateX(calc(10px + 5%))",
+		"translateY(calc(10px + 5%))",
+		"translateZ(calc(10px + 2px))",
+		"translate(min(10px, max(5px, 20px)), calc(25% + 1em))",
+		"translate3d(calc(10% + 1px), calc(20% + 2px), calc(3px + 4px))",
+		"scaleX(calc(1 + 1))",
+		"scaleY(calc(1 + 1))",
+		"scaleZ(calc(1 + 1))",
+		"scale(calc(1 + 1))",
+		"scale(calc(1 + 1), max(2, 3))",
+		"scale3d(calc(1 + 1), min(2, 3), clamp(1, 2, 3))",
+		"rotateX(calc(45deg + 45deg))",
+		"rotateY(max(1rad, 45deg))",
+		"rotateZ(min(90deg, 2rad))",
+		"rotate(calc(90deg / 2))",
+		"rotate3d(calc(1), calc(0), calc(0), calc(45deg + 45deg))",
+		"skewX(calc(10deg + 5deg))",
+		"skewY(calc(10deg + 5deg))",
+		"skew(calc(10deg + 5deg), max(10deg, 5deg))",
+		"perspective(calc(100px + 1em))",
+	};
+	for (const char* value : transform_values)
+	{
+		CAPTURE(String(value));
+		CHECK(document->SetProperty("transform", value));
+	}
+
+	TestsShell::SetNumExpectedWarnings(4);
+	CHECK_FALSE(document->SetProperty("transform", "translateX(calc(1 + 2))"));
+	CHECK_FALSE(document->SetProperty("transform", "scaleX(calc(1px + 2px))"));
+	CHECK_FALSE(document->SetProperty("transform", "rotate(calc(1px + 2px))"));
+	CHECK_FALSE(document->SetProperty("transform", "perspective(calc(50%))"));
+
+	document->Close();
+	TestsShell::ShutdownShell();
+}
+
+TEST_CASE("Calculation.compound.gradient_wpt")
+{
+	Context* context = TestsShell::GetContext();
+	REQUIRE(context);
+	ElementDocument* document = context->CreateDocument();
+	REQUIRE(document);
+
+	auto get_declaration = [&]() -> const DecoratorDeclaration* {
+		const Property* property = document->GetLocalProperty("decorator");
+		if (!property || property->unit != Unit::DECORATOR)
+			return nullptr;
+		const DecoratorsPtr declarations = property->value.Get<DecoratorsPtr>();
+		return declarations && declarations->list.size() == 1 ? &declarations->list[0] : nullptr;
+	};
+	auto find_color_stops = [](const DecoratorDeclaration& declaration) -> const ColorStopList* {
+		for (const auto& pair : declaration.properties.GetProperties())
+			if (pair.second.unit == Unit::COLORSTOPLIST)
+				return &pair.second.value.GetReference<ColorStopList>();
+		return nullptr;
+	};
+	auto resolve_stop = [&](const ColorStop& stop, float percentage_basis, float& result) {
+		if (stop.position_calculation)
+			return ResolveElementCalculation(*stop.position_calculation, *document, percentage_basis, result);
+		if (stop.position.unit == Unit::PERCENT)
+		{
+			result = stop.position.number * .01f * percentage_basis;
+			return true;
+		}
+		if (Any(stop.position.unit & Unit::LENGTH))
+		{
+			result = document->ResolveLength(stop.position);
+			return true;
+		}
+		return false;
+	};
+
+	// Source: css/css-values/calc-background-image-gradient-1.html.
+	CHECK(document->SetProperty("decorator", "radial-gradient(circle farthest-side at calc(50px + 50%) calc(100% - 30px), red, green)"));
+	const DecoratorDeclaration* radial_position_declaration = get_declaration();
+	REQUIRE(radial_position_declaration);
+	Vector<std::pair<int, CalculationPtr>> radial_position_calculations;
+	for (const auto& pair : radial_position_declaration->properties.GetProperties())
+	{
+		if (pair.second.unit == Unit::CALCULATION)
+			radial_position_calculations.emplace_back(int(pair.first), pair.second.value.Get<CalculationPtr>());
+	}
+	std::sort(radial_position_calculations.begin(), radial_position_calculations.end(),
+		[](const auto& lhs, const auto& rhs) { return lhs.first < rhs.first; });
+	REQUIRE(radial_position_calculations.size() == 2);
+	float radial_position_x = 0.f;
+	float radial_position_y = 0.f;
+	REQUIRE(ResolveElementCalculation(*radial_position_calculations[0].second, *document, 200.f, radial_position_x));
+	REQUIRE(ResolveElementCalculation(*radial_position_calculations[1].second, *document, 50.f, radial_position_y));
+	CHECK(radial_position_x == doctest::Approx(150.f));
+	CHECK(radial_position_y == doctest::Approx(20.f));
+
+	// Source: css/css-values/calc-background-linear-gradient-1.html. All five pinned gradient vectors are adapted
+	// directly to RmlUi's decorator property while preserving every math stop expression and expected
+	// 100px gradient-line position from the WPT reference rendering.
+	struct LinearGradientCase {
+		const char* value;
+		Array<float, 5> expected_positions;
+		int num_positions;
+	};
+	const LinearGradientCase linear_gradient_cases[] = {
+		{"linear-gradient(lime 0px, lime calc(100% - 10px), blue calc(100% - 10px), blue 100%)", {0.f, 90.f, 90.f, 100.f}, 4},
+		{"linear-gradient(blue calc(100% - 100px), green calc(10% + 20px), red 40px, white calc(100% - 40px), lime 80px)",
+			{0.f, 30.f, 40.f, 60.f, 80.f}, 5},
+		{"linear-gradient(blue calc(0px), purple calc(20%), red calc(10px + 10px + 20px), blue calc(30% + 30px), lime calc(180% - 100px))",
+			{0.f, 20.f, 40.f, 60.f, 80.f}, 5},
+		{"linear-gradient(blue calc(0% + 0px), green calc(10% + 20px), red 40px, blue calc(200% / 2 - 40px), yellow 80px)",
+			{0.f, 30.f, 40.f, 60.f, 80.f}, 5},
+		{"linear-gradient(red calc(100% - 100px), green calc(10% + 20px))", {0.f, 30.f}, 2},
+	};
+	for (const LinearGradientCase& test : linear_gradient_cases)
+	{
+		CAPTURE(String(test.value));
+		REQUIRE(document->SetProperty("decorator", test.value));
+		const DecoratorDeclaration* declaration = get_declaration();
+		REQUIRE(declaration);
+		const ColorStopList* stops = find_color_stops(*declaration);
+		REQUIRE(stops);
+		REQUIRE(int(stops->size()) == test.num_positions);
+		for (int i = 0; i < test.num_positions; ++i)
+		{
+			float position = 0.f;
+			REQUIRE(resolve_stop((*stops)[i], 100.f, position));
+			CHECK(position == doctest::Approx(test.expected_positions[i]));
+		}
+	}
+
+	// Source: css/css-values/calc-linear-radial-conic-gradient-001.html. grad/turn units are unsupported.
+	REQUIRE(document->SetProperty("decorator", "linear-gradient(green calc(0%), blue)"));
+	const DecoratorDeclaration* linear_stop_declaration = get_declaration();
+	REQUIRE(linear_stop_declaration);
+	const ColorStopList* linear_stops = find_color_stops(*linear_stop_declaration);
+	REQUIRE(linear_stops);
+	float linear_first_stop = -1.f;
+	REQUIRE(resolve_stop((*linear_stops)[0], 100.f, linear_first_stop));
+	CHECK(linear_first_stop == doctest::Approx(0.f));
+
+	for (const char* value : {"linear-gradient(calc(90deg), green, blue)", "linear-gradient(calc(90deg), green calc(0%), blue)"})
+	{
+		REQUIRE(document->SetProperty("decorator", value));
+		const DecoratorDeclaration* declaration = get_declaration();
+		REQUIRE(declaration);
+		CalculationPtr angle_calculation;
+		for (const auto& pair : declaration->properties.GetProperties())
+			if (pair.second.unit == Unit::CALCULATION)
+				angle_calculation = pair.second.value.Get<CalculationPtr>();
+		REQUIRE(bool(angle_calculation));
+		float angle = 0.f;
+		REQUIRE(ResolveElementCalculation(*angle_calculation, *document, 0.f, angle));
+		CHECK(angle == doctest::Approx(Math::RMLUI_PI * .5f));
+		if (String(value).find("calc(0%)") != String::npos)
+		{
+			const ColorStopList* stops = find_color_stops(*declaration);
+			REQUIRE(stops);
+			float first_stop = -1.f;
+			REQUIRE(resolve_stop((*stops)[0], 100.f, first_stop));
+			CHECK(first_stop == doctest::Approx(0.f));
+		}
+	}
+
+	REQUIRE(document->SetProperty("decorator", "radial-gradient(green calc(10% + 20%), blue calc(30% + 40%))"));
+	const DecoratorDeclaration* radial_stop_declaration = get_declaration();
+	REQUIRE(radial_stop_declaration);
+	const ColorStopList* radial_stops = find_color_stops(*radial_stop_declaration);
+	REQUIRE(radial_stops);
+	REQUIRE(radial_stops->size() == 2);
+	for (int i = 0; i < 2; ++i)
+	{
+		float position = 0.f;
+		REQUIRE(resolve_stop((*radial_stops)[i], 100.f, position));
+		CHECK(position == doctest::Approx(i == 0 ? 30.f : 70.f));
+	}
+	// Keep the parsed stop calculation and change only its owning gradient geometry basis. This is the
+	// Keep the parsed calculation alive for lazy compound resolution rather than reparsing the declaration.
+	float resized_radial_stop = 0.f;
+	REQUIRE(resolve_stop((*radial_stops)[0], 200.f, resized_radial_stop));
+	CHECK(resized_radial_stop == doctest::Approx(60.f));
+
+	REQUIRE(document->SetProperty("decorator", "conic-gradient(green calc(50% + 10%), blue calc(60% + 20%))"));
+	const DecoratorDeclaration* conic_stop_declaration = get_declaration();
+	REQUIRE(conic_stop_declaration);
+	const ColorStopList* conic_stops = find_color_stops(*conic_stop_declaration);
+	REQUIRE(conic_stops);
+	REQUIRE(conic_stops->size() == 2);
+	const float conic_basis = 2.f * Math::RMLUI_PI;
+	for (int i = 0; i < 2; ++i)
+	{
+		float position = 0.f;
+		REQUIRE(resolve_stop((*conic_stops)[i], conic_basis, position));
+		CHECK(position / conic_basis == doctest::Approx(i == 0 ? .6f : .8f));
+	}
+
+	// Distinct percentage hints are type checked by the owning color-stop parser.
+	TestsShell::SetNumExpectedWarnings(2);
+	CHECK_FALSE(document->SetProperty("decorator", "linear-gradient(red calc(10deg + 5deg), blue)"));
+	CHECK_FALSE(document->SetProperty("decorator", "conic-gradient(red calc(10px + 5px), blue)"));
+
+	document->Close();
+	TestsShell::ShutdownShell();
+}
+
+TEST_CASE("Calculation.compound.media_wpt")
+{
+	Context* context = TestsShell::GetContext();
+	REQUIRE(context);
+	context->SetDimensions(Vector2i(100, 10));
+	context->SetDensityIndependentPixelRatio(2.f);
+
+	// Sources: calc-in-media-queries-001/002.html and all twelve support documents driven by
+	// calc-in-media-queries-with-mixed-units.html. The style parser must retain every exact math expression.
+	const char* media_conditions[] = {
+		"min-width: calc(100px)",
+		"min-width: calc(-100px)",
+		"width: calc(116px - 1em)",
+		"width: calc(200vh + 5em)",
+		"height: calc(100vw - 5.625em)",
+		"width: calc(10vw + 900vh)",
+		"width: calc(900vh + 10px)",
+		"width: calc(90vw + 10px)",
+		"width: calc(100px / 1em * 1em)",
+		"width: calc((50vh * 5em) / 4px)",
+		"height: calc(50vw / 0.3125em * 10px)",
+		"width: calc(10vw / 10px * 1000vh)",
+		"width: calc(8000vh * 1vw / 1em * 8px / 40vh)",
+		"width: calc(100vw * 10vh * 1px * 0.0625em / 1px / 1px / 1px)",
+	};
+	// The WPT support documents use the browser's 16px initial font size, while RmlUi media queries
+	// deliberately use DefaultComputedValues() (12px). Preserve every pinned expression and assert
+	// its exact RmlUi match result under that existing media-query context instead of merely parsing it.
+	constexpr bool expected_initial_matches[] = {
+		true,  // calc-in-media-queries-001.html
+		true,  // calc-in-media-queries-002.html
+		false, // mixed-units-01.html: 116px - 1em = 104px
+		false, // mixed-units-02.html: 200vh + 5em = 80px
+		false, // mixed-units-03.html: 100vw - 5.625em = 32.5px
+		true,  // mixed-units-04.html
+		true,  // mixed-units-05.html
+		true,  // mixed-units-06.html
+		true,  // mixed-units-07.html
+		false, // mixed-units-08.html: (50vh * 5em) / 4px = 75px
+		false, // mixed-units-09.html: 50vw / 0.3125em * 10px = 133.333...px
+		true,  // mixed-units-10.html
+		false, // mixed-units-11.html: evaluates to 133.333...px
+		false, // mixed-units-12.html: evaluates to 75px
+	};
+	static_assert(Count(expected_initial_matches) == Count(media_conditions));
+	String styles = "div { width: 1px; height: 1px; }";
+	for (int i = 0; i < int(Count(media_conditions)); ++i)
+		styles += CreateString("@media (%s) { #m%d { width: %dpx; } }", media_conditions[i], i, i + 2);
+	// Resolution is an existing RmlUi media feature not supplied by these three WPT sources.
+	styles += "@media (min-resolution: calc(1x + 1x)) { #resolution { width: 77px; } }";
+	styles += "@media (resolution: calc(1x / 41 * 82)) { #resolution-equality { width: 88px; } }";
+
+	String body;
+	for (int i = 0; i < int(Count(media_conditions)); ++i)
+		body += CreateString("<div id='m%d'/>", i);
+	body += "<div id='resolution'/><div id='resolution-equality'/>";
+	const String rml = "<rml><head><style>" + styles + "</style></head><body>" + body + "</body></rml>";
+	ElementDocument* document = context->LoadDocumentFromMemory(rml);
+	REQUIRE(document);
+	document->Show();
+	TestsShell::RenderLoop();
+
+	// Assert every WPT-owned condition, not just representative parsing. The first two source cases
+	// match; the mixed-unit expectations above reflect RmlUi's explicitly preserved 12px media font.
+	for (int i = 0; i < int(Count(media_conditions)); ++i)
+	{
+		CAPTURE(i);
+		const float expected_width = expected_initial_matches[i] ? float(i + 2) : 1.f;
+		CHECK(document->GetElementById(CreateString("m%d", i))->GetComputedValues().width().value == doctest::Approx(expected_width));
+	}
+	CHECK(document->GetElementById("resolution")->GetComputedValues().width().value == doctest::Approx(77.f));
+	// Mathematically 1 / 41 * 82 == 2. The calculation path accumulates float roundoff, so exact
+	// resolution equality must use the same calculated-value tolerance as width/height equality.
+	CHECK(document->GetElementById("resolution-equality")->GetComputedValues().width().value == doctest::Approx(88.f));
+
+	// Media calculations are re-evaluated against current viewport/dp state when the stylesheet is recompiled.
+	context->SetDimensions(Vector2i(116, 10));
+	context->SetDensityIndependentPixelRatio(1.f);
+	TestsShell::RenderLoop();
+	CHECK(document->GetElementById("m0")->GetComputedValues().width().value == doctest::Approx(2.f));
+	CHECK(document->GetElementById("m5")->GetComputedValues().width().value == doctest::Approx(1.f));
+	CHECK(document->GetElementById("resolution")->GetComputedValues().width().value == doctest::Approx(1.f));
+	CHECK(document->GetElementById("resolution-equality")->GetComputedValues().width().value == doctest::Approx(1.f));
+
+	document->Close();
+	TestsShell::ShutdownShell();
+}
+
+TEST_CASE("Calculation.compound.shadow_filter_and_lazy_lifecycle")
+{
+	Context* context = TestsShell::GetContext();
+	REQUIRE(context);
+	context->SetDimensions(Vector2i(800, 400));
+	context->SetDensityIndependentPixelRatio(1.f);
+	const String rml =
+		R"RML(<rml><body style="font-size: 16px"><div id="target" style="display: block; width: 200px; height: 100px; font-size: 20px"/></body></rml>)RML";
+	ElementDocument* document = context->LoadDocumentFromMemory(rml);
+	REQUIRE(document);
+	document->Show();
+	TestsShell::RenderLoop();
+	Element* target = document->GetElementById("target");
+	REQUIRE(target);
+	Box initial_box;
+	initial_box.SetContent(Vector2f(200.f, 100.f));
+	target->SetBox(initial_box);
+
+	CHECK(target->SetProperty("box-shadow", "#000 calc(1em + 1px) calc(1rem + 2px) calc(1vw + 3px) calc(1dp + 4px)"));
+	auto resolve_box_shadow = [&]() {
+		const BoxShadowGeometryInfo geometry =
+			GeometryBoxShadow::Resolve(target, CornerSizes{}, ColourbPremultiplied{}, Array<ColourbPremultiplied, 4>{}, 1.f);
+		REQUIRE(geometry.shadow_list.size() == 1);
+		return geometry.shadow_list[0];
+	};
+	const BoxShadow initial_shadow = resolve_box_shadow();
+	for (const char* property : {"filter", "backdrop-filter"})
+	{
+		CAPTURE(String(property));
+		REQUIRE(target->SetProperty(property,
+			"brightness(calc(50%)) contrast(calc(1 + 1)) hue-rotate(calc(45deg + 45deg)) blur(calc(1em + 1vw)) drop-shadow(#000 calc(1em) calc(1rem) "
+			"calc(1vw))"));
+		const Property* compound_filter_property = target->GetLocalProperty(property);
+		REQUIRE(compound_filter_property);
+		const FiltersPtr compound_filter_declarations = compound_filter_property->value.Get<FiltersPtr>();
+		REQUIRE(bool(compound_filter_declarations));
+		REQUIRE(compound_filter_declarations->list.size() == 5);
+		for (const FilterDeclaration& declaration : compound_filter_declarations->list)
+		{
+			REQUIRE(declaration.instancer);
+			CHECK(bool(declaration.instancer->InstanceFilter(declaration.type, declaration.properties)));
+		}
+		CHECK(target->SetProperty(property, "brightness(50%)"));
+		CHECK(target->SetProperty(property, "brightness(calc(50%))"));
+	}
+
+	// Number-or-Percent keeps raw Percent until FilterBasic normalizes it; mixed Number + raw Percent is invalid.
+	TestsShell::SetNumExpectedWarnings(2);
+	CHECK_FALSE(target->SetProperty("filter", "brightness(calc(1 + 50%))"));
+	CHECK_FALSE(target->SetProperty("backdrop-filter", "opacity(calc(1 + 50%))"));
+
+	// Retain actual lazy filter instances across context changes. Their ExtendInkOverflow() owner path
+	// must resolve the same parsed calculations against the current element instead of cached scalars.
+	REQUIRE(target->SetProperty("filter", "blur(calc(1em + 1vw)) drop-shadow(#000 calc(1em) calc(1rem) calc(1vw))"));
+	const Property* lazy_filter_property = target->GetLocalProperty("filter");
+	REQUIRE(lazy_filter_property);
+	const FiltersPtr lazy_filter_declarations = lazy_filter_property->value.Get<FiltersPtr>();
+	REQUIRE(bool(lazy_filter_declarations));
+	REQUIRE(lazy_filter_declarations->list.size() == 2);
+	Vector<SharedPtr<Filter>> lazy_filters;
+	for (const FilterDeclaration& declaration : lazy_filter_declarations->list)
+	{
+		REQUIRE(declaration.instancer);
+		SharedPtr<Filter> filter = declaration.instancer->InstanceFilter(declaration.type, declaration.properties);
+		REQUIRE(bool(filter));
+		lazy_filters.push_back(std::move(filter));
+	}
+	auto filter_overflow = [&](int index) {
+		Rectanglef overflow = Rectanglef::FromSize(Vector2f(100.f));
+		lazy_filters[index]->ExtendInkOverflow(target, overflow);
+		return overflow;
+	};
+	const Rectanglef initial_blur_overflow = filter_overflow(0);
+	const Rectanglef initial_drop_shadow_overflow = filter_overflow(1);
+
+	// A single translation exercises all lazy compound dependencies. ResolvePrimitive() is deliberately independent
+	// of ElementStyle's direct-property dependency cache and must observe each current context/basis on every call.
+	REQUIRE(target->SetProperty("transform", "translateX(calc(50% + 1em + 1rem + 1vw + 1vh + 1dp))"));
+	const Property* transform_property = target->GetLocalProperty("transform");
+	REQUIRE(transform_property);
+	TransformPtr transform = transform_property->value.Get<TransformPtr>();
+	REQUIRE(bool(transform));
+	auto resolved_x = [&]() {
+		const TransformPrimitive primitive = transform->ResolvePrimitive(0, *target);
+		REQUIRE(primitive.type == TransformPrimitive::TRANSLATEX);
+		return primitive.translate_x.values[0].number;
+	};
+	const float initial = resolved_x();
+
+	REQUIRE(target->SetProperty("font-size", "30px"));
+	TestsShell::RenderLoop();
+	CHECK(resolved_x() != doctest::Approx(initial));
+	CHECK(resolve_box_shadow().offset_x.number != doctest::Approx(initial_shadow.offset_x.number));
+	CHECK(filter_overflow(0).Width() > initial_blur_overflow.Width());
+	CHECK(filter_overflow(1).Width() > initial_drop_shadow_overflow.Width());
+	const float after_font = resolved_x();
+	const BoxShadow after_font_shadow = resolve_box_shadow();
+	const Rectanglef after_font_drop_shadow_overflow = filter_overflow(1);
+	REQUIRE(document->SetProperty("font-size", "24px"));
+	TestsShell::RenderLoop();
+	CHECK(resolved_x() != doctest::Approx(after_font));
+	CHECK(resolve_box_shadow().offset_y.number != doctest::Approx(after_font_shadow.offset_y.number));
+	CHECK(filter_overflow(1).Height() != doctest::Approx(after_font_drop_shadow_overflow.Height()));
+	const float after_root = resolved_x();
+	const BoxShadow after_root_shadow = resolve_box_shadow();
+	const Rectanglef after_root_blur_overflow = filter_overflow(0);
+	const Rectanglef after_root_drop_shadow_overflow = filter_overflow(1);
+	context->SetDimensions(Vector2i(1000, 500));
+	TestsShell::RenderLoop();
+	CHECK(resolved_x() != doctest::Approx(after_root));
+	CHECK(resolve_box_shadow().blur_radius.number != doctest::Approx(after_root_shadow.blur_radius.number));
+	CHECK(filter_overflow(0).Width() != doctest::Approx(after_root_blur_overflow.Width()));
+	CHECK(filter_overflow(1).Width() != doctest::Approx(after_root_drop_shadow_overflow.Width()));
+	const float after_viewport = resolved_x();
+	const BoxShadow after_viewport_shadow = resolve_box_shadow();
+	context->SetDensityIndependentPixelRatio(2.f);
+	TestsShell::RenderLoop();
+	CHECK(resolved_x() != doctest::Approx(after_viewport));
+	CHECK(resolve_box_shadow().spread_distance.number != doctest::Approx(after_viewport_shadow.spread_distance.number));
+	const float after_dp = resolved_x();
+	const float geometry_before = target->GetBox().GetSize(BoxArea::Border).x;
+	Box enlarged_box;
+	enlarged_box.SetContent(Vector2f(400.f, 100.f));
+	target->SetBox(enlarged_box);
+	const float geometry_after = target->GetBox().GetSize(BoxArea::Border).x;
+	CHECK(geometry_after > geometry_before);
+	CHECK(resolved_x() > after_dp + 0.4f * (geometry_after - geometry_before));
+	CHECK(target->GetLocalProperty("transform")->value.Get<TransformPtr>().get() == transform.get());
+
+	// The sidecar follows normal Transform value semantics. A copied transform retains its calculation
+	// ownership after the parsed property and its original Transform owner are released.
+	const float before_copy_release = resolved_x();
+	Transform copied_transform = *transform;
+	REQUIRE(target->SetProperty("transform", "none"));
+	transform.reset();
+	const TransformPrimitive copied_primitive = copied_transform.ResolvePrimitive(0, *target);
+	REQUIRE(copied_primitive.type == TransformPrimitive::TRANSLATEX);
+	CHECK(copied_primitive.translate_x.values[0].number == doctest::Approx(before_copy_release));
+
+	document->Close();
+	TestsShell::ShutdownShell();
+}
+
+TEST_CASE("Calculation.compound.rmlui_extension_rejection")
+{
+	Context* context = TestsShell::GetContext();
+	REQUIRE(context);
+	ElementDocument* document = context->LoadDocumentFromMemory("<rml><head><style>body { display: block; }</style></head><body/></rml>");
+	REQUIRE(document);
+
+	// Font effects are eagerly instanced and must reject calculations before scalar extraction.
+	TestsShell::SetNumExpectedWarnings(8);
+	CHECK_FALSE(document->SetProperty("font-effect", "blur(calc(1px + 1px) #000)"));
+	CHECK_FALSE(document->SetProperty("font-effect", "outline(calc(1px + 1px) #000)"));
+	CHECK_FALSE(document->SetProperty("font-effect", "shadow(calc(1px) calc(2px) #000)"));
+	CHECK_FALSE(document->SetProperty("font-effect", "glow(calc(1px) calc(2px) calc(3px) calc(4px) #000)"));
+
+	// Decorators are declaration-deferred. Drive the actual instancer lifecycle and require their private numeric
+	// slots to reject before any NumericValue extraction.
+	for (const char* value : {
+			 "text(\"x\" #fff calc(1px + 1px) center)",
+			 "image(/assets/invader.tga fill calc(1px + 1px) center)",
+			 "radial-gradient(circle calc(50%), red, blue)",
+		 })
+	{
+		CAPTURE(String(value));
+		CHECK(document->SetProperty("decorator", value));
+		const Property* property = document->GetLocalProperty("decorator");
+		REQUIRE(property);
+		const DecoratorsPtr declarations = property->value.Get<DecoratorsPtr>();
+		REQUIRE(bool(declarations));
+		REQUIRE(document->GetStyleSheet());
+		REQUIRE(document->GetRenderManager());
+		TestsShell::SetNumExpectedWarnings(1);
+		const DecoratorPtrList& decorators = document->GetStyleSheet()->InstanceDecorators(*document->GetRenderManager(), *declarations, nullptr);
+		CHECK(decorators.empty());
+	}
+	TestsShell::SetNumExpectedWarnings(1);
+	CHECK_FALSE(document->SetProperty("decorator", "ninepatch(outer, inner, calc(1px + 1px))"));
+
+	// The private ElementHandle edge-margin parser rejects calculation values instead of exposing them as NumericValue.
+	ElementPtr handle = Factory::InstanceElement(document, "handle", "handle", XMLAttributes{});
+	REQUIRE(handle);
+	document->AppendChild(std::move(handle));
+	Element* handle_element = document->GetLastChild();
+	REQUIRE(handle_element);
+	handle_element->SetAttribute("edge_margin", "calc(1px + 1px)");
+	TestsShell::SetNumExpectedWarnings(1);
+	handle_element->DispatchEvent("click", Dictionary{});
+
+	// Stylesheet-only extensions must reject calculation values while parsing their private numeric descriptors.
+	const char extension_styles[] = R"RCSS(
+@spritesheet private_math {
+	src: /assets/high_scores_alien_3.tga;
+	bad-rect: calc(1px + 1px) 0px 10px 10px;
+	resolution: calc(1x + 1x);
+}
+@font-face {
+	font-family: LatoLatin;
+	src: /assets/LatoLatin-Regular.ttf;
+	font-weight: calc(300 + 100);
+	-rmlui-face-index: calc(0 + 1);
+}
+)RCSS";
+	StyleSheetContainer extension_container;
+	StreamMemory extension_stream{reinterpret_cast<const byte*>(extension_styles), sizeof(extension_styles) - 1};
+	TestsShell::SetNumExpectedWarnings(5);
+	CHECK(extension_container.LoadStyleSheetContainer(&extension_stream, 1));
+
+	document->Close();
+	TestsShell::ShutdownShell();
+}
+
+TEST_CASE("Calculation.animation.wpt_interpolation")
+{
+	Context* context = TestsShell::GetContext();
+	REQUIRE(context);
+	context->SetDimensions(Vector2i(800, 600));
+	const String rml =
+		R"RML(<rml><body><div id="container" style="position: relative; width: 50px; height: 50px"><div id="target" style="position: absolute"/></div><div id="square-container" style="width: 200px; height: 200px"><div id="square"/></div></body></rml>)RML";
+	ElementDocument* document = context->LoadDocumentFromMemory(rml);
+	REQUIRE(document);
+	document->Show();
+	TestsShell::RenderLoop();
+	Element* container = document->GetElementById("container");
+	REQUIRE(container);
+	Box container_box;
+	container_box.SetContent(Vector2f(50.f, 50.f));
+	container->SetBox(container_box);
+	Element* square_container = document->GetElementById("square-container");
+	REQUIRE(square_container);
+	Box square_container_box;
+	square_container_box.SetContent(Vector2f(200.f, 200.f));
+	square_container->SetBox(square_container_box);
+
+	Element* target = document->GetElementById("target");
+	REQUIRE(target);
+	target->SetOffset(Vector2f(0.f), container);
+	REQUIRE(target->SetProperty("left", "calc(50% - 25px)"));
+	const Property left_from = *target->GetLocalProperty("left");
+	REQUIRE(target->SetProperty("left", "calc(100% - 10px)"));
+	const Property left_to = *target->GetLocalProperty("left");
+	// Source: animations/calc-interpolation.html. RmlUi clamps interpolation to the key interval, so
+	// RmlUi's animation model clamps to the key interval, so exercise every in-range WPT sample
+	// (0, .25, .5, .75, 1) and omit the source's extrapolation probes.
+	const CalculationPtr left_from_calculation = left_from.value.Get<CalculationPtr>();
+	REQUIRE(bool(left_from_calculation));
+	float left_start = -1.f;
+	REQUIRE(ResolveElementCalculation(*left_from_calculation, *target, 50.f, left_start, RelativeTarget::ContainingBlockWidth));
+	CHECK(left_start == doctest::Approx(0.f));
+
+	ElementAnimation left_animation(PropertyId::Left, ElementAnimationOrigin::User, left_from, *target, 0.0, 0.4f, 1, false);
+	REQUIRE(left_animation.AddKey(0.4f, left_to, *target, Tween{}, false));
+	constexpr float sample_times[] = {0.1f, 0.2f, 0.3f, 0.4f};
+	constexpr float expected_values[] = {10.f, 20.f, 30.f, 40.f};
+	for (size_t i = 0; i < Count(sample_times); ++i)
+	{
+		const Property sample = left_animation.UpdateAndGetProperty(sample_times[i], *target);
+		REQUIRE(sample.unit == Unit::PX);
+		CHECK(sample.Get<float>() == doctest::Approx(expected_values[i]));
+	}
+
+	Element* square = document->GetElementById("square");
+	REQUIRE(square);
+	square->SetOffset(Vector2f(0.f), square_container);
+	auto midpoint = [&](const char* property_name, PropertyId property_id, const char* from, const char* to) {
+		REQUIRE(square->SetProperty(property_name, from));
+		const Property p0 = *square->GetLocalProperty(property_name);
+		REQUIRE(square->SetProperty(property_name, to));
+		const Property p1 = *square->GetLocalProperty(property_name);
+		ElementAnimation animation(property_id, ElementAnimationOrigin::User, p0, *square, 0.0, 0.2f, 1, false);
+		REQUIRE(animation.AddKey(0.2f, p1, *square, Tween{}, false));
+		return animation.UpdateAndGetProperty(0.1, *square);
+	};
+
+	const Property width_midpoint = midpoint("width", PropertyId::Width, "min(50px, 30%)", "max(75%, 100px)");
+	CHECK(width_midpoint.unit == Unit::PX);
+	CHECK(width_midpoint.Get<float>() == doctest::Approx(100.f));
+	const Property height_midpoint = midpoint("height", PropertyId::Height, "min(75%, 160px)", "max(50px, 20%)");
+	CHECK(height_midpoint.unit == Unit::PX);
+	CHECK(height_midpoint.Get<float>() == doctest::Approx(100.f));
+
+	document->Close();
+	TestsShell::ShutdownShell();
+}
+
+TEST_CASE("Calculation.animation.rmlui_interpolation_lifecycle")
+{
+	Context* context = TestsShell::GetContext();
+	REQUIRE(context);
+	context->SetDimensions(Vector2i(800, 600));
+	const String rml = R"RML(<rml><body><div id="container"><div id="target"/></div></body></rml>)RML";
+	ElementDocument* document = context->LoadDocumentFromMemory(rml);
+	REQUIRE(document);
+	document->Show();
+	TestsShell::RenderLoop();
+	Element* container = document->GetElementById("container");
+	Element* target = document->GetElementById("target");
+	REQUIRE(container);
+	REQUIRE(target);
+	Box container_box;
+	container_box.SetContent(Vector2f(200.f, 100.f));
+	container->SetBox(container_box);
+	target->SetOffset(Vector2f(0.f), container);
+
+	// RmlUi-specific lifecycle gap: fixed-to-calculated interpolation must reevaluate the calculated
+	// endpoint against the current containing block instead of freezing the basis at key insertion.
+	REQUIRE(target->SetProperty("left", "0px"));
+	const Property left_from = *target->GetLocalProperty("left");
+	REQUIRE(target->SetProperty("left", "calc(100% - 20px)"));
+	const Property left_to = *target->GetLocalProperty("left");
+	ElementAnimation left_animation(PropertyId::Left, ElementAnimationOrigin::User, left_from, *target, 0.0, 0.2f, 1, false);
+	REQUIRE(left_animation.AddKey(0.2f, left_to, *target, Tween{}, false));
+	CHECK(left_animation.UpdateAndGetProperty(0.05, *target).Get<float>() == doctest::Approx(45.f));
+	container_box.SetContent(Vector2f(400.f, 100.f));
+	container->SetBox(container_box);
+	const Property basis_changed_midpoint = left_animation.UpdateAndGetProperty(0.1, *target);
+	CHECK(basis_changed_midpoint.unit == Unit::PX);
+	CHECK(basis_changed_midpoint.Get<float>() == doctest::Approx(190.f));
+
+	// Number endpoints use the same scalar interpolation path as ordinary numeric properties.
+	REQUIRE(target->SetProperty("opacity", "calc(0.25 + 0.25)"));
+	const Property opacity_from = *target->GetLocalProperty("opacity");
+	REQUIRE(target->SetProperty("opacity", "calc(1)"));
+	const Property opacity_to = *target->GetLocalProperty("opacity");
+	ElementAnimation opacity_animation(PropertyId::Opacity, ElementAnimationOrigin::User, opacity_from, *target, 0.0, 0.2f, 1, false);
+	REQUIRE(opacity_animation.AddKey(0.2f, opacity_to, *target, Tween{}, false));
+	const Property opacity_midpoint = opacity_animation.UpdateAndGetProperty(0.1, *target);
+	CHECK(opacity_midpoint.unit == Unit::NUMBER);
+	CHECK(opacity_midpoint.Get<float>() == doctest::Approx(0.75f));
+
+	// Final interpolation audit regression: ordinary different-unit lengths must resolve both endpoints.
+	REQUIRE(target->SetProperty("font-size", "20px"));
+	TestsShell::RenderLoop();
+	REQUIRE(target->SetProperty("left", "1em"));
+	const Property ordinary_length_from = *target->GetLocalProperty("left");
+	REQUIRE(target->SetProperty("left", "40px"));
+	const Property ordinary_length_to = *target->GetLocalProperty("left");
+	ElementAnimation ordinary_length_animation(PropertyId::Left, ElementAnimationOrigin::User, ordinary_length_from, *target, 0.0, 0.2f, 1, false);
+	REQUIRE(ordinary_length_animation.AddKey(0.2f, ordinary_length_to, *target, Tween{}, false));
+	const Property ordinary_length_midpoint = ordinary_length_animation.UpdateAndGetProperty(0.1, *target);
+	CHECK(ordinary_length_midpoint.unit == Unit::PX);
+	CHECK(ordinary_length_midpoint.Get<float>() == doctest::Approx(30.f));
+
+	// Transform supplies the angle case and compound geometry case. Calculated arguments must be
+	// resolved from each endpoint at update time and interpolated as ordinary canonical primitives.
+	Box target_box;
+	target_box.SetContent(Vector2f(200.f, 100.f));
+	target->SetBox(target_box);
+	REQUIRE(target->SetProperty("transform", "translateX(0px) rotate(0deg) scaleX(1)"));
+	const Property transform_from = *target->GetLocalProperty("transform");
+	REQUIRE(target->SetProperty("transform", "translateX(calc(100% - 20px)) rotate(calc(90deg + 90deg)) scaleX(calc(1 + 2))"));
+	const Property transform_to = *target->GetLocalProperty("transform");
+	ElementAnimation transform_animation(PropertyId::Transform, ElementAnimationOrigin::User, transform_from, *target, 0.0, 0.2f, 1, false);
+	REQUIRE(transform_animation.AddKey(0.2f, transform_to, *target, Tween{}, false));
+	const Property transform_quarter = transform_animation.UpdateAndGetProperty(0.05, *target);
+	const TransformPtr transform_quarter_value = transform_quarter.value.Get<TransformPtr>();
+	REQUIRE(bool(transform_quarter_value));
+	CHECK(transform_quarter_value->ResolvePrimitive(0, *target).translate_x.values[0].number == doctest::Approx(45.f));
+	target_box.SetContent(Vector2f(400.f, 100.f));
+	target->SetBox(target_box);
+	const Property transform_midpoint = transform_animation.UpdateAndGetProperty(0.1, *target);
+	REQUIRE(transform_midpoint.unit == Unit::TRANSFORM);
+	const TransformPtr transform = transform_midpoint.value.Get<TransformPtr>();
+	REQUIRE(bool(transform));
+	REQUIRE(transform->GetNumPrimitives() == 3);
+	const TransformPrimitive translate = transform->ResolvePrimitive(0, *target);
+	const TransformPrimitive rotate = transform->ResolvePrimitive(1, *target);
+	const TransformPrimitive scale = transform->ResolvePrimitive(2, *target);
+	CHECK(translate.translate_x.values[0].unit == Unit::PX);
+	CHECK(translate.translate_x.values[0].number == doctest::Approx(190.f));
+	CHECK(rotate.rotate_2d.values[0] == doctest::Approx(Math::RMLUI_PI * 0.5f));
+	CHECK(scale.scale_x.values[0] == doctest::Approx(2.f));
+
+	// Gradient geometry owns the percentage bases for positions, radii, and color stops. Keep those
+	// expressions deferred through decorator interpolation so the instancer can resolve the current geometry.
+	REQUIRE(target->SetProperty("decorator", "radial-gradient(circle at calc(50% + 10px) center, red calc(10%), blue)"));
+	const Property decorator_from = *target->GetLocalProperty("decorator");
+	REQUIRE(target->SetProperty("decorator", "radial-gradient(circle at calc(100% - 20px) center, red calc(30%), blue)"));
+	const Property decorator_to = *target->GetLocalProperty("decorator");
+	ElementAnimation decorator_animation(PropertyId::Decorator, ElementAnimationOrigin::User, decorator_from, *target, 0.0, 0.2f, 1, false);
+	REQUIRE(decorator_animation.AddKey(0.2f, decorator_to, *target, Tween{}, false));
+	const Property decorator_midpoint = decorator_animation.UpdateAndGetProperty(0.1, *target);
+	REQUIRE(decorator_midpoint.unit == Unit::DECORATOR);
+	const DecoratorsPtr midpoint_decorators = decorator_midpoint.value.Get<DecoratorsPtr>();
+	REQUIRE(bool(midpoint_decorators));
+	REQUIRE(midpoint_decorators->list.size() == 1);
+	const PropertyDictionary& midpoint_properties = midpoint_decorators->list[0].properties;
+
+	CalculationPtr midpoint_position;
+	const ColorStopList* midpoint_stops = nullptr;
+	for (const auto& pair : midpoint_properties.GetProperties())
+	{
+		if (pair.second.unit == Unit::CALCULATION)
+			midpoint_position = pair.second.value.Get<CalculationPtr>();
+		else if (pair.second.unit == Unit::COLORSTOPLIST)
+			midpoint_stops = &pair.second.value.GetReference<ColorStopList>();
+	}
+	REQUIRE(bool(midpoint_position));
+	float resolved_midpoint_position = 0.f;
+	REQUIRE(ResolveElementCalculation(*midpoint_position, *target, 200.f, resolved_midpoint_position));
+	CHECK(resolved_midpoint_position == doctest::Approx(145.f));
+	REQUIRE(midpoint_stops);
+	REQUIRE(midpoint_stops->size() == 2);
+	REQUIRE(bool((*midpoint_stops)[0].position_calculation));
+	float resolved_midpoint_stop = 0.f;
+	REQUIRE(ResolveElementCalculation(*(*midpoint_stops)[0].position_calculation, *target, 100.f, resolved_midpoint_stop));
+	CHECK(resolved_midpoint_stop == doctest::Approx(20.f));
+
+	document->Close();
+	TestsShell::ShutdownShell();
+}
+
+TEST_CASE("Calculation.animation.calculated_time_drives_animation")
+{
+	Context* context = TestsShell::GetContext();
+	REQUIRE(context);
+	const String rml = R"RML(<rml><body><div id="target"/></body></rml>)RML";
+	ElementDocument* document = context->LoadDocumentFromMemory(rml);
+	REQUIRE(document);
+	document->Show();
+	Element* target = document->GetElementById("target");
+	REQUIRE(target);
+
+	REQUIRE(target->SetProperty("animation", "fade calc(100ms + 100ms) linear"));
+	const Property* animation_property = target->GetLocalProperty("animation");
+	REQUIRE(animation_property);
+	const AnimationList animation_list = animation_property->value.Get<AnimationList>();
+	REQUIRE(animation_list.size() == 1);
+	CHECK(animation_list[0].duration == doctest::Approx(0.2f));
+
+	REQUIRE(target->SetProperty("opacity", "0"));
+	const Property opacity_from = *target->GetLocalProperty("opacity");
+	REQUIRE(target->SetProperty("opacity", "1"));
+	const Property opacity_to = *target->GetLocalProperty("opacity");
+	ElementAnimation animation(PropertyId::Opacity, ElementAnimationOrigin::Animation, opacity_from, *target, 0.0, animation_list[0].duration, 1,
+		false);
+	REQUIRE(animation.AddKey(animation_list[0].duration, opacity_to, *target, animation_list[0].tween, false));
+	const Property midpoint = animation.UpdateAndGetProperty(0.1, *target);
+	CHECK(midpoint.unit == Unit::NUMBER);
+	CHECK(midpoint.Get<float>() == doctest::Approx(0.5f));
+
+	document->Close();
+	TestsShell::ShutdownShell();
+}
+
+#endif

--- a/Tests/Source/UnitTests/Calculation.cpp
+++ b/Tests/Source/UnitTests/Calculation.cpp
@@ -32,6 +32,8 @@ using namespace Rml;
 
 namespace {
 
+#ifdef RMLUI_MATH_EXPRESSIONS
+
 // WPT-derived test data below is adapted from web-platform-tests/wpt at
 // 5b6a1e61dbf639ebea0b7f19d9df0e313ae5d959 (BSD-3-Clause). Source paths are
 // recorded alongside the adapted cases. Tests requiring unsupported CSS functions, units, or
@@ -435,16 +437,6 @@ constexpr CalculationCorpusCase typed_arithmetic_cases[] = {
 	{"typed_arithmetic.html", "calc(1px * 3deg / 1deg / 1px)", "3"},
 };
 
-// Targeted owning-property source outside css/css-values:
-//   css/css-inline/parsing/line-height-computed.html
-constexpr CalculationCorpusCase line_height_cases[] = {
-	{"line-height-computed.html", "calc(200% + 10px)", "font 40px -> 90px"},
-	{"line-height-computed.html", "calc(10px - 0.5em)", "font 40px -> -10px then existing line-height range behavior"},
-	{"line-height-computed.html", "calc(10px + 0.5em)", "font 40px -> 30px"},
-	{"plan-required", "calc(200%)", "font 40px -> 80px final Length"},
-	{"plan-required", "calc(2)", "final Number 2"},
-};
-
 // Exhaustive adapted parser/type rows from the supported WPT math-function corpus. Context-dependent
 // rows assert parse/type behavior here and are covered separately by computed/used-value fixtures.
 constexpr WptParseCase wpt_valid_parse_cases[] = {
@@ -823,6 +815,8 @@ constexpr size_t Count(const T (&)[N])
 {
 	return N;
 }
+
+#endif
 
 } // namespace
 
@@ -2435,10 +2429,11 @@ TEST_CASE("Calculation.compound.angle_transform_wpt_and_arguments")
 	}
 	// Every existing numeric transform argument accepts an appropriately typed calculation. Nested commas
 	// remain inside min/max/clamp rather than being mistaken for transform argument separators.
-	const char* transform_values[] = {
+	const String transform_values[] = {
 		"matrix(calc(1), calc(0), calc(0), calc(1), calc(10), calc(20))",
-		"matrix3d(calc(1),calc(0),calc(0),calc(0),calc(0),calc(1),calc(0),calc(0),calc(0),calc(0),calc(1),calc(0),calc(10),calc(20),calc(30),calc(1)"
-		")",
+		String("matrix3d(calc(1),calc(0),calc(0),calc(0),calc(0),calc(1),calc(0),calc(0),calc(0),calc(0),calc(1),calc(0),calc(10),calc(20),calc(30),"
+			   "calc(1)") +
+			")",
 		"translateX(calc(10px + 5%))",
 		"translateY(calc(10px + 5%))",
 		"translateZ(calc(10px + 2px))",
@@ -2460,9 +2455,9 @@ TEST_CASE("Calculation.compound.angle_transform_wpt_and_arguments")
 		"skew(calc(10deg + 5deg), max(10deg, 5deg))",
 		"perspective(calc(100px + 1em))",
 	};
-	for (const char* value : transform_values)
+	for (const String& value : transform_values)
 	{
-		CAPTURE(String(value));
+		CAPTURE(value);
 		CHECK(document->SetProperty("transform", value));
 	}
 

--- a/Tests/Source/UnitTests/CalculationTypes.cpp
+++ b/Tests/Source/UnitTests/CalculationTypes.cpp
@@ -1,0 +1,123 @@
+#include <RmlUi/Core/ComputedValues.h>
+#include <RmlUi/Core/NumericValue.h>
+#include <RmlUi/Core/Property.h>
+#include <RmlUi/Core/StyleTypes.h>
+#include <RmlUi/Core/Variant.h>
+#include <doctest.h>
+
+#ifdef RMLUI_MATH_EXPRESSIONS
+	#include "../../../Source/Core/Calculation.h"
+#endif
+
+using namespace Rml;
+
+#ifdef RMLUI_MATH_EXPRESSIONS
+
+TEST_CASE("Calculation.types.numeric_value_boundary")
+{
+	CHECK(sizeof(NumericValue::number) == sizeof(float));
+	CHECK(sizeof(NumericValue::unit) == sizeof(Unit));
+	CHECK(!Any(Unit::CALCULATION & Unit::NUMERIC));
+	CHECK(Variant(CalculationPtr()).GetType() == Variant::CALCULATIONPTR);
+}
+
+TEST_CASE("Calculation.types.returned_value_owns_residual")
+{
+	CalculationPtr calculation =
+		Calculation::MakeOperation(Calculation::Kind::Sum, {Calculation::MakeValue(50.f, Unit::PERCENT), Calculation::MakeValue(-20.f, Unit::PX)});
+	Style::LengthPercentageAuto returned_auto;
+	Style::LengthPercentage returned_plain;
+	{
+		ComputedValues values(nullptr);
+		values.width(Style::LengthPercentageAuto(calculation));
+		values.padding_left(Style::LengthPercentage(calculation));
+		returned_auto = values.width();
+		returned_plain = values.padding_left();
+		CHECK(returned_auto.type == Style::LengthPercentageAuto::Calculation);
+		CHECK(returned_plain.type == Style::LengthPercentage::Calculation);
+	}
+	calculation.reset();
+	REQUIRE(bool(returned_auto.calculation));
+	REQUIRE(bool(returned_plain.calculation));
+	CHECK(*returned_auto.calculation == *returned_plain.calculation);
+	CHECK(returned_auto.calculation->ToString() == "calc(50% + -20px)");
+}
+
+TEST_CASE("Calculation.types.variant_and_property_structural_equality")
+{
+	CalculationPtr first =
+		Calculation::MakeOperation(Calculation::Kind::Sum, {Calculation::MakeValue(10.f, Unit::PX), Calculation::MakeValue(25.f, Unit::PERCENT)});
+	CalculationPtr equivalent =
+		Calculation::MakeOperation(Calculation::Kind::Sum, {Calculation::MakeValue(10.f, Unit::PX), Calculation::MakeValue(25.f, Unit::PERCENT)});
+	CalculationPtr different =
+		Calculation::MakeOperation(Calculation::Kind::Sum, {Calculation::MakeValue(11.f, Unit::PX), Calculation::MakeValue(25.f, Unit::PERCENT)});
+	REQUIRE(bool(first != equivalent));
+
+	Variant a(first), b(equivalent), c(different), null_a{CalculationPtr()}, null_b{CalculationPtr()};
+	CHECK(a == b);
+	CHECK(a != c);
+	CHECK(null_a == null_b);
+	CHECK(a != null_a);
+	CHECK(bool(a.Get<CalculationPtr>() == first));
+
+	Variant copied = a;
+	Variant moved = std::move(copied);
+	CHECK(moved == a);
+	moved.Clear();
+	CHECK(moved.GetType() == Variant::NONE);
+
+	Property p1(first, Unit::CALCULATION);
+	Property p2(equivalent, Unit::CALCULATION);
+	Property p3(different, Unit::CALCULATION);
+	CHECK(p1 == p2);
+	CHECK(p1 != p3);
+}
+
+TEST_CASE("Calculation.types.computed_value_storage_lifecycle")
+{
+	ComputedValues values(nullptr);
+	CHECK(values.width().type == Style::LengthPercentageAuto::Auto);
+	CHECK(values.padding_left().type == Style::LengthPercentage::Length);
+
+	CalculationPtr width = Calculation::MakeValue(25.f, Unit::PERCENT);
+	CalculationPtr padding = Calculation::MakeValue(3.f, Unit::PX);
+	values.width(Style::LengthPercentageAuto(width));
+	CHECK(bool(values.width().calculation == width));
+	values.padding_left(Style::LengthPercentage(padding));
+
+	ComputedValues copy(nullptr);
+	copy.CopyNonInherited(values);
+	CHECK(bool(copy.width().calculation == width));
+	CHECK(bool(copy.padding_left().calculation == padding));
+
+	values.width(Style::LengthPercentageAuto(Style::LengthPercentageAuto::Length, 42.f));
+	CHECK(values.width().type == Style::LengthPercentageAuto::Length);
+	CHECK(values.width().value == doctest::Approx(42.f));
+	CHECK(!values.width().calculation);
+	values.padding_left(Style::LengthPercentage(Style::LengthPercentage::Percentage, 10.f));
+	CHECK(values.padding_left().type == Style::LengthPercentage::Percentage);
+	CHECK(!values.padding_left().calculation);
+
+	copy.CopyNonInherited(values);
+	CHECK(copy.width().type == Style::LengthPercentageAuto::Length);
+	CHECK(!copy.width().calculation);
+	CHECK(copy.padding_left().type == Style::LengthPercentage::Percentage);
+	CHECK(!copy.padding_left().calculation);
+}
+
+TEST_CASE("Calculation.types.scalar_paths_reject_calculation")
+{
+	Property ordinary_length(12.f, Unit::PX);
+	const NumericValue numeric_value = ordinary_length.GetNumericValue();
+	CHECK(numeric_value.number == doctest::Approx(12.f));
+	CHECK(numeric_value.unit == Unit::PX);
+
+	CalculationPtr calculation = Calculation::MakeValue(12.f, Unit::PX);
+	Property calculated(calculation, Unit::CALCULATION);
+	CHECK(calculated.value.GetType() == Variant::CALCULATIONPTR);
+	CHECK(bool(calculated.Get<CalculationPtr>() == calculation));
+	CHECK(calculated.GetNumericValue() == NumericValue());
+	CHECK(!Any(Unit::CALCULATION & Unit::NUMERIC));
+}
+
+#endif

--- a/Tests/Source/UnitTests/CustomProperties.cpp
+++ b/Tests/Source/UnitTests/CustomProperties.cpp
@@ -1403,15 +1403,13 @@ TEST_CASE("custom_properties.misc_properties")
 		Element* div = document->GetFirstChild();
 
 		CHECK(div->GetComputedValues().has_box_shadow());
-		CHECK(div->GetProperty(PropertyId::BoxShadow)->Get<BoxShadowList>() ==
-			BoxShadowList{BoxShadow{
-				ColourbPremultiplied{0, 255, 0, 255},
-				NumericValue{0, Unit::DP},
-				NumericValue{8, Unit::DP},
-				NumericValue{24, Unit::DP},
-				NumericValue{0, Unit::DP},
-				false,
-			}});
+		BoxShadow expected_shadow;
+		expected_shadow.color = ColourbPremultiplied{0, 255, 0, 255};
+		expected_shadow.offset_x = NumericValue{0, Unit::DP};
+		expected_shadow.offset_y = NumericValue{8, Unit::DP};
+		expected_shadow.blur_radius = NumericValue{24, Unit::DP};
+		expected_shadow.spread_distance = NumericValue{0, Unit::DP};
+		CHECK(div->GetProperty(PropertyId::BoxShadow)->Get<BoxShadowList>() == BoxShadowList{expected_shadow});
 	}
 
 	SUBCASE("flex")


### PR DESCRIPTION
This implements CSS mathematical expressions as discussed in #691, adding support for `calc()`, `min()`, `max()`, and `clamp()` across compatible RCSS numeric contexts.

The implementation includes typed arithmetic and simplification, length-percentage expressions, computed/used-value resolution, custom properties, transforms, gradients, filters, media queries, animation values/times, and the related parser and lifecycle handling.

## Standards coverage / WPT

The parser and evaluation behavior were developed against relevant Web Platform Tests for CSS Values mathematical expressions. Rather than importing the WPT harness itself, representative WPT cases were transcribed into RmlUi unit tests and grouped by behavior: numeric and angle expressions, length-percentage arithmetic, comparison functions, typed arithmetic, whitespace/grammar rules, invalid expressions, nesting/complexity limits, computed-value canonicalization, and basis-dependent used values.

Those cases are used both as positive conformance tests and, importantly, as rejection tests for invalid type combinations and unsupported syntax. Additional RmlUi-specific tests cover integration points that WPT does not directly exercise here, such as RCSS custom properties, transforms, gradients, filters, media queries, animation interpolation/timing, layout resolution, and calculation object lifetime/ownership.

The implementation intentionally remains finite-only and does not attempt the broader CSS math function family or authored infinity/NaN semantics.

## Internal changes

The feature required some changes below the individual property parsers because a calculated value cannot always be reduced to a single numeric value at parse time.

At a high level:

* `Unit` gains a distinct calculation unit, deliberately separate from the existing numeric-unit mask.
* Common property/value representations can carry an immutable shared calculation object when a value must survive until computed- or used-value resolution.
* Length/percentage value types can represent either their existing scalar forms or a deferred calculation.
* `Variant`, `Property`, computed values, transforms, gradients, filters, shadows, animation values, and related common style structures were extended where necessary to preserve these deferred values.
* A calculation parser builds a typed expression tree, performs type validation and simplification, and records unit dependencies.
* Computed-value resolution canonicalizes context-dependent units and reduces expressions where possible. Length-percentage expressions that still depend on layout are retained in a compact residual form for used-value resolution.
* The ordinary non-calculation paths remain fast paths; calculation trees are only consulted when the stored value is actually a calculation.

This is consequently more than a parser-only addition, but the changes are concentrated around the existing shared numeric/style value machinery rather than introducing parallel property systems.

## Performance

During development I added the `RMLUI_MATH_EXPRESSIONS` CMake option primarily so the implementation could be benchmarked directly against an otherwise identical build with math support compiled out.

I recently optimized the enabled-but-unused paths to minimize the cost for applications which do not use math expressions. Nine interleaved OFF/ON benchmark runs gave these median results:

| Ordinary path                                       |       OFF |        ON |            Difference |
| --------------------------------------------------- | --------: | --------: | --------------------: |
| Number parsing                                      | 116.25 ns | 121.41 ns |      +5.16 ns (+4.4%) |
| Length parsing                                      | 111.37 ns | 115.16 ns |      +3.79 ns (+3.4%) |
| Length-percentage parsing                           | 110.25 ns | 111.40 ns |      +1.15 ns (+1.0%) |
| Property declaration                                | 344.41 ns | 346.42 ns |      +2.01 ns (+0.6%) |
| Fixed used value                                    |   0.39 ns |   0.40 ns |              +0.01 ns |
| Percentage used value                               |   0.50 ns |   0.49 ns | effectively unchanged |
| 100-element ordinary document, SetInnerRML + Update | 181.15 µs | 183.30 µs |      +2.15 µs (+1.2%) |

Actual math parsing on the enabled build is approximately 303 ns for a definite expression, 338 ns for a length-percentage expression, and 775 ns for a more complex expression tree.

The benchmarks were run locally with turbo enabled, so small differences should not be over-interpreted, but they suggest that the practical cost of having the feature available when it is unused is small.

Because the CMake flag mainly served as benchmarking and development scaffolding, I think it can likely be removed before merging. Making math expressions unconditional would substantially simplify the implementation by removing the dual type/layout paths and many `#ifdef RMLUI_MATH_EXPRESSIONS` branches, while the measured runtime cost does not appear significant enough to justify maintaining two configurations.

## Before Merge

I'm still doing some practical tests myself. I think others should do the same.

Also, I suggest the CMake flag be removed once this has been reviewed. I can easily do that, but I kept them so maintainers can test for themselves.
