### PR TITLE
Fix mouse wheel target selection across scroll axes

### DIFF
--- a/Include/RmlUi/Core/Element.h
+++ b/Include/RmlUi/Core/Element.h
@@ -572,6 +572,8 @@ public:
 	ElementScroll* GetElementScroll() const;
 	/// Returns the element's nearest scroll container that can be scrolled, if any.
 	Element* GetClosestScrollableContainer();
+	/// Returns the element's nearest scroll container for any non-zero axis in the scroll delta, if any.
+	Element* GetClosestScrollableContainer(Vector2f scroll_delta);
 	/// Returns the element's transform state.
 	const TransformState* GetTransformState() const noexcept;
 	/// Returns the data model of this element.

--- a/Include/RmlUi/Core/Element.h
+++ b/Include/RmlUi/Core/Element.h
@@ -570,10 +570,8 @@ public:
 	ElementBackgroundBorder* GetElementBackgroundBorder() const;
 	/// Returns the element's scrollbar functionality.
 	ElementScroll* GetElementScroll() const;
-	/// Returns the element's nearest scroll container that can be scrolled, if any.
-	Element* GetClosestScrollableContainer();
-	/// Returns the element's nearest scroll container for any non-zero axis in the scroll delta, if any.
-	Element* GetClosestScrollableContainer(Vector2f scroll_delta);
+	/// Returns the element's nearest scroll container for any non-zero axis in the scroll delta, if any. Defaults to both axes.
+	Element* GetClosestScrollableContainer(Vector2f scroll_delta = Vector2f(1.f));
 	/// Returns the element's transform state.
 	const TransformState* GetTransformState() const noexcept;
 	/// Returns the data model of this element.

--- a/Source/Core/Context.cpp
+++ b/Source/Core/Context.cpp
@@ -826,7 +826,7 @@ bool Context::ProcessMouseWheel(Vector2f wheel_delta, int key_modifier_state)
 
 	const float unit_scroll_length = UNIT_SCROLL_LENGTH * density_independent_pixel_ratio;
 	const Vector2f scroll_length = wheel_delta * unit_scroll_length;
-	Element* target = hover->GetClosestScrollableContainer();
+	Element* target = hover->GetClosestScrollableContainer(wheel_delta);
 
 	if (scroll_controller->GetMode() == ScrollController::Mode::Smoothscroll && scroll_controller->GetTarget() == target)
 		scroll_controller->IncrementSmoothscrollTarget(scroll_length);

--- a/Source/Core/Element.cpp
+++ b/Source/Core/Element.cpp
@@ -1995,40 +1995,18 @@ bool Element::IsLayoutDirty()
 	return false;
 }
 
-Element* Element::GetClosestScrollableContainer()
-{
-	using namespace Style;
-
-	Overflow overflow_x = meta->computed_values.overflow_x();
-	Overflow overflow_y = meta->computed_values.overflow_y();
-	bool scrollable_x = (overflow_x == Overflow::Auto || overflow_x == Overflow::Scroll);
-	bool scrollable_y = (overflow_y == Overflow::Auto || overflow_y == Overflow::Scroll);
-
-	scrollable_x = (scrollable_x && GetScrollWidth() > GetClientWidth());
-	scrollable_y = (scrollable_y && GetScrollHeight() > GetClientHeight());
-
-	if (scrollable_x || scrollable_y || meta->computed_values.overscroll_behavior() == OverscrollBehavior::Contain)
-		return this;
-	else if (parent)
-		return parent->GetClosestScrollableContainer();
-
-	return nullptr;
-}
-
 Element* Element::GetClosestScrollableContainer(Vector2f scroll_delta)
 {
 	using namespace Style;
 
 	const Overflow overflow_x = meta->computed_values.overflow_x();
 	const Overflow overflow_y = meta->computed_values.overflow_y();
-	const bool scroll_container_x = (scroll_delta.x != 0.f && (overflow_x == Overflow::Auto || overflow_x == Overflow::Scroll));
-	const bool scroll_container_y = (scroll_delta.y != 0.f && (overflow_y == Overflow::Auto || overflow_y == Overflow::Scroll));
-	const bool scrollable_x = (scroll_container_x && GetScrollWidth() > GetClientWidth());
-	const bool scrollable_y = (scroll_container_y && GetScrollHeight() > GetClientHeight());
-	const bool contains_scroll =
-		(scroll_container_x || scroll_container_y) && meta->computed_values.overscroll_behavior() == OverscrollBehavior::Contain;
+	const bool scrollable_x =
+		(scroll_delta.x != 0.f && (overflow_x == Overflow::Auto || overflow_x == Overflow::Scroll) && GetScrollWidth() > GetClientWidth());
+	const bool scrollable_y =
+		(scroll_delta.y != 0.f && (overflow_y == Overflow::Auto || overflow_y == Overflow::Scroll) && GetScrollHeight() > GetClientHeight());
 
-	if (scrollable_x || scrollable_y || contains_scroll)
+	if (scrollable_x || scrollable_y || meta->computed_values.overscroll_behavior() == OverscrollBehavior::Contain)
 		return this;
 	else if (parent)
 		return parent->GetClosestScrollableContainer(scroll_delta);

--- a/Source/Core/Element.cpp
+++ b/Source/Core/Element.cpp
@@ -2015,6 +2015,27 @@ Element* Element::GetClosestScrollableContainer()
 	return nullptr;
 }
 
+Element* Element::GetClosestScrollableContainer(Vector2f scroll_delta)
+{
+	using namespace Style;
+
+	const Overflow overflow_x = meta->computed_values.overflow_x();
+	const Overflow overflow_y = meta->computed_values.overflow_y();
+	const bool scroll_container_x = (scroll_delta.x != 0.f && (overflow_x == Overflow::Auto || overflow_x == Overflow::Scroll));
+	const bool scroll_container_y = (scroll_delta.y != 0.f && (overflow_y == Overflow::Auto || overflow_y == Overflow::Scroll));
+	const bool scrollable_x = (scroll_container_x && GetScrollWidth() > GetClientWidth());
+	const bool scrollable_y = (scroll_container_y && GetScrollHeight() > GetClientHeight());
+	const bool contains_scroll =
+		(scroll_container_x || scroll_container_y) && meta->computed_values.overscroll_behavior() == OverscrollBehavior::Contain;
+
+	if (scrollable_x || scrollable_y || contains_scroll)
+		return this;
+	else if (parent)
+		return parent->GetClosestScrollableContainer(scroll_delta);
+
+	return nullptr;
+}
+
 void Element::ProcessDefaultAction(Event& event)
 {
 	if (event == EventId::Mousedown)

--- a/Tests/Source/UnitTests/Element.cpp
+++ b/Tests/Source/UnitTests/Element.cpp
@@ -120,6 +120,62 @@ static const String document_scroll_rml = R"(
 </rml>
 )";
 
+static const String document_scroll_target_rml = R"(
+<rml>
+<head>
+	<style>
+		body { margin: 0; }
+		#vertical {
+			width: 100px;
+			height: 100px;
+			overflow-x: hidden;
+			overflow-y: auto;
+		}
+		#vertical-content {
+			width: 100px;
+			height: 220px;
+		}
+		#horizontal {
+			width: 100px;
+			height: 50px;
+			overflow-x: auto;
+			overflow-y: hidden;
+			overscroll-behavior: contain;
+		}
+		#horizontal-content {
+			width: 200px;
+			height: 50px;
+		}
+		#contained-y {
+			width: 100px;
+			height: 50px;
+			overflow-y: auto;
+			overscroll-behavior: contain;
+		}
+		#target, #contained-target {
+			display: block;
+			width: 20px;
+			height: 20px;
+		}
+		scrollbarvertical, scrollbarhorizontal {
+			width: 0;
+			height: 0;
+		}
+	</style>
+</head>
+<body>
+	<div id="vertical">
+		<div id="vertical-content">
+			<div id="horizontal">
+				<div id="horizontal-content"><span id="target"/></div>
+			</div>
+			<div id="contained-y"><span id="contained-target"/></div>
+		</div>
+	</div>
+</body>
+</rml>
+)";
+
 TEST_CASE("Element")
 {
 	Context* context = TestsShell::GetContext();
@@ -302,6 +358,48 @@ TEST_CASE("Element")
 		inner_rml = document->GetInnerRML();
 		CHECK(inner_rml == R"(<div style="background-color: #ff0000;">This is a <img /><span>sample</span>.<button>Click me</button></div>)");
 	}
+
+	document->Close();
+	TestsShell::ShutdownShell();
+}
+
+TEST_CASE("Element.GetClosestScrollableContainer")
+{
+	Context* context = TestsShell::GetContext();
+	REQUIRE(context);
+
+	ElementDocument* document = context->LoadDocumentFromMemory(document_scroll_target_rml);
+	REQUIRE(document);
+	document->Show();
+	TestsShell::RenderLoop();
+
+	Element* vertical = document->GetElementById("vertical");
+	Element* horizontal = document->GetElementById("horizontal");
+	Element* target = document->GetElementById("target");
+	Element* contained_y = document->GetElementById("contained-y");
+	Element* contained_target = document->GetElementById("contained-target");
+	REQUIRE(vertical);
+	REQUIRE(horizontal);
+	REQUIRE(target);
+	REQUIRE(contained_y);
+	REQUIRE(contained_target);
+
+	CHECK(target->GetClosestScrollableContainer() == horizontal);
+	CHECK(target->GetClosestScrollableContainer({1.f, 0.f}) == horizontal);
+	CHECK(target->GetClosestScrollableContainer({0.f, 1.f}) == vertical);
+	CHECK(contained_target->GetClosestScrollableContainer() == contained_y);
+	CHECK(contained_target->GetClosestScrollableContainer({0.f, 1.f}) == contained_y);
+
+	context->SetDefaultScrollBehavior(ScrollBehavior::Instant, 1.f);
+	const Vector2f target_position = target->GetAbsoluteOffset(BoxArea::Border) + Vector2f(5.f);
+	context->ProcessMouseMove(int(target_position.x), int(target_position.y), 0);
+	context->ProcessMouseWheel({0.f, 1.f}, 0);
+	const float vertical_scroll_top = vertical->GetScrollTop();
+	const float horizontal_scroll_left_after_vertical_wheel = horizontal->GetScrollLeft();
+	context->SetDefaultScrollBehavior(ScrollBehavior::Smooth, 1.f);
+
+	CHECK(vertical_scroll_top > 0.f);
+	CHECK(horizontal_scroll_left_after_vertical_wheel == 0.f);
 
 	document->Close();
 	TestsShell::ShutdownShell();

--- a/Tests/Source/UnitTests/Element.cpp
+++ b/Tests/Source/UnitTests/Element.cpp
@@ -125,6 +125,7 @@ static const String document_scroll_target_rml = R"(
 <head>
 	<style>
 		body { margin: 0; }
+		div { display: block; }
 		#vertical {
 			width: 100px;
 			height: 100px;
@@ -140,7 +141,6 @@ static const String document_scroll_target_rml = R"(
 			height: 50px;
 			overflow-x: auto;
 			overflow-y: hidden;
-			overscroll-behavior: contain;
 		}
 		#horizontal-content {
 			width: 200px;
@@ -387,6 +387,11 @@ TEST_CASE("Element.GetClosestScrollableContainer")
 	CHECK(target->GetClosestScrollableContainer() == horizontal);
 	CHECK(target->GetClosestScrollableContainer({1.f, 0.f}) == horizontal);
 	CHECK(target->GetClosestScrollableContainer({0.f, 1.f}) == vertical);
+	REQUIRE(horizontal->SetProperty("overscroll-behavior", "contain"));
+	TestsShell::RenderLoop();
+	CHECK(target->GetClosestScrollableContainer({0.f, 1.f}) == horizontal);
+	horizontal->RemoveProperty(PropertyId::OverscrollBehavior);
+	TestsShell::RenderLoop();
 	CHECK(contained_target->GetClosestScrollableContainer() == contained_y);
 	CHECK(contained_target->GetClosestScrollableContainer({0.f, 1.f}) == contained_y);
 


### PR DESCRIPTION
## Summary

- Select the closest scroll container that supports at least one non-zero axis of the mouse wheel delta.
- Preserve the existing `overscroll-behavior: contain` semantics.
- Use one lookup implementation whose default keeps the existing axis-independent behavior for touch scrolling and autoscroll.

## Motivation

With a horizontal scroll container nested inside a vertical one, a vertical mouse wheel currently selects the horizontal child because it is scrollable on another axis. The child cannot consume the vertical delta, so the vertical ancestor does not scroll.

The updated lookup makes wheel target selection aware of the requested axes. A pure vertical delta skips an x-only child and reaches the vertical parent, while a horizontal delta still selects the child. Existing callers without a delta continue to search both axes.

The scroll controller still operates on one target at a time, so simultaneous diagonal input retains the existing single-target model.

## Testing

- Added `Element.GetClosestScrollableContainer` coverage for horizontal and vertical deltas.
- Covered the axis-independent default and existing `overscroll-behavior: contain` behavior.
- Covered the end-to-end `Context::ProcessMouseWheel` path for a vertical wheel over a horizontal child.
- All 147 RmlUi unit tests pass locally.