### PR TITLE
Round premultiplied colour channels to nearest byte

### DIFF
--- a/Include/RmlUi/Core/Colour.h
+++ b/Include/RmlUi/Core/Colour.h
@@ -77,9 +77,9 @@ public:
 	inline Colour<ColourType, AlphaDefault, true> ToPremultiplied() const
 	{
 		return {
-			ColourType((red * alpha) / 255),
-			ColourType((green * alpha) / 255),
-			ColourType((blue * alpha) / 255),
+			ColourType((red * alpha + 127) / 255),
+			ColourType((green * alpha + 127) / 255),
+			ColourType((blue * alpha + 127) / 255),
 			alpha,
 		};
 	}
@@ -90,9 +90,9 @@ public:
 	{
 		const float new_alpha = alpha * opacity;
 		return {
-			ColourType(red * (new_alpha / 255.f)),
-			ColourType(green * (new_alpha / 255.f)),
-			ColourType(blue * (new_alpha / 255.f)),
+			ColourType(red * (new_alpha / 255.f) + 0.5f),
+			ColourType(green * (new_alpha / 255.f) + 0.5f),
+			ColourType(blue * (new_alpha / 255.f) + 0.5f),
 			ColourType(new_alpha),
 		};
 	}

--- a/Tests/Source/UnitTests/Math.cpp
+++ b/Tests/Source/UnitTests/Math.cpp
@@ -4,6 +4,12 @@
 
 using namespace Rml;
 
+TEST_CASE("Colour.ToPremultiplied")
+{
+	CHECK(Colourb(100, 150, 200, 127).ToPremultiplied() == ColourbPremultiplied(50, 75, 100, 127));
+	CHECK(Colourb(100, 150, 200, 128).ToPremultiplied(0.5f) == ColourbPremultiplied(25, 38, 50, 64));
+}
+
 TEST_CASE("Math.RoundedLerp")
 {
 	const ColourbPremultiplied c0(0, 0, 0, 255);

--- a/Tests/Source/UnitTests/Properties.cpp
+++ b/Tests/Source/UnitTests/Properties.cpp
@@ -160,20 +160,20 @@ TEST_CASE("Properties")
 			},
 			{
 				"lab(55% none none), lab(30% 67% -110) 50%, lab(90% -90 80 / 0.5) 10dp",
-				"#838383, #0000fb 50%, #00ff267f 10dp",
+				"#838383, #0000fb 50%, #00ff287f 10dp",
 				{
 					ColorStop{ColourbPremultiplied(131, 131, 131), NumericValue{}},
 					ColorStop{ColourbPremultiplied(0, 0, 251), NumericValue{50.f, Unit::PERCENT}},
-					ColorStop{ColourbPremultiplied(0, 127, 19, 127), NumericValue{10.f, Unit::DP}},
+					ColorStop{ColourbPremultiplied(0, 127, 20, 127), NumericValue{10.f, Unit::DP}},
 				},
 			},
 			{
 				"lch(55% none 300.0), lch(30% 85% 180.0) 50%, lch(90% 90 100.0 / 50%) 10dp",
-				"#838383, #006044 50%, #f0e6007f 10dp",
+				"#838383, #006044 50%, #f0e6027f 10dp",
 				{
 					ColorStop{ColourbPremultiplied(131, 131, 131), NumericValue{}},
 					ColorStop{ColourbPremultiplied(0, 96, 68), NumericValue{50.f, Unit::PERCENT}},
-					ColorStop{ColourbPremultiplied(120, 115, 0, 127), NumericValue{10.f, Unit::DP}},
+					ColorStop{ColourbPremultiplied(120, 115, 1, 127), NumericValue{10.f, Unit::DP}},
 				},
 			},
 			{
@@ -187,11 +187,11 @@ TEST_CASE("Properties")
 			},
 			{
 				"oklch(75% 100% 30.0), oklch(0.5 0.2 270) 50%, oklch(1.0 0.1 none / 0.5) 10dp",
-				"#ff0000, #3a50d2 50%, #ffe2fa7f 10dp",
+				"#ff0000, #3a50d2 50%, #ffe2fc7f 10dp",
 				{
 					ColorStop{ColourbPremultiplied(255, 0, 0), NumericValue{}},
 					ColorStop{ColourbPremultiplied(58, 80, 210), NumericValue{50.f, Unit::PERCENT}},
-					ColorStop{ColourbPremultiplied(127, 113, 125, 127), NumericValue{10.f, Unit::DP}},
+					ColorStop{ColourbPremultiplied(127, 113, 126, 127), NumericValue{10.f, Unit::DP}},
 				},
 			},
 			{


### PR DESCRIPTION
## Summary

Round premultiplied RGB channels to the nearest byte instead of truncating them. Alpha is unchanged.

- Integer overload: `(channel * alpha + 127) / 255`
- Opacity overload: `channel * (new_alpha / 255.f) + 0.5f`

This removes the systematic downward bias produced by truncation. The PR adds unit coverage and updates the gradient expectations affected by the corrected RGB values.

## Evidence

[bblitec](https://github.com/sailro/bblitec) compiles [Babylon Lite](https://github.com/BabylonJS/Babylon-Lite) TypeScript applications to native C++. Its [parity harness](https://github.com/sailro/bblitec/blob/main/docs/fidelity.md) runs the original application in a browser and the generated native executable with the same source, assets, resolution, and deterministic capture frame. DOM/CSS is rendered by the browser in the reference capture and by RmlUi in the native capture. MAD is the mean absolute RGB-byte difference between corresponding pixels; zero is an exact match.

Both demos below were captured in controlled A/B runs at 1280x720 through two independent native backends, SDL_GPU and Dawn. The only native source difference is the six RGB expressions changed by this PR; alpha handling and application code are unchanged. The changed pixel/channel sets and closer/farther classifications are identical across the two backends, which rules out an SDL_GPU-specific rendering effect.

### Platformer

[Platformer](https://babylonjs.com/lite-demos/demo-platformer.html) is a Babylon Lite 2D sprite-game demo ([TypeScript source](https://github.com/BabylonJS/Babylon-Lite/blob/master/lab/lite/src/demos/platformer.ts)). At [deterministic frame 180](https://github.com/sailro/bblitec/blob/main/src/scene-registry.ts#L3209-L3221), its HTML/CSS start overlay displays the semi-transparent `PRESS SPACE · TAP A` prompt.

| Metric | Current truncation | This PR |
| --- | ---: | ---: |
| Full-frame RGB MAD (SDL_GPU) | 1.047313 | 1.046343 |
| Full-frame RGB MAD (Dawn) | 1.044623 | 1.043654 |
| MAD on the 4,126 RGB channels changed by this PR | 6.500 | 5.851 |
| Changed channels closer / farther from the browser | - | 3,403 / 723 |
| Changed pixels | - | 2,338 (0.254% of the frame) |

The map below classifies only the pixels affected by the arithmetic change. Green pixels move closer to the browser reference, red pixels move farther away, yellow pixels retain the same absolute error, and dark pixels are unchanged. The prompt shape identifies the affected UI region; this is a comparison map, not a rendered screenshot. Of the 2,338 affected pixels, 1,765 improve, 401 regress, and 172 have equal error.

<img width="900" alt="Pixel comparison for the semi-transparent Platformer start prompt: green is closer to the browser reference, red is farther, yellow has equal error, and dark is unchanged" src="https://github.com/user-attachments/assets/c658e27d-09f4-47fc-a77a-422a0d3706dc">

### Racer

[Racer](https://babylonjs.com/lite-demos/demo-racer.html) is a separate Babylon Lite 3D driving demo ([TypeScript source](https://github.com/BabylonJS/Babylon-Lite/blob/master/lab/lite/src/demos/racer.ts)). Its retained HTML/CSS HUD includes the lap/timer panel, vehicle selector, minimap, and footer help. The capture uses its own [deterministic frame 180 configuration](https://github.com/sailro/bblitec/blob/main/src/scene-registry.ts#L3237-L3249).

| Metric | Current truncation | This PR |
| --- | ---: | ---: |
| Full-frame RGB MAD (SDL_GPU) | 1.109884 | 1.106168 |
| Full-frame RGB MAD (Dawn) | 1.109846 | 1.106130 |
| MAD on the 13,212 RGB channels changed by this PR | 13.534 | 12.757 |
| Changed channels closer / farther from the browser | - | 11,742 / 1,470 |
| Changed pixels | - | 12,576 (1.365% of the frame) |

The map below uses the same classification as Platformer and preserves full-frame screen position. It shows three independent affected HUD regions: the lap/timing panel at upper left, the vehicle selector at upper center, and the footer controls at lower center. Of the 12,576 affected pixels, 11,490 improve and 1,086 regress; no affected pixel has equal error.

<img width="900" alt="Full-frame Racer HUD comparison: green pixels move closer to the browser reference, red pixels move farther away, and dark pixels are unchanged" src="https://gist.githubusercontent.com/sailro/4b2226a1ca4ca238e54837cb3dfacafd/raw/708fb573efab6ae8565779ac7d255da5bcb871b8/racer-premultiplied-rounding-map.svg">

## Validation

`rmlui_unit_tests`: 148 tests passed, 8,329 assertions passed.